### PR TITLE
cardano-assets + maestro: retain additional-media CIDs through the Maestro path

### DIFF
--- a/cardano-assets/resources/test/bankcard2500.json
+++ b/cardano-assets/resources/test/bankcard2500.json
@@ -1,0 +1,21 @@
+{
+  "Card Type": "Partner",
+  "Game Rewards": "Share of 10%",
+  "Partner Perk 1": "Additional in game benefits",
+  "Platypus Perk": "500 ADA held in wallet to qualify for .5 staking",
+  "Staking Factor": "1",
+  "collection": "BANK- Bankcard",
+  "files": [
+    {
+      "mediaType": "video/mp4",
+      "name": "Bankopoly #01",
+      "src": [
+        "ipfs://bafybeiflyytsm445wlbv4fsayvdlnhnz34rzrxntzp74notjtrqi2joz",
+        "ay"
+      ]
+    }
+  ],
+  "image": "ipfs://bafybeibakqunty3xjq6ljfyfi3lde27xf3edm2tz6rm2kyb6n4aczgcjee",
+  "mediaType": "image/gif",
+  "name": "Bankopoly #01"
+}

--- a/cardano-assets/resources/test/derpbird07490.json
+++ b/cardano-assets/resources/test/derpbird07490.json
@@ -1,0 +1,38 @@
+{
+  "attributes": {
+    "Back": "Stoner",
+    "Background": "Black",
+    "Beak": "Stoner",
+    "Body": "Corpo",
+    "Color": "Blue",
+    "Ears": "DJ",
+    "Eyes": "DJ",
+    "Head": "Stoner",
+    "Perfect Specimen": "No",
+    "Power Level": "Undetermined",
+    "Rarity": "Uncommon",
+    "Tail": "Corpo"
+  },
+  "files": [
+    {
+      "mediaType": "image/png",
+      "name": "Rebirth",
+      "src": "ipfs://Qmdd54FbzM2kqb9g8Q9Fhkejbm6k684U7egqRMs7yS9Tim"
+    },
+    {
+      "mediaType": "image/png",
+      "name": "OG",
+      "src": "ipfs://Qmag7ZNVNEQQTBtVXnNoVojeU6MZHaCnX4sRYxGTCpn1Y2"
+    },
+    {
+      "mediaType": "image/png",
+      "name": "Head",
+      "src": "ipfs://QmfJb52NaXNZ8Jtym9iV7dFUzpN3TuC6aRgkZK1NyQrgnW"
+    }
+  ],
+  "image": "ipfs://Qmdd54FbzM2kqb9g8Q9Fhkejbm6k684U7egqRMs7yS9Tim",
+  "mediaType": "image/png",
+  "name": "Derp Bird #07490",
+  "series": 2,
+  "url": "derpbirds.io"
+}

--- a/cardano-assets/resources/test/pred09193.json
+++ b/cardano-assets/resources/test/pred09193.json
@@ -1,0 +1,31 @@
+{
+  "attributes": {
+    "Background": "Infiltration",
+    "Body": "Farmer's Body",
+    "Face": "Trooper's Face",
+    "Head": "Marksman's ???",
+    "Rank": 1,
+    "Skin Color": "Gray"
+  },
+  "files": [
+    {
+      "mediaType": "image/png",
+      "name": "Pred #09193",
+      "src": "ipfs://QmU3PxikRHYa6chUW9GD9tb3rgrSejsD2mqJNkeD8pn523"
+    },
+    {
+      "mediaType": "image/png",
+      "name": "v1",
+      "src": "ipfs://QmTJAgWvLRJCHfvM1xvqPE7kXrgaD1yf8jrXhJKytAkdH4"
+    }
+  ],
+  "image": "ipfs://QmU3PxikRHYa6chUW9GD9tb3rgrSejsD2mqJNkeD8pn523",
+  "name": "Pred #09193",
+  "series": 2,
+  "swaps": [
+    "DP05438",
+    "DE10004"
+  ],
+  "type": "image/png",
+  "url": "https://derpbirds.io"
+}

--- a/cardano-assets/src/cid.rs
+++ b/cardano-assets/src/cid.rs
@@ -324,6 +324,60 @@ mod tests {
     }
 
     #[test]
+    fn extracts_media_with_numeric_trait_and_extra_fields() {
+        // Real metadata: "Pred #09193" — a headline image plus a
+        // two-entry `files[]` (the first duplicates the image), a
+        // numeric trait value (`Rank: 1`), a `swaps` string array and
+        // a `type` field (not `mediaType`). Exercises CID extraction
+        // alongside the decoder's tolerance of those shapes.
+        let json = include_str!("../resources/test/pred09193.json");
+        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
+        let cids = metadata.extract_cids();
+
+        assert_eq!(
+            cids.len(),
+            2,
+            "headline image (deduped with files[0]) + 1 distinct file"
+        );
+        assert_eq!(cids[0].role, CidRole::Image);
+        assert_eq!(
+            cids[0].cid,
+            "bafybeicuxkjhqrktemdvjqmb7ppep2capgreu76tdqaxya2h5gr2y35luq"
+        );
+        assert_eq!(cids[1].role, CidRole::File);
+        assert_eq!(
+            cids[1].cid,
+            "bafybeicju6krfmaqgdjczkj6pnyulmo3dlaaxrpqcys7vjgotv2tyjjb3m"
+        );
+        assert_eq!(cids[1].media_type.as_deref(), Some("image/png"));
+    }
+
+    #[test]
+    fn extracts_media_from_flattened_metadata_with_chunked_src() {
+        // Real metadata: "Bankopoly #01" — the `Flattened` variant
+        // (trait keys at the top level), whose single `files[]` entry
+        // has a CIP-25-chunked `src` (a string array that must be
+        // joined) pointing at an mp4, plus a CIDv1 `image` that
+        // passes through normalisation unchanged.
+        let json = include_str!("../resources/test/bankcard2500.json");
+        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
+        let cids = metadata.extract_cids();
+
+        assert_eq!(cids.len(), 2, "headline image + 1 distinct video file");
+        assert_eq!(cids[0].role, CidRole::Image);
+        assert_eq!(
+            cids[0].cid,
+            "bafybeibakqunty3xjq6ljfyfi3lde27xf3edm2tz6rm2kyb6n4aczgcjee"
+        );
+        assert_eq!(cids[1].role, CidRole::File);
+        assert_eq!(
+            cids[1].cid,
+            "bafybeiflyytsm445wlbv4fsayvdlnhnz34rzrxntzp74notjtrqi2jozay"
+        );
+        assert_eq!(cids[1].media_type.as_deref(), Some("video/mp4"));
+    }
+
+    #[test]
     fn skips_http_image_urls() {
         let json = r#"{"name": "x", "image": "https://example.com/x.png"}"#;
         let metadata: AssetMetadata = serde_json::from_str(json).unwrap();

--- a/cardano-assets/src/cid.rs
+++ b/cardano-assets/src/cid.rs
@@ -8,7 +8,7 @@
 //! This module is pure (no chain dependencies) and is always compiled; the
 //! CIP-68 datum decoder that feeds it lives behind the `cip68` feature.
 
-use crate::{get_image_url, Asset, AssetFile, AssetMetadata, AssetMetadata68, PrimitiveOrList};
+use crate::{Asset, AssetFile, AssetMetadata, AssetMetadata68, PrimitiveOrList};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
@@ -49,7 +49,7 @@ impl AssetMetadata {
         let mut seen = HashSet::new();
         let mut out = Vec::new();
 
-        if let Some(cid) = cid_from_url(&get_image_url(image.clone())) {
+        if let Some(cid) = cid_from_url(&image.dechunked()) {
             if seen.insert(cid.clone()) {
                 out.push(ExtractedCid {
                     cid,
@@ -289,92 +289,93 @@ mod tests {
     }
 
     #[test]
-    fn extracts_all_media_from_multi_file_metadata() {
-        // Real metadata: "Derp Bird #07490" — a headline image plus a
-        // three-entry `files[]` where the first file duplicates the
-        // headline image and the other two are distinct media. All
-        // three CIDs are CIDv0. The flatten to `Asset` would keep only
-        // the headline image; `extract_cids` on `AssetMetadata` keeps
-        // the lot.
-        let json = include_str!("../resources/test/derpbird07490.json");
-        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
-        let cids = metadata.extract_cids();
+    fn dechunked_resolves_cip25_string_chunking() {
+        // A plain string is returned as-is; a chunked value (CIP-25's
+        // 64-byte split) is concatenated back into the whole.
+        let plain = PrimitiveOrList::Primitive("ipfs://bafyone".to_string());
+        assert_eq!(plain.dechunked(), "ipfs://bafyone");
+        let chunked = PrimitiveOrList::List(vec!["ipfs://bafy".to_string(), "rest".to_string()]);
+        assert_eq!(chunked.dechunked(), "ipfs://bafyrest");
+    }
 
-        assert_eq!(
-            cids.len(),
-            3,
-            "headline image (deduped with files[0]) + 2 distinct files"
-        );
-        assert_eq!(cids[0].role, CidRole::Image);
-        assert_eq!(
-            cids[0].cid,
-            "bafybeihdcqqgawor7rqnucl3fvhbmxtp7bspkf2i6k2ev6wqaihjujrqny"
-        );
-        assert_eq!(cids[1].role, CidRole::File);
-        assert_eq!(
-            cids[1].cid,
-            "bafybeifxjcrr6ahvauwym6qz6wqxjcxoilu7lkzeyyikzsn6a6rzlwzq34"
-        );
-        assert_eq!(cids[1].media_type.as_deref(), Some("image/png"));
-        assert_eq!(cids[2].role, CidRole::File);
-        assert_eq!(
-            cids[2].cid,
-            "bafybeih4b5tk5zrfgrzpwogn6voq6lutg2rb3z4753zg4p2hrjof2odnem"
-        );
+    /// One real on-chain CIP-25 fixture and the CIDs `extract_cids`
+    /// should recover from it.
+    struct CidCase {
+        asset: &'static str,
+        metadata_json: &'static str,
+        expected: &'static [(CidRole, &'static str)],
     }
 
     #[test]
-    fn extracts_media_with_numeric_trait_and_extra_fields() {
-        // Real metadata: "Pred #09193" — a headline image plus a
-        // two-entry `files[]` (the first duplicates the image), a
-        // numeric trait value (`Rank: 1`), a `swaps` string array and
-        // a `type` field (not `mediaType`). Exercises CID extraction
-        // alongside the decoder's tolerance of those shapes.
-        let json = include_str!("../resources/test/pred09193.json");
-        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
-        let cids = metadata.extract_cids();
+    fn extracts_cids_from_real_collections() {
+        // Each fixture is real on-chain metadata, chosen to span the
+        // shapes the resolver must handle: both metadata variants,
+        // CIDv0 + CIDv1, single + chunked `files[].src`, and a file
+        // that repeats the headline image (which dedupes). Add a case
+        // here when a new on-chain shape needs covering.
+        let cases = [
+            // Attributed variant; 3 files, files[0] repeats the image;
+            // all CIDv0 (exercises CIDv0 -> CIDv1 normalisation).
+            CidCase {
+                asset: "Derp Bird #07490",
+                metadata_json: include_str!("../resources/test/derpbird07490.json"),
+                expected: &[
+                    (
+                        CidRole::Image,
+                        "bafybeihdcqqgawor7rqnucl3fvhbmxtp7bspkf2i6k2ev6wqaihjujrqny",
+                    ),
+                    (
+                        CidRole::File,
+                        "bafybeifxjcrr6ahvauwym6qz6wqxjcxoilu7lkzeyyikzsn6a6rzlwzq34",
+                    ),
+                    (
+                        CidRole::File,
+                        "bafybeih4b5tk5zrfgrzpwogn6voq6lutg2rb3z4753zg4p2hrjof2odnem",
+                    ),
+                ],
+            },
+            // Attributed variant with a numeric trait + `swaps` array
+            // + a `type` (not `mediaType`) field; 2 files, files[0]
+            // repeats the image.
+            CidCase {
+                asset: "Pred #09193",
+                metadata_json: include_str!("../resources/test/pred09193.json"),
+                expected: &[
+                    (
+                        CidRole::Image,
+                        "bafybeicuxkjhqrktemdvjqmb7ppep2capgreu76tdqaxya2h5gr2y35luq",
+                    ),
+                    (
+                        CidRole::File,
+                        "bafybeicju6krfmaqgdjczkj6pnyulmo3dlaaxrpqcys7vjgotv2tyjjb3m",
+                    ),
+                ],
+            },
+            // Flattened variant; a chunked `files[].src` (string array)
+            // pointing at an mp4; CIDv1 image (normalisation passthrough).
+            CidCase {
+                asset: "Bankopoly #01",
+                metadata_json: include_str!("../resources/test/bankcard2500.json"),
+                expected: &[
+                    (
+                        CidRole::Image,
+                        "bafybeibakqunty3xjq6ljfyfi3lde27xf3edm2tz6rm2kyb6n4aczgcjee",
+                    ),
+                    (
+                        CidRole::File,
+                        "bafybeiflyytsm445wlbv4fsayvdlnhnz34rzrxntzp74notjtrqi2jozay",
+                    ),
+                ],
+            },
+        ];
 
-        assert_eq!(
-            cids.len(),
-            2,
-            "headline image (deduped with files[0]) + 1 distinct file"
-        );
-        assert_eq!(cids[0].role, CidRole::Image);
-        assert_eq!(
-            cids[0].cid,
-            "bafybeicuxkjhqrktemdvjqmb7ppep2capgreu76tdqaxya2h5gr2y35luq"
-        );
-        assert_eq!(cids[1].role, CidRole::File);
-        assert_eq!(
-            cids[1].cid,
-            "bafybeicju6krfmaqgdjczkj6pnyulmo3dlaaxrpqcys7vjgotv2tyjjb3m"
-        );
-        assert_eq!(cids[1].media_type.as_deref(), Some("image/png"));
-    }
-
-    #[test]
-    fn extracts_media_from_flattened_metadata_with_chunked_src() {
-        // Real metadata: "Bankopoly #01" — the `Flattened` variant
-        // (trait keys at the top level), whose single `files[]` entry
-        // has a CIP-25-chunked `src` (a string array that must be
-        // joined) pointing at an mp4, plus a CIDv1 `image` that
-        // passes through normalisation unchanged.
-        let json = include_str!("../resources/test/bankcard2500.json");
-        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
-        let cids = metadata.extract_cids();
-
-        assert_eq!(cids.len(), 2, "headline image + 1 distinct video file");
-        assert_eq!(cids[0].role, CidRole::Image);
-        assert_eq!(
-            cids[0].cid,
-            "bafybeibakqunty3xjq6ljfyfi3lde27xf3edm2tz6rm2kyb6n4aczgcjee"
-        );
-        assert_eq!(cids[1].role, CidRole::File);
-        assert_eq!(
-            cids[1].cid,
-            "bafybeiflyytsm445wlbv4fsayvdlnhnz34rzrxntzp74notjtrqi2jozay"
-        );
-        assert_eq!(cids[1].media_type.as_deref(), Some("video/mp4"));
+        for case in &cases {
+            let metadata: AssetMetadata = serde_json::from_str(case.metadata_json)
+                .unwrap_or_else(|e| panic!("{}: metadata did not decode: {e}", case.asset));
+            let cids = metadata.extract_cids();
+            let got: Vec<(CidRole, &str)> = cids.iter().map(|c| (c.role, c.cid.as_str())).collect();
+            assert_eq!(got.as_slice(), case.expected, "{}", case.asset);
+        }
     }
 
     #[test]

--- a/cardano-assets/src/cid.rs
+++ b/cardano-assets/src/cid.rs
@@ -9,10 +9,16 @@
 //! CIP-68 datum decoder that feeds it lives behind the `cip68` feature.
 
 use crate::{get_image_url, Asset, AssetFile, AssetMetadata, AssetMetadata68, PrimitiveOrList};
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
 /// Where in the metadata a CID was found.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
 pub enum CidRole {
     /// The headline `image` field.
     Image,
@@ -21,13 +27,15 @@ pub enum CidRole {
 }
 
 /// A single IPFS CID recovered from asset metadata.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct ExtractedCid {
     /// The CID, normalised to CIDv1 (base32).
     pub cid: String,
     /// Where it was referenced from.
     pub role: CidRole,
     /// The `mediaType` of the referencing entry, when known (`files[]` only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub media_type: Option<String>,
 }
 
@@ -277,6 +285,41 @@ mod tests {
         assert_eq!(
             cids[1].cid,
             "bafybeidw54qa6bcbbjnztbbj6cd7qzazr33instef33ql4lws45mp6uw3e"
+        );
+    }
+
+    #[test]
+    fn extracts_all_media_from_multi_file_metadata() {
+        // Real metadata: "Derp Bird #07490" — a headline image plus a
+        // three-entry `files[]` where the first file duplicates the
+        // headline image and the other two are distinct media. All
+        // three CIDs are CIDv0. The flatten to `Asset` would keep only
+        // the headline image; `extract_cids` on `AssetMetadata` keeps
+        // the lot.
+        let json = include_str!("../resources/test/derpbird07490.json");
+        let metadata: AssetMetadata = serde_json::from_str(json).unwrap();
+        let cids = metadata.extract_cids();
+
+        assert_eq!(
+            cids.len(),
+            3,
+            "headline image (deduped with files[0]) + 2 distinct files"
+        );
+        assert_eq!(cids[0].role, CidRole::Image);
+        assert_eq!(
+            cids[0].cid,
+            "bafybeihdcqqgawor7rqnucl3fvhbmxtp7bspkf2i6k2ev6wqaihjujrqny"
+        );
+        assert_eq!(cids[1].role, CidRole::File);
+        assert_eq!(
+            cids[1].cid,
+            "bafybeifxjcrr6ahvauwym6qz6wqxjcxoilu7lkzeyyikzsn6a6rzlwzq34"
+        );
+        assert_eq!(cids[1].media_type.as_deref(), Some("image/png"));
+        assert_eq!(cids[2].role, CidRole::File);
+        assert_eq!(
+            cids[2].cid,
+            "bafybeih4b5tk5zrfgrzpwogn6voq6lutg2rb3z4753zg4p2hrjof2odnem"
         );
     }
 

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -1038,6 +1038,7 @@ impl Asset {
         AssetWithId {
             id: id.to_string(),
             asset: self.clone(),
+            cids: Vec::new(),
         }
     }
 }
@@ -1057,6 +1058,20 @@ impl From<Asset> for Traits {
 pub struct AssetWithId {
     pub id: String,
     pub asset: Asset,
+    /// IPFS CIDs (headline image + every `files[]` entry) this asset
+    /// references, extracted from the source metadata *before* it was
+    /// flattened to `Asset` — the flatten keeps only the headline
+    /// image, so this is where additional media survives.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cids: Vec<ExtractedCid>,
+}
+
+impl AssetWithId {
+    /// Construct with an explicit extracted-CID set.
+    #[must_use]
+    pub fn new(id: String, asset: Asset, cids: Vec<ExtractedCid>) -> Self {
+        Self { id, asset, cids }
+    }
 }
 
 #[derive(Serialize, Default, Debug)]

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -71,16 +71,26 @@ pub enum PrimitiveOrList<T> {
     List(Vec<T>),
 }
 
+impl PrimitiveOrList<String> {
+    /// Resolve a possibly-chunked string to its full value.
+    ///
+    /// CIP-25 caps on-chain metadata strings at 64 bytes, so longer
+    /// values (IPFS URLs, descriptions) are stored split across a JSON
+    /// array of ≤64-byte chunks; shorter values are stored as a plain
+    /// string. Either way this returns the whole value — chunks
+    /// concatenated in order, a plain string as-is.
+    #[must_use]
+    pub fn dechunked(&self) -> String {
+        match self {
+            PrimitiveOrList::Primitive(value) => value.clone(),
+            PrimitiveOrList::List(chunks) => chunks.concat(),
+        }
+    }
+}
+
 impl From<PrimitiveOrList<String>> for String {
     fn from(value: PrimitiveOrList<String>) -> Self {
-        match value {
-            PrimitiveOrList::Primitive(val) => val,
-            PrimitiveOrList::List(items) => {
-                let default = String::new();
-                let result = items.first().unwrap_or(&default);
-                result.clone()
-            }
-        }
+        value.dechunked()
     }
 }
 
@@ -94,15 +104,9 @@ pub struct AssetFile {
 }
 
 impl AssetFile {
-    /// Get the source URL, handling both string and array formats
+    /// The source URL, with any CIP-25 string chunking resolved.
     pub fn get_src(&self) -> String {
-        match &self.src {
-            PrimitiveOrList::Primitive(url) => url.clone(),
-            PrimitiveOrList::List(urls) => {
-                // For arrays like ["ipfs://hash", "oa"], concatenate them
-                urls.join("")
-            }
-        }
+        self.src.dechunked()
     }
 
     /// Get the media type
@@ -731,7 +735,7 @@ impl AssetMetadata {
 
                 // Otherwise, try to find matching file in files array
                 if let Some(file_list) = files {
-                    let image_url = get_image_url(image.clone());
+                    let image_url = image.dechunked();
                     for file in file_list {
                         if file.get_src() == image_url {
                             return Some(file.media_type().to_string());
@@ -763,7 +767,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits: merged_traits,
                     rarity_rank: None,
@@ -777,7 +781,7 @@ impl From<AssetMetadata> for Asset {
                 ..
             } => Self {
                 name,
-                image: get_image_url(image),
+                image: image.dechunked(),
                 media_type: extracted_media_type,
                 traits,
                 rarity_rank: None,
@@ -812,7 +816,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits,
                     rarity_rank: None,
@@ -834,7 +838,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits,
                     rarity_rank: None,
@@ -854,7 +858,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits,
                     rarity_rank: None,
@@ -872,7 +876,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits,
                     rarity_rank: None,
@@ -912,7 +916,7 @@ impl From<AssetMetadata> for Asset {
 
                 Self {
                     name: title,
-                    image: get_image_url(image),
+                    image: image.dechunked(),
                     media_type: extracted_media_type,
                     traits,
                     rarity_rank: None,
@@ -1192,13 +1196,6 @@ pub fn get_asset_tags(asset: &CnftAsset, max_rarity: Option<u32>) -> Vec<AssetTa
     }
 
     tags
-}
-
-fn get_image_url(input: PrimitiveOrList<String>) -> String {
-    match input {
-        PrimitiveOrList::Primitive(val) => val,
-        PrimitiveOrList::List(items) => items.join(""),
-    }
 }
 
 /// Merge extra metadata fields into traits, filtering out known metadata fields

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -2,7 +2,7 @@
 
 use async_stream::stream;
 use cardano_assets::{
-    Asset, AssetMetadata, AssetMetadata68, AssetWithId, MetadataKind, NftPurpose,
+    Asset, AssetMetadata, AssetMetadata68, AssetWithId, ExtractedCid, MetadataKind, NftPurpose,
 };
 use chrono::Utc;
 use futures_core::stream::Stream;
@@ -110,6 +110,24 @@ impl TryFrom<AssetStandards> for Asset {
                 Err(MaestroError::NoMetadata)
             }
         }
+    }
+}
+
+impl AssetStandards {
+    /// Every IPFS CID (headline image + each `files[]` entry) this
+    /// asset's metadata references. Extracted from the rich
+    /// `AssetMetadata` / `AssetMetadata68` — flattening to `Asset`
+    /// keeps only the headline image, so callers that need the full
+    /// media set must read it here.
+    #[must_use]
+    pub fn extract_cids(&self) -> Vec<ExtractedCid> {
+        if let Some(cip68) = &self.cip68_metadata {
+            return cip68.extract_cids();
+        }
+        if let Some(cip25) = &self.cip25_metadata {
+            return cip25.extract_cids();
+        }
+        Vec::new()
     }
 }
 
@@ -1472,7 +1490,12 @@ impl MaestroApi {
             .get_importable_nfts()
             .iter()
             .filter_map(|d| match Asset::try_from(d.asset_standards.clone()) {
-                Ok(asset) => Some(asset.with_id(&d.asset_name)),
+                Ok(asset) => {
+                    // Capture the full CID set (image + files[]) from the
+                    // rich metadata before the flatten to `Asset` drops it.
+                    let cids = d.asset_standards.extract_cids();
+                    Some(AssetWithId::new(d.asset_name.clone(), asset, cids))
+                }
                 Err(_) => None,
             })
             .collect();


### PR DESCRIPTION
A NFT's CIP-25 `files[]` array (extra media — alternate art, video,
hi-res) was being lost: the `AssetMetadata → Asset` flatten keeps only
the headline `image`, and the Maestro pipeline flattens before anything
extracts CIDs. This carries the full CID set through, and centralises
CIP-25 string-chunk handling along the way.

### cardano-assets

- **`AssetWithId` gains `cids: Vec<ExtractedCid>`** — the headline image
  plus every `files[]` entry, extracted from the rich `AssetMetadata` /
  `AssetMetadata68` before the flatten discards `files[]`. Added
  `AssetWithId::new`; `Asset::with_id` defaults the set empty.
- `ExtractedCid` / `CidRole` now derive `Serialize` / `Deserialize` so
  they can ride on `AssetWithId`.
- **`PrimitiveOrList<String>::dechunked()`** — one named, documented
  operation for CIP-25's 64-byte string-chunking convention. `get_src`,
  the `From<PrimitiveOrList<String>> for String` impl, and all eight
  `image` call sites now route through it; the ad-hoc `get_image_url`
  helper is removed.
- **Bug fix:** `From<PrimitiveOrList<String>> for String` used
  `items.first()`, which silently **truncated a chunked string to its
  first ≤64-byte chunk** — corrupting long IPFS URLs / descriptions
  taken via `.into()`. It now dechunks like everything else.

### maestro

- New `AssetStandards::extract_cids()` — pulls the full CID set from the
  decoded `cip25_metadata` / `cip68_metadata`.
- `get_asset_page_classified` now populates `AssetWithId.cids` from the
  asset's standards before the `Asset` flatten. Same already-fetched
  data — no extra API calls; `get_all_assets` inherits it.

### Testing

- Three real on-chain multi-media fixtures under
  `cardano-assets/resources/test/` (Derp Bird #07490, Pred #09193,
  Bankopoly #01) — chosen to span both metadata variants, CIDv0 + CIDv1,
  single + chunked `files[].src`, and a file that repeats the headline
  image (dedup).
- Consolidated into one table-driven `extracts_cids_from_real_collections`
  test; added `dechunked_resolves_cip25_string_chunking`.
- cardano-assets: 85 lib + 2 doc tests pass. maestro: 35 tests pass.
  `clippy -D warnings` and `cargo fmt --check` clean on both.

### Context

Lets the collection-ownership worker's Maestro ingest capture the full
IPFS media set per asset (`a.cids`) for the Policy CID Index, instead of
just the headline image.