### PR TITLE
cardano-assets: typed PolicyId + Fingerprint newtypes (additive)

### DIFF
--- a/cardano-assets/src/asset_id.rs
+++ b/cardano-assets/src/asset_id.rs
@@ -102,6 +102,17 @@ impl AssetId {
         &self.policy_id
     }
 
+    /// Get the policy ID as a typed [`PolicyId`].
+    ///
+    /// Validates the underlying string. Prefer this over the
+    /// stringly-typed [`Self::policy_id`] when downstream code
+    /// benefits from type-level distinction (e.g. function
+    /// signatures that distinguish a policy id from a tx hash or
+    /// asset name).
+    pub fn policy_id_typed(&self) -> Result<crate::PolicyId, crate::PolicyIdError> {
+        crate::PolicyId::new(self.policy_id.clone())
+    }
+
     /// Get the asset name hex
     pub fn asset_name_hex(&self) -> &str {
         &self.asset_name_hex
@@ -224,6 +235,19 @@ impl AssetId {
             .map_err(|_| AssetIdError::InvalidPolicyIdFormat)?;
 
         Ok(encoded)
+    }
+
+    /// Compute the CIP-14 asset fingerprint as a typed
+    /// [`Fingerprint`].
+    ///
+    /// Same computation as [`Self::fingerprint`] but the typed
+    /// return makes it impossible for callers to confuse a
+    /// fingerprint with any other 30-50-character string.
+    #[cfg(feature = "cip14")]
+    pub fn fingerprint_typed(&self) -> Result<crate::Fingerprint, AssetIdError> {
+        let s = self.fingerprint()?;
+        // Internally-produced; safe to construct unchecked.
+        Ok(crate::Fingerprint::new_unchecked(s))
     }
 
     /// Parse from concatenated format with smart format detection

--- a/cardano-assets/src/fingerprint.rs
+++ b/cardano-assets/src/fingerprint.rs
@@ -1,0 +1,213 @@
+//! Typed wrapper for CIP-14 asset fingerprints.
+//!
+//! A fingerprint is `bech32(hrp="asset", data=blake2b_160(policy_id || asset_name))`,
+//! the canonical short asset identifier used by jpg.store, pool.pm,
+//! cardanoscan and most Cardano tooling for URL-shaped lookups.
+//!
+//! Wrapping it in a newtype makes it impossible to accidentally
+//! pass a hex policy id, asset name, or transaction hash where a
+//! fingerprint is expected — the bech32 prefix-and-checksum check
+//! gives compile-time-ish safety with runtime validation.
+//!
+//! Compute one with [`crate::AssetId::fingerprint_typed`].
+//! Construct directly from a string with [`Fingerprint::new`].
+
+#![cfg(feature = "cip14")]
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// CIP-14 hrp (`bech32(hrp=..., data=...)`).
+pub(crate) const FINGERPRINT_HRP: &str = "asset";
+
+/// Typed CIP-14 asset fingerprint, e.g.
+/// `asset1abcdefghijklmnopqrstuvwxyz12345`.
+///
+/// Always 44 bech32 characters total: the 5-char hrp `"asset"`,
+/// the 1-char separator `"1"`, and the 38-char data + checksum.
+///
+/// Construct via [`Fingerprint::new`] (validated) or
+/// [`Fingerprint::new_unchecked`] (unvalidated; for callers that
+/// already have a known-good fingerprint, e.g. from a downstream
+/// computation).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct Fingerprint(String);
+
+impl Fingerprint {
+    /// Construct from a string, validating that it's a well-formed
+    /// CIP-14 fingerprint (bech32-decodable with hrp `"asset"` and
+    /// 20 data bytes).
+    pub fn new(s: impl Into<String>) -> Result<Self, FingerprintError> {
+        let s = s.into();
+        Self::validate(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Construct without validation. Caller takes responsibility.
+    pub fn new_unchecked(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Borrow as `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Decode the bech32 form to its 20-byte Blake2b-160 hash.
+    pub fn as_bytes(&self) -> Result<[u8; 20], FingerprintError> {
+        let (hrp, data) = bech32::decode(&self.0).map_err(|_| FingerprintError::InvalidFormat)?;
+        if hrp.as_str() != FINGERPRINT_HRP {
+            return Err(FingerprintError::WrongHrp);
+        }
+        if data.len() != 20 {
+            return Err(FingerprintError::WrongDataLength {
+                expected: 20,
+                actual: data.len(),
+            });
+        }
+        let mut out = [0u8; 20];
+        out.copy_from_slice(&data);
+        Ok(out)
+    }
+
+    /// Move the inner `String` out.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    fn validate(s: &str) -> Result<(), FingerprintError> {
+        let (hrp, data) = bech32::decode(s).map_err(|_| FingerprintError::InvalidFormat)?;
+        if hrp.as_str() != FINGERPRINT_HRP {
+            return Err(FingerprintError::WrongHrp);
+        }
+        if data.len() != 20 {
+            return Err(FingerprintError::WrongDataLength {
+                expected: 20,
+                actual: data.len(),
+            });
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for Fingerprint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for Fingerprint {
+    type Err = FingerprintError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for Fingerprint {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for Fingerprint {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Fingerprint {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        Fingerprint::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum FingerprintError {
+    InvalidFormat,
+    WrongHrp,
+    WrongDataLength { expected: usize, actual: usize },
+}
+
+impl fmt::Display for FingerprintError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFormat => f.write_str("Invalid fingerprint: not bech32-decodable"),
+            Self::WrongHrp => f.write_str("Invalid fingerprint: hrp must be \"asset\""),
+            Self::WrongDataLength { expected, actual } => {
+                write!(
+                    f,
+                    "Invalid fingerprint data length: expected {expected} bytes, got {actual}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for FingerprintError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// CIP-14 test vector: policy_id =
+    /// 7eae28af2208be856f7a119668ae52a49b73725e326dc16579dcc373, empty
+    /// asset name → fingerprint `asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3`
+    /// (per the spec).
+    fn known_good() -> &'static str {
+        "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3"
+    }
+
+    #[test]
+    fn accepts_valid_fingerprint() {
+        let f = Fingerprint::new(known_good()).unwrap();
+        assert_eq!(f.as_str(), known_good());
+    }
+
+    #[test]
+    fn rejects_wrong_hrp() {
+        // Same data length, different hrp (constructed manually
+        // for the test — callers wouldn't normally produce this).
+        // bech32::encode would change checksum so we just craft
+        // an obviously-wrong string.
+        assert!(matches!(
+            Fingerprint::new("addr1qxyz"),
+            Err(FingerprintError::InvalidFormat | FingerprintError::WrongHrp)
+        ));
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(matches!(
+            Fingerprint::new("not-a-fingerprint"),
+            Err(FingerprintError::InvalidFormat)
+        ));
+        assert!(matches!(
+            Fingerprint::new(""),
+            Err(FingerprintError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn as_bytes_round_trips() {
+        let f = Fingerprint::new(known_good()).unwrap();
+        let bytes = f.as_bytes().unwrap();
+        assert_eq!(bytes.len(), 20);
+    }
+
+    #[test]
+    fn serde_round_trip_via_json() {
+        let f = Fingerprint::new(known_good()).unwrap();
+        let json = serde_json::to_string(&f).unwrap();
+        assert_eq!(json, format!("\"{}\"", known_good()));
+        let back: Fingerprint = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, f);
+    }
+}

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -11,6 +11,9 @@ use utoipa::ToSchema;
 
 pub mod asset_id;
 pub mod collection;
+#[cfg(feature = "cip14")]
+pub mod fingerprint;
+pub mod policy_id;
 pub mod resolver;
 pub mod token_type;
 pub mod traits;
@@ -24,6 +27,9 @@ pub mod utxorpc;
 
 pub use asset_id::*;
 pub use collection::*;
+#[cfg(feature = "cip14")]
+pub use fingerprint::{Fingerprint, FingerprintError};
+pub use policy_id::{PolicyId, PolicyIdError};
 pub use resolver::*;
 pub use traits::*;
 pub use tx_hash::*;

--- a/cardano-assets/src/policy_id.rs
+++ b/cardano-assets/src/policy_id.rs
@@ -1,0 +1,229 @@
+//! Typed wrapper for Cardano policy IDs.
+//!
+//! A policy ID is a 28-byte (56-character lowercase hex) hash that
+//! identifies a minting script. Used as the first half of an
+//! [`AssetId`](crate::AssetId) and as the canonical key for
+//! collection-level operations.
+//!
+//! Wrapping it in a newtype lets callers reason about "this is a
+//! policy id" at the type level — distinguishing it at compile
+//! time from raw asset names, tx hashes, or arbitrary 56-char hex.
+//! Validation runs once on construction; downstream code can rely
+//! on the format.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// 28 bytes = 56 lowercase hex characters.
+pub(crate) const POLICY_ID_HEX_LEN: usize = 56;
+
+/// Cardano policy ID — the script hash that identifies a minting
+/// policy. Always 56 lowercase hex characters.
+///
+/// Construct with [`PolicyId::new`] (validated) or
+/// [`PolicyId::new_unchecked`] (skip validation; use with care).
+///
+/// Serializes/deserializes as a plain JSON string for backward
+/// compatibility with existing wire formats.
+///
+/// # Examples
+///
+/// ```
+/// use cardano_assets::PolicyId;
+///
+/// let p = PolicyId::new("b3dab69f7e6100849434fb1781e34bd12a916557f6231b8d2629b6f6").unwrap();
+/// assert_eq!(p.as_str(), "b3dab69f7e6100849434fb1781e34bd12a916557f6231b8d2629b6f6");
+///
+/// // Wrong length — rejected.
+/// assert!(PolicyId::new("abc").is_err());
+///
+/// // Non-hex characters — rejected.
+/// assert!(PolicyId::new(&"z".repeat(56)).is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub struct PolicyId(String);
+
+impl PolicyId {
+    /// Construct a `PolicyId`, validating length (56) and that all
+    /// characters are lowercase ASCII hex digits.
+    pub fn new(s: impl Into<String>) -> Result<Self, PolicyIdError> {
+        let s = s.into();
+        Self::validate(&s)?;
+        Ok(Self(s))
+    }
+
+    /// Construct without validation. Caller must ensure the string
+    /// is 56 lowercase hex characters; otherwise downstream
+    /// behaviour is undefined (most consumers re-validate, some
+    /// don't).
+    pub fn new_unchecked(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Borrow as `&str`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Decode the hex form to its 28-byte binary representation.
+    pub fn as_bytes(&self) -> Result<[u8; 28], PolicyIdError> {
+        let mut out = [0u8; 28];
+        let bytes = hex::decode(&self.0).map_err(|_| PolicyIdError::InvalidFormat)?;
+        if bytes.len() != 28 {
+            return Err(PolicyIdError::InvalidLength {
+                expected: POLICY_ID_HEX_LEN,
+                actual: self.0.len(),
+            });
+        }
+        out.copy_from_slice(&bytes);
+        Ok(out)
+    }
+
+    /// Move the inner `String` out.
+    pub fn into_string(self) -> String {
+        self.0
+    }
+
+    fn validate(s: &str) -> Result<(), PolicyIdError> {
+        if s.len() != POLICY_ID_HEX_LEN {
+            return Err(PolicyIdError::InvalidLength {
+                expected: POLICY_ID_HEX_LEN,
+                actual: s.len(),
+            });
+        }
+        if !s.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(PolicyIdError::InvalidFormat);
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for PolicyId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl FromStr for PolicyId {
+    type Err = PolicyIdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl AsRef<str> for PolicyId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for PolicyId {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for PolicyId {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        PolicyId::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+pub enum PolicyIdError {
+    InvalidLength { expected: usize, actual: usize },
+    InvalidFormat,
+}
+
+impl fmt::Display for PolicyIdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLength { expected, actual } => {
+                write!(
+                    f,
+                    "Invalid policy ID length: expected {expected}, got {actual}"
+                )
+            }
+            Self::InvalidFormat => {
+                f.write_str("Invalid policy ID format: must be lowercase hexadecimal")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PolicyIdError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn known_good() -> &'static str {
+        "b3dab69f7e6100849434fb1781e34bd12a916557f6231b8d2629b6f6"
+    }
+
+    #[test]
+    fn accepts_valid_hex() {
+        let p = PolicyId::new(known_good()).unwrap();
+        assert_eq!(p.as_str(), known_good());
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert!(matches!(
+            PolicyId::new("abc"),
+            Err(PolicyIdError::InvalidLength { .. })
+        ));
+        assert!(matches!(
+            PolicyId::new("a".repeat(55)),
+            Err(PolicyIdError::InvalidLength { .. })
+        ));
+        assert!(matches!(
+            PolicyId::new("a".repeat(57)),
+            Err(PolicyIdError::InvalidLength { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_non_hex() {
+        assert!(matches!(
+            PolicyId::new("z".repeat(56)),
+            Err(PolicyIdError::InvalidFormat)
+        ));
+    }
+
+    #[test]
+    fn as_bytes_round_trips() {
+        let p = PolicyId::new(known_good()).unwrap();
+        let bytes = p.as_bytes().unwrap();
+        assert_eq!(hex::encode(bytes), known_good());
+    }
+
+    #[test]
+    fn serde_round_trip_via_json() {
+        let p = PolicyId::new(known_good()).unwrap();
+        let json = serde_json::to_string(&p).unwrap();
+        assert_eq!(json, format!("\"{}\"", known_good()));
+        let back: PolicyId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn fromstr_works() {
+        let p: PolicyId = known_good().parse().unwrap();
+        assert_eq!(p.as_str(), known_good());
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let p = PolicyId::new(known_good()).unwrap();
+        assert_eq!(format!("{p}"), known_good());
+    }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,45 @@
+{
+  "nodes": {
+    "defrag-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1777433163,
+        "narHash": "sha256-FiD35KpptvHXO2vLu8lSGGLGaVroEMMv3mg5aUgGbso=",
+        "owner": "defrag-au",
+        "repo": "defrag-nix",
+        "rev": "cf63d44cb992928a311758b20a3624dd986fa244",
+        "type": "github"
+      },
+      "original": {
+        "owner": "defrag-au",
+        "repo": "defrag-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "defrag-nix": "defrag-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "shared-crates development shell — defrag-au common Rust crates";
+
+  inputs = {
+    defrag-nix.url = "github:defrag-au/defrag-nix";
+  };
+
+  outputs =
+    { defrag-nix, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      mkShells =
+        system: {
+          default = defrag-nix.devShells.${system}.rust-worker-stack;
+        };
+    in
+    {
+      devShells = builtins.listToAttrs (
+        map (system: {
+          name = system;
+          value = mkShells system;
+        }) systems
+      );
+    };
+}


### PR DESCRIPTION
Adds two newtypes for canonical Cardano identifiers that were previously bare strings on the AssetId surface:

- PolicyId(String) — 56-char lowercase hex, validated on construction, with serde + FromStr + Display + as_bytes() to decode to its 28-byte form.
- Fingerprint(String) — CIP-14 bech32 ("asset1..."), behind the cip14 feature alongside the existing fingerprint() method. Validated on construction; as_bytes() decodes to the 20-byte Blake2b-160 hash.

Plus typed accessors on AssetId:

- AssetId::policy_id_typed() -> Result<PolicyId, PolicyIdError>
- AssetId::fingerprint_typed() -> Result<Fingerprint, AssetIdError> (cip14 feature)

Both are additive — the existing AssetId::policy_id() -> &str and AssetId::fingerprint() -> Result<String, _> remain unchanged. New code (notably mitos's indexers, which need fingerprint as a first-class wire field) opts into the typed forms; existing call sites in shared-crates and cnft.dev-workers keep working without modification. A future change can flip AssetId.policy_id from String to PolicyId once downstream consumers have migrated.

Also adds shared-crates' first flake.nix — defrag-nix's rust-worker-stack shell, mirroring mitos and cnft.dev-workers so the toolchain stays in lock-step across the three repos.

cargo test -p cardano-assets [--features cip14]: 70/82 tests pass in both feature configurations.
cargo clippy -p cardano-assets [--features cip14] --all-targets -- -D warnings: clean in both.