### PR TITLE
feature[cardano-assets]: CIP-68 datum decoding + IPFS CID extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,8 @@ dependencies = [
  "cnft_tools",
  "hex",
  "indexmap",
+ "pallas-codec",
+ "pallas-primitives",
  "pallas-utxorpc",
  "serde",
  "serde_json",

--- a/cardano-assets/Cargo.toml
+++ b/cardano-assets/Cargo.toml
@@ -19,10 +19,14 @@ utoipa = { workspace = true, optional = true }
 # whole pipeline upgrades in lockstep with `pallas-utxorpc`.
 utxorpc-spec = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
+# CIP-68 datum (Plutus data) CBOR decoding — optional, behind `cip68`.
+pallas-codec = { workspace = true, optional = true }
+pallas-primitives = { workspace = true, optional = true }
 
 [features]
 default = []
 cip14 = ["dep:bech32", "dep:blake2"]
+cip68 = ["dep:pallas-codec", "dep:pallas-primitives"]
 utxorpc = ["dep:utxorpc-spec", "dep:tracing"]
 openapi = ["dep:utoipa"]
 cnft_tools = ["dep:cnft_tools"]

--- a/cardano-assets/resources/cip68/nikeverse1501_new.datum.cbor
+++ b/cardano-assets/resources/cip68/nikeverse1501_new.datum.cbor
@@ -1,0 +1,1 @@
+ØyŸªDnameFGuthixEimage_X@ipfs://bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uwB3eÿImediaTypeIimage/pngDtierEElderJbackgroundC1/1DbodyC1/1GclothesC1/1DeyesC1/1DnoseC1/1DheadC1/1ÿ

--- a/cardano-assets/resources/cip68/nikeverse1501_prev.datum.cbor
+++ b/cardano-assets/resources/cip68/nikeverse1501_prev.datum.cbor
@@ -1,0 +1,1 @@
+ØyŸªDnameFGuthixEimageX5ipfs://QmQVcekGM1VRMHZnDjNPvYiEQ3mYYRaXiEAPs2qwHHk8kvImediaTypeIimage/pngDtierEElderJbackgroundC1/1DbodyC1/1GclothesC1/1DeyesC1/1DnoseC1/1DheadC1/1ÿ

--- a/cardano-assets/src/cid.rs
+++ b/cardano-assets/src/cid.rs
@@ -1,0 +1,305 @@
+//! IPFS CID extraction and normalisation.
+//!
+//! [`AssetMetadata::extract_cids`] collects every IPFS CID a piece of
+//! asset metadata references — the headline `image` plus every
+//! `files[].src` — and returns them normalised to CIDv1 so they sort and
+//! dedupe stably regardless of how they were originally encoded on-chain.
+//!
+//! This module is pure (no chain dependencies) and is always compiled; the
+//! CIP-68 datum decoder that feeds it lives behind the `cip68` feature.
+
+use crate::{get_image_url, Asset, AssetFile, AssetMetadata, AssetMetadata68, PrimitiveOrList};
+use std::collections::HashSet;
+
+/// Where in the metadata a CID was found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CidRole {
+    /// The headline `image` field.
+    Image,
+    /// An entry in the `files[]` array (`files[].src`).
+    File,
+}
+
+/// A single IPFS CID recovered from asset metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedCid {
+    /// The CID, normalised to CIDv1 (base32).
+    pub cid: String,
+    /// Where it was referenced from.
+    pub role: CidRole,
+    /// The `mediaType` of the referencing entry, when known (`files[]` only).
+    pub media_type: Option<String>,
+}
+
+impl AssetMetadata {
+    /// Collect every IPFS CID this metadata references, normalised to
+    /// CIDv1 and deduped (first occurrence wins). HTTP and other
+    /// non-IPFS URLs are skipped — this is an IPFS preservation index.
+    #[must_use]
+    pub fn extract_cids(&self) -> Vec<ExtractedCid> {
+        let (image, files) = self.image_and_files();
+        let mut seen = HashSet::new();
+        let mut out = Vec::new();
+
+        if let Some(cid) = cid_from_url(&get_image_url(image.clone())) {
+            if seen.insert(cid.clone()) {
+                out.push(ExtractedCid {
+                    cid,
+                    role: CidRole::Image,
+                    media_type: None,
+                });
+            }
+        }
+
+        if let Some(files) = files {
+            for file in files {
+                if let Some(cid) = cid_from_url(&file.get_src()) {
+                    if seen.insert(cid.clone()) {
+                        out.push(ExtractedCid {
+                            cid,
+                            role: CidRole::File,
+                            media_type: Some(file.media_type().to_owned()),
+                        });
+                    }
+                }
+            }
+        }
+
+        out
+    }
+
+    /// The `image` and `files` fields, which every variant carries.
+    fn image_and_files(&self) -> (&PrimitiveOrList<String>, &Option<Vec<AssetFile>>) {
+        match self {
+            AssetMetadata::Attributed { image, files, .. }
+            | AssetMetadata::Flattened { image, files, .. }
+            | AssetMetadata::FlattenedMixed { image, files, .. }
+            | AssetMetadata::CodifiedTraits { image, files, .. }
+            | AssetMetadata::ColonDelimitedAttributes { image, files, .. }
+            | AssetMetadata::AttributeArray { image, files, .. }
+            | AssetMetadata::UnsignedAlgorithms { image, files, .. } => (image, files),
+        }
+    }
+}
+
+impl AssetMetadata68 {
+    /// Collect every IPFS CID this CIP-68 metadata references.
+    /// See [`AssetMetadata::extract_cids`].
+    #[must_use]
+    pub fn extract_cids(&self) -> Vec<ExtractedCid> {
+        self.metadata.extract_cids()
+    }
+}
+
+/// Pull a CID out of a metadata URL string and normalise it to CIDv1.
+///
+/// Handles `ipfs://<cid>`, `ipfs://ipfs/<cid>`, gateway URLs containing
+/// `/ipfs/<cid>`, and bare CIDs. Returns `None` for anything that is not
+/// a recognisable IPFS CID (e.g. plain `https://` image URLs).
+fn cid_from_url(url: &str) -> Option<String> {
+    let url = url.trim();
+    let candidate = if let Some(rest) = url.strip_prefix("ipfs://") {
+        // Tolerate the occasional `ipfs://ipfs/<cid>` double prefix.
+        let rest = rest.strip_prefix("ipfs/").unwrap_or(rest);
+        rest.split('/').next().unwrap_or("")
+    } else if let Some(idx) = url.find("/ipfs/") {
+        url[idx + "/ipfs/".len()..].split('/').next().unwrap_or("")
+    } else {
+        url
+    };
+    normalize_cid(candidate.trim())
+}
+
+/// Validate `s` as an IPFS CID and return it normalised to CIDv1.
+///
+/// CIDv0 (`Qm…`) values are converted to their canonical CIDv1 form so
+/// the index sorts and dedupes by a single representation. Returns
+/// `None` if `s` is not a recognisable CID.
+#[must_use]
+pub fn normalize_cid(s: &str) -> Option<String> {
+    if s.len() == 46 && s.starts_with("Qm") {
+        return cid_v0_to_v1(s);
+    }
+    if Asset::is_valid_cid(s) {
+        // Already a CIDv1.
+        return Some(s.to_owned());
+    }
+    None
+}
+
+/// Convert a CIDv0 (`Qm…`, base58btc-encoded dag-pb / sha2-256 multihash)
+/// to its canonical CIDv1 (`bafybei…`, base32) form.
+///
+/// Returns `None` if `s` is not a structurally valid CIDv0.
+#[must_use]
+pub fn cid_v0_to_v1(s: &str) -> Option<String> {
+    let multihash = base58btc_decode(s)?;
+    // A CIDv0 is always a sha2-256 multihash: 0x12 (hash code) followed
+    // by 0x20 (32-byte digest length) and the 32-byte digest.
+    if multihash.len() != 34 || multihash[0] != 0x12 || multihash[1] != 0x20 {
+        return None;
+    }
+    // CIDv1 = <version 0x01> <codec 0x70 = dag-pb> <multihash>, then
+    // base32-lower with a `b` multibase prefix.
+    let mut payload = Vec::with_capacity(2 + multihash.len());
+    payload.push(0x01);
+    payload.push(0x70);
+    payload.extend_from_slice(&multihash);
+    Some(format!("b{}", base32_lower_encode(&payload)))
+}
+
+/// Decode a base58btc (Bitcoin alphabet) string to bytes.
+fn base58btc_decode(s: &str) -> Option<Vec<u8>> {
+    const ALPHABET: &[u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    let mut bytes: Vec<u8> = Vec::with_capacity(s.len());
+    for ch in s.bytes() {
+        let mut carry = ALPHABET.iter().position(|&a| a == ch)? as u32;
+        for b in &mut bytes {
+            carry += u32::from(*b) * 58;
+            *b = (carry & 0xff) as u8;
+            carry >>= 8;
+        }
+        while carry > 0 {
+            bytes.push((carry & 0xff) as u8);
+            carry >>= 8;
+        }
+    }
+    // Each leading '1' encodes one leading zero byte.
+    for ch in s.bytes() {
+        if ch == b'1' {
+            bytes.push(0);
+        } else {
+            break;
+        }
+    }
+    bytes.reverse();
+    Some(bytes)
+}
+
+/// Encode bytes as lowercase RFC 4648 base32, no padding.
+fn base32_lower_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz234567";
+    let mut out = String::with_capacity(data.len() * 8 / 5 + 1);
+    let mut acc: u32 = 0;
+    let mut bits: u32 = 0;
+    for &byte in data {
+        acc = (acc << 8) | u32::from(byte);
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            out.push(ALPHABET[((acc >> bits) & 0x1f) as usize] as char);
+        }
+        acc &= (1 << bits) - 1;
+    }
+    if bits > 0 {
+        out.push(ALPHABET[((acc << (5 - bits)) & 0x1f) as usize] as char);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Golden CIDv0 -> CIDv1 vectors. The first is the canonical example
+    // from the IPFS documentation; the second is the Nikeverse1501
+    // pre-update image. Both were cross-checked with an independent
+    // base58/base32 implementation.
+    const CIDV0_VECTORS: &[(&str, &str)] = &[
+        (
+            "QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        ),
+        (
+            "QmQVcekGM1VRMHZnDjNPvYiEQ3mYYRaXiEAPs2qwHHk8kv",
+            "bafybeibaanddhnz7v7quubnv3dlngzkl2x56zxllbyhtfck3kybrepaee4",
+        ),
+    ];
+
+    #[test]
+    fn converts_cidv0_to_cidv1() {
+        for (v0, v1) in CIDV0_VECTORS {
+            assert_eq!(cid_v0_to_v1(v0).as_deref(), Some(*v1), "for {v0}");
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_cidv0() {
+        assert!(cid_v0_to_v1("QmNotARealCidValueHereJustGarbage1234567890xx").is_none());
+        assert!(cid_v0_to_v1("not-a-cid").is_none());
+    }
+
+    #[test]
+    fn normalize_passes_through_cidv1() {
+        let v1 = "bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e";
+        assert_eq!(normalize_cid(v1).as_deref(), Some(v1));
+    }
+
+    #[test]
+    fn normalize_upgrades_cidv0() {
+        assert_eq!(
+            normalize_cid("QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR").as_deref(),
+            Some("bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"),
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_non_cid() {
+        assert!(normalize_cid("https://example.com/x.png").is_none());
+        assert!(normalize_cid("").is_none());
+    }
+
+    #[test]
+    fn extracts_image_and_file_cids() {
+        let json = r#"{
+            "name": "Guthix",
+            "image": "ipfs://QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR",
+            "mediaType": "image/png",
+            "files": [
+                {
+                    "name": "hi-res",
+                    "mediaType": "image/webp",
+                    "src": "ipfs://bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e"
+                }
+            ],
+            "tier": "Elder"
+        }"#;
+        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
+        let cids = metadata.extract_cids();
+        assert_eq!(cids.len(), 2);
+        assert_eq!(cids[0].role, CidRole::Image);
+        assert_eq!(
+            cids[0].cid,
+            "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+        );
+        assert_eq!(cids[1].role, CidRole::File);
+        assert_eq!(cids[1].media_type.as_deref(), Some("image/webp"));
+        assert_eq!(
+            cids[1].cid,
+            "bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e"
+        );
+    }
+
+    #[test]
+    fn skips_http_image_urls() {
+        let json = r#"{"name": "x", "image": "https://example.com/x.png"}"#;
+        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
+        assert!(metadata.extract_cids().is_empty());
+    }
+
+    #[test]
+    fn dedupes_repeated_cids() {
+        let cid = "bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e";
+        let json = format!(
+            r#"{{
+                "name": "x",
+                "image": "ipfs://{cid}",
+                "files": [{{"mediaType": "image/png", "src": "ipfs://{cid}"}}]
+            }}"#
+        );
+        let metadata: AssetMetadata = serde_json::from_str(&json).unwrap();
+        let cids = metadata.extract_cids();
+        assert_eq!(cids.len(), 1, "the same CID across image + files dedupes");
+        assert_eq!(cids[0].role, CidRole::Image);
+    }
+}

--- a/cardano-assets/src/cip68.rs
+++ b/cardano-assets/src/cip68.rs
@@ -1,0 +1,236 @@
+//! CIP-68 reference-token datum decoding.
+//!
+//! CIP-68 metadata lives on-chain in the inline datum of the `000643b0`
+//! reference token, encoded as a Plutus
+//! `Constr 0 [metadata_map, version, extra?]`. [`decode_cip68_datum`]
+//! turns that raw datum CBOR into the same typed [`AssetMetadata`] this
+//! crate already produces from CIP-25 JSON — the CIP-68 metadata map
+//! mirrors the CIP-25 shape, so once it is rendered to a JSON value the
+//! existing decoder handles every known variant. Downstream consumers
+//! (trait extraction, [`crate::cid`] CID extraction) are unchanged.
+//!
+//! Behind the `cip68` feature; pulls in `pallas-codec` / `pallas-primitives`.
+
+use crate::{AssetMetadata, AssetMetadata68, NftPurpose};
+use pallas_primitives::{BigInt, PlutusData};
+use serde_json::{Map, Number, Value};
+use std::fmt;
+
+/// CBOR tag of a Plutus `Constructor 0` value.
+const CONSTR_0_TAG: u64 = 121;
+
+/// Failure modes when decoding a CIP-68 reference-token datum.
+#[derive(Debug)]
+pub enum Cip68Error {
+    /// The datum bytes were not valid `PlutusData` CBOR.
+    Cbor(String),
+    /// The datum was valid CBOR but not a constructor value.
+    NotConstructor,
+    /// The constructor was not `Constructor 0`, which CIP-68 requires.
+    WrongConstructor,
+    /// The constructor carried no fields — no metadata map present.
+    EmptyDatum,
+    /// The metadata map did not match any known `AssetMetadata` shape.
+    Metadata(serde_json::Error),
+}
+
+impl fmt::Display for Cip68Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Cip68Error::Cbor(e) => write!(f, "invalid PlutusData CBOR: {e}"),
+            Cip68Error::NotConstructor => f.write_str("datum is not a constructor value"),
+            Cip68Error::WrongConstructor => f.write_str("datum constructor is not Constructor 0"),
+            Cip68Error::EmptyDatum => f.write_str("datum constructor has no fields"),
+            Cip68Error::Metadata(e) => {
+                write!(f, "metadata map did not match a known shape: {e}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Cip68Error {}
+
+/// Decode a CIP-68 reference-token datum (raw Plutus data CBOR) into a
+/// typed [`AssetMetadata68`].
+///
+/// The datum is expected to be `Constr 0 [metadata_map, version, extra?]`.
+/// The `version` field is read when present (defaulting to `1`); the
+/// optional `extra` field is ignored. The returned
+/// [`AssetMetadata68::purpose`] is always [`NftPurpose::ReferenceNft`] —
+/// CIP-68 metadata datums only ever live on the reference token.
+pub fn decode_cip68_datum(datum_cbor: &[u8]) -> Result<AssetMetadata68, Cip68Error> {
+    let plutus: PlutusData =
+        pallas_codec::minicbor::decode(datum_cbor).map_err(|e| Cip68Error::Cbor(e.to_string()))?;
+
+    let constr = match plutus {
+        PlutusData::Constr(c) => c,
+        _ => return Err(Cip68Error::NotConstructor),
+    };
+    if constr.tag != CONSTR_0_TAG && constr.any_constructor != Some(0) {
+        return Err(Cip68Error::WrongConstructor);
+    }
+
+    let fields: Vec<PlutusData> = constr.fields.into();
+    let metadata_pd = fields.first().ok_or(Cip68Error::EmptyDatum)?;
+    let version = fields.get(1).and_then(plutus_as_u32).unwrap_or(1);
+
+    let metadata: AssetMetadata =
+        serde_json::from_value(plutus_to_json(metadata_pd)).map_err(Cip68Error::Metadata)?;
+
+    Ok(AssetMetadata68 {
+        purpose: NftPurpose::ReferenceNft,
+        version,
+        metadata,
+    })
+}
+
+/// Read a `PlutusData` integer as a `u32`, if it fits.
+fn plutus_as_u32(pd: &PlutusData) -> Option<u32> {
+    match pd {
+        PlutusData::BigInt(BigInt::Int(n)) => u32::try_from(i128::from(*n)).ok(),
+        _ => None,
+    }
+}
+
+/// Render a `PlutusData` value to a `serde_json::Value`.
+///
+/// Byte strings become UTF-8 strings when valid, otherwise `0x…` hex
+/// strings. Maps become objects (keys string-coerced via
+/// [`plutus_key`]). Constructors become `{ "__constructor": n,
+/// "fields": [...] }`. Integers become JSON numbers, falling back to a
+/// decimal string outside the `i64` range.
+fn plutus_to_json(pd: &PlutusData) -> Value {
+    match pd {
+        PlutusData::Constr(c) => {
+            let mut obj = Map::new();
+            obj.insert(
+                "__constructor".to_owned(),
+                Value::Number(Number::from(c.any_constructor.unwrap_or(0))),
+            );
+            obj.insert(
+                "fields".to_owned(),
+                Value::Array(c.fields.iter().map(plutus_to_json).collect()),
+            );
+            Value::Object(obj)
+        }
+        PlutusData::Map(entries) => {
+            let mut obj = Map::new();
+            for (k, v) in entries.iter() {
+                obj.insert(plutus_key(k), plutus_to_json(v));
+            }
+            Value::Object(obj)
+        }
+        PlutusData::BigInt(BigInt::Int(n)) => {
+            let raw = i128::from(*n);
+            i64::try_from(raw).map_or_else(
+                |_| Value::String(raw.to_string()),
+                |v| Value::Number(v.into()),
+            )
+        }
+        PlutusData::BigInt(BigInt::BigUInt(b) | BigInt::BigNInt(b)) => {
+            Value::String(format!("0x{}", hex::encode(&**b)))
+        }
+        PlutusData::BoundedBytes(b) => bytes_to_json(b),
+        PlutusData::Array(items) => Value::Array(items.iter().map(plutus_to_json).collect()),
+    }
+}
+
+/// Render bytes as a UTF-8 string, or a `0x…` hex string if not valid UTF-8.
+fn bytes_to_json(bytes: &[u8]) -> Value {
+    match std::str::from_utf8(bytes) {
+        Ok(s) => Value::String(s.to_owned()),
+        Err(_) => Value::String(format!("0x{}", hex::encode(bytes))),
+    }
+}
+
+/// Coerce a `PlutusData` map key to a JSON object key. CIP-68 metadata
+/// keys are byte strings; integer keys are stringified; anything more
+/// exotic (a spec violation) is preserved as `0x…` CBOR hex.
+fn plutus_key(pd: &PlutusData) -> String {
+    match pd {
+        PlutusData::BoundedBytes(b) => match std::str::from_utf8(b) {
+            Ok(s) => s.to_owned(),
+            Err(_) => format!("0x{}", hex::encode(&**b)),
+        },
+        PlutusData::BigInt(BigInt::Int(n)) => i128::from(*n).to_string(),
+        other => {
+            let mut buf = Vec::new();
+            if pallas_codec::minicbor::encode(other, &mut buf).is_ok() {
+                format!("0x{}", hex::encode(&buf))
+            } else {
+                "<unencodable>".to_owned()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Asset, CidRole};
+
+    // Real CIP-68 reference-token datums lifted from the mitos
+    // `asset-metadata-update` Nikeverse1501 fixture: the metadata of a
+    // dynamic CIP-68 NFT before and after an on-chain update. The
+    // `prev` datum carries a CIDv0 image, the `new` datum a CIDv1 image.
+    const NIKEVERSE_PREV: &[u8] =
+        include_bytes!("../resources/cip68/nikeverse1501_prev.datum.cbor");
+    const NIKEVERSE_NEW: &[u8] = include_bytes!("../resources/cip68/nikeverse1501_new.datum.cbor");
+
+    #[test]
+    fn decodes_reference_datum_with_cidv0_image() {
+        let decoded = decode_cip68_datum(NIKEVERSE_PREV).expect("prev datum decodes");
+        assert_eq!(decoded.purpose, NftPurpose::ReferenceNft);
+        assert_eq!(decoded.version, 1);
+
+        let asset = Asset::from(decoded.metadata);
+        assert_eq!(asset.name, "Guthix");
+        assert_eq!(
+            asset.image,
+            "ipfs://QmQVcekGM1VRMHZnDjNPvYiEQ3mYYRaXiEAPs2qwHHk8kv"
+        );
+        assert_eq!(asset.media_type.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn decodes_reference_datum_with_cidv1_image() {
+        let decoded = decode_cip68_datum(NIKEVERSE_NEW).expect("new datum decodes");
+        let asset = Asset::from(decoded.metadata);
+        assert_eq!(asset.name, "Guthix");
+        assert_eq!(
+            asset.image,
+            "ipfs://bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e"
+        );
+    }
+
+    #[test]
+    fn extracts_cid_from_decoded_datum() {
+        // The `prev` datum's CIDv0 image is normalised to CIDv1 on the
+        // way out, so the index sees a single stable representation.
+        let decoded = decode_cip68_datum(NIKEVERSE_PREV).expect("prev datum decodes");
+        let cids = decoded.extract_cids();
+        assert_eq!(cids.len(), 1);
+        assert_eq!(cids[0].role, CidRole::Image);
+        assert_eq!(
+            cids[0].cid,
+            "bafybeibaanddhnz7v7quubnv3dlngzkl2x56zxllbyhtfck3kybrepaee4"
+        );
+    }
+
+    #[test]
+    fn rejects_non_constructor_datum() {
+        // A bare CBOR integer (`1`) is valid CBOR but not a constructor.
+        assert!(matches!(
+            decode_cip68_datum(&[0x01]),
+            Err(Cip68Error::NotConstructor)
+        ));
+    }
+
+    #[test]
+    fn rejects_garbage_cbor() {
+        assert!(matches!(
+            decode_cip68_datum(&[0xff, 0xfe, 0xfd]),
+            Err(Cip68Error::Cbor(_))
+        ));
+    }
+}

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -10,6 +10,9 @@ use std::str::FromStr;
 use utoipa::ToSchema;
 
 pub mod asset_id;
+pub mod cid;
+#[cfg(feature = "cip68")]
+pub mod cip68;
 pub mod collection;
 #[cfg(feature = "cip14")]
 pub mod fingerprint;
@@ -26,6 +29,9 @@ pub use token_type::TokenType;
 pub mod utxorpc;
 
 pub use asset_id::*;
+pub use cid::{cid_v0_to_v1, normalize_cid, CidRole, ExtractedCid};
+#[cfg(feature = "cip68")]
+pub use cip68::{decode_cip68_datum, Cip68Error};
 pub use collection::*;
 #[cfg(feature = "cip14")]
 pub use fingerprint::{Fingerprint, FingerprintError};


### PR DESCRIPTION
Extends `cardano-assets` to decode CIP-68 metadata from on-chain Plutus
datum CBOR, and adds first-class IPFS CID extraction. Until now the crate
only decoded CIP-25 metadata from indexer-supplied JSON (Maestro-shaped);
CIP-68 metadata arrives as a CBOR datum and had no path.

### Changes

- **New `cip68` feature** — optional, pulls `pallas-codec` /
  `pallas-primitives` (workspace pins, `1.0.0-alpha.6`). Off by default,
  so JSON-only consumers are unaffected.
- **`cip68::decode_cip68_datum(&[u8]) -> Result<AssetMetadata68, Cip68Error>`**
  — decodes a CIP-68 reference-token datum (`Constr 0 [metadata, version,
  extra?]`) to `PlutusData`, renders the metadata map to a JSON value, and
  reuses the existing untagged `AssetMetadata` decoder. Every CIP-25 shape
  the crate already knows works for CIP-68 with no new variant logic.
- **`cid` module (always compiled, no chain deps)** —
  `AssetMetadata::extract_cids()` / `AssetMetadata68::extract_cids()`
  collect the headline `image` plus every `files[].src`, deduped and
  normalised to CIDv1. `cid_v0_to_v1()` / `normalize_cid()` handle
  CIDv0→CIDv1 conversion (hand-rolled base58/base32, no new runtime dep).

### Testing

- 13 new tests; fixtures are real CIP-68 datums lifted from the mitos
  `asset-metadata-update` Nikeverse1501 fixture (one CIDv0-image datum,
  one CIDv1-image datum) under `resources/cip68/`.
- CIDv0→v1 golden vectors cross-checked against an independent
  base58/base32 implementation.
- Default build and `--features cip68` both clippy-clean (`-D warnings`);
  `cargo fmt` applied.

### Context

Groundwork for the collection-ownership Policy CID Index
(`GET /api/cids/{policy_id}`), which decodes mitos `cip-25-mint` /
`cip-68-mint` / `asset-metadata-update` events worker-side so the
Hodlcroft archivist never decodes metadata itself.
