### PR TITLE
feature[cardano-tx]: Wayup collection-offer create/cancel + witness-aware & per-redeemer fees

### DIFF
--- a/cardano-tx/examples/wayup_cancel_eval.rs
+++ b/cardano-tx/examples/wayup_cancel_eval.rs
@@ -1,0 +1,79 @@
+//! One-off: build an UNSIGNED Wayup collection-offer cancel TX
+//! against real mainnet inputs and print its CBOR, so it can be
+//! fed to Maestro `/transactions/evaluate`. Confirms the cancel
+//! validates WITHOUT the 1 ADA courtesy fee and reports the real
+//! per-cancel ex-units.
+//!
+//! Inputs are real, unspent as of 2026-05-24 (bidder cba51a…):
+//!   - offer  5a6c5f13…:0  (120 ADA, Perp3876 asset-offer)
+//!   - fee    98e91808…:1  (~4694 ADA, pure ADA — fee + collateral)
+//!
+//! Run: `cargo run -p cardano-tx --example wayup_cancel_eval`
+
+use cardano_assets::utxo::UtxoApi;
+use cardano_tx::builder::collection_offer::{
+    build_cancel_offers_tx_with, CancelContract, CancelOfferRequest,
+};
+use cardano_tx::builder::TxDeps;
+use cardano_tx::params::TxBuildParams;
+use pallas_addresses::Address;
+use pallas_txbuilder::BuildConway;
+
+fn main() {
+    let wallet = "addr1q99qpegypskhugq6nss8gjkwvjlj35wd54venfynreqxjgkt55dzuk6msq4qgq4g0dmz6tkvdvdfkmgd6uyd4urms2ksl0yc60";
+    let from_address = Address::from_bech32(wallet).expect("wallet bech32");
+
+    // Real pure-ADA wallet UTxO for fee + collateral.
+    let fee_utxo = UtxoApi {
+        tx_hash: "98e91808cf24f6e598fc41ff42f704722ef36730e6ee89e62e8e7133c7c88a76".to_string(),
+        output_index: 1,
+        lovelace: 4_694_828_471,
+        assets: vec![],
+        tags: vec![],
+    };
+
+    // Real unspent Wayup offer owned by cba51a (datum field 0 =
+    // cba51a stake cred = the required cancel signer).
+    let datum_cbor_hex = "d8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad9fd8799fd8799fd8799f581c5f08a64f580e581735070e1b1d2ce29ae6942ab45ccff5a1747d2283ffd8799fd8799fd8799f581c28f17fdd2d8b8f559ad61e899e31eae90b9e209cbedb1ee8a8c6c7d1ffffffffa140d8799f00a1401a00249f00ffffd8799fd8799fd8799f581c4a00e5040c2d7e201a9c20744ace64bf28d1cda55999a4931e406922ffd8799fd8799fd8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82adffffffffa1581ce6ba9c0ff27be029442c32533c6efd956a60d15ecb976acbb64c4de0d8799f00a148506572703338373601ffffd8799fd8799fd8799f581cf00407b340f62c8327c0c2737e41514d715b60664aca3b65bdce6c90ffd8799fd8799fd8799f581ca234f55927f22416761471cb23a7d4faa0546c882c1f7570013dfce7ffffffffa140d8799f00a1401a00b71b00ffffffff";
+
+    let req = CancelOfferRequest {
+        co_tx_hash: "5a6c5f13884dcdeb41ecd6eeb9589e05db61738955565d02bea829ccea877923".to_string(),
+        co_output_index: 0,
+        co_lovelace: 120_000_000,
+        // Wayup cancel signer = the bidder's STAKE credential.
+        owner_pkh: "cba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad".to_string(),
+        datum_cbor_hex: Some(datum_cbor_hex.to_string()),
+        ex_units_mem: None,
+        ex_units_steps: None,
+    };
+
+    // Mainnet protocol params (stable values + live ex-unit prices).
+    let params = TxBuildParams {
+        min_fee_coefficient: 44,
+        min_fee_constant: 155_381,
+        coins_per_utxo_byte: 4_310,
+        max_tx_size: 16_384,
+        max_value_size: 5_000,
+        price_mem: Some((577, 10_000)),
+        price_step: Some((721, 10_000_000)),
+        min_fee_ref_script_cost_per_byte: 15,
+        ref_script_size: 2_557, // Wayup PlutusV2 script: 2560 CBOR bytes - 3-byte bytestring header
+    };
+
+    let deps = TxDeps {
+        utxos: vec![fee_utxo],
+        params,
+        from_address,
+        network_id: 1,
+    };
+
+    let unsigned = build_cancel_offers_tx_with(&deps, &[req], &CancelContract::wayup())
+        .expect("build wayup cancel");
+    let built = unsigned
+        .staging
+        .build_conway_raw()
+        .expect("build_conway_raw");
+
+    eprintln!("converged fee: {} lovelace", unsigned.fee);
+    println!("{}", hex::encode(&built.tx_bytes.0));
+}

--- a/cardano-tx/examples/wayup_create_eval.rs
+++ b/cardano-tx/examples/wayup_create_eval.rs
@@ -1,0 +1,70 @@
+//! One-off: build an UNSIGNED Wayup collection-offer CREATE TX and dump its
+//! CBOR + a structural summary. Confirms the offer output sits at the bidder
+//! frankenaddress with an INLINE datum (byte-exact to Wayup's format), that no
+//! script-data hash is produced (datum-only TXs don't need one when inline),
+//! and that the `674` marker label is attached.
+//!
+//! Run: `cargo run -p cardano-tx --example wayup_create_eval`
+
+use cardano_assets::utxo::UtxoApi;
+use cardano_tx::builder::collection_offer::{
+    build_wayup_collection_offers_tx, CollectionOfferRequest,
+};
+use cardano_tx::builder::TxDeps;
+use cardano_tx::params::TxBuildParams;
+use pallas_addresses::{Address, Network};
+use pallas_txbuilder::BuildConway;
+
+fn main() {
+    let wallet = "addr1q99qpegypskhugq6nss8gjkwvjlj35wd54venfynreqxjgkt55dzuk6msq4qgq4g0dmz6tkvdvdfkmgd6uyd4urms2ksl0yc60";
+    let from_address = Address::from_bech32(wallet).expect("wallet bech32");
+
+    let funding = UtxoApi {
+        tx_hash: "98e91808cf24f6e598fc41ff42f704722ef36730e6ee89e62e8e7133c7c88a76".to_string(),
+        output_index: 1,
+        lovelace: 200_000_000,
+        assets: vec![],
+        tags: vec![],
+    };
+
+    // Two collection offers (10 ADA + 25 ADA) on the same collection so we
+    // exercise the multi-offer path. Same bidder → same frankenaddress.
+    let mk = |lovelace: u64| CollectionOfferRequest {
+        policy_id: "a316bcf768f0309be743b4b7d067f3348017bf0f00f6a29562aebda2".into(),
+        total_lovelace: lovelace,
+        buyer_pkh: "4a00e5040c2d7e201a9c20744ace64bf28d1cda55999a4931e406922".into(),
+        buyer_stake_hash: Some("cba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad".into()),
+        royalty_pct: 0.05,
+        royalty_pkh: "04bdd97da6dfacd1fb4c5d5e1a14292e4ee0f2015a46f8543e552c49".into(),
+        royalty_stake_hash: Some("8eaef6e3337032021c887b180b74dfc0ff625d167df78b77e476b68d".into()),
+        royalty_is_key: true,
+        royalty_stake_is_key: true,
+        network: Network::Mainnet,
+    };
+
+    let params = TxBuildParams {
+        min_fee_coefficient: 44,
+        min_fee_constant: 155_381,
+        coins_per_utxo_byte: 4_310,
+        max_tx_size: 16_384,
+        max_value_size: 5_000,
+        price_mem: Some((577, 10_000)),
+        price_step: Some((721, 10_000_000)),
+        min_fee_ref_script_cost_per_byte: 15,
+        ref_script_size: 0,
+    };
+
+    let deps = TxDeps {
+        utxos: vec![funding],
+        params,
+        from_address,
+        network_id: 1,
+    };
+
+    let unsigned = build_wayup_collection_offers_tx(&deps, &[mk(10_000_000), mk(25_000_000)])
+        .expect("build wayup create");
+    let built = unsigned.staging.build_conway_raw().expect("build_conway_raw");
+
+    eprintln!("converged fee: {} lovelace", unsigned.fee);
+    println!("{}", hex::encode(&built.tx_bytes.0));
+}

--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -602,6 +602,272 @@ fn build_co_metadata_multi(
 }
 
 // ---------------------------------------------------------------------------
+// Wayup collection-offer CREATE
+// ---------------------------------------------------------------------------
+//
+// Wayup's offer format differs from jpg.store's in several load-bearing ways
+// (all verified against real create TXs 3938ca11… and 42f7a522…):
+//
+//   * **Datum field 0** is the bidder's *stake* credential (jpg uses the
+//     payment cred). It's also the cancel signer.
+//   * **Payout order** is [marketplace_fee, NFT_delivery, royalty]
+//     (jpg uses [marketplace, royalty, NFT]).
+//   * **Offer address** is a "frankenaddress": the Wayup payment *script*
+//     `27d46ecb…` + the *bidder's own* stake key. Each bidder's offers sit at
+//     a distinct address (their stake cred as the staking part).
+//   * **Marketplace fee** is 2% of the locked amount, min 1 ADA (jpg: 2.5%,
+//     min 2 ADA), paid to a fixed key/key address.
+//   * **Datum publication**: Wayup itself publishes the preimage in the create
+//     TX witness set (forcing a script-data hash). We instead attach the datum
+//     **inline** on the output (CIP-32) — identical spendability, fully
+//     self-contained, and avoids the witness-datum script-data-hash path
+//     (pallas-txbuilder can't produce the empty-language-view hash a
+//     datum-only TX needs). A `674` marker label mirrors Wayup's tag.
+//
+// The datum *value/address* encodings are identical to jpg's, so the payout
+// helpers (`build_ada_payout`, `build_nft_payout`, `build_datum_address`,
+// `build_ada_value`) are reused as-is.
+
+/// Wayup offer payment script hash (PlutusV2). Same script the cancel path
+/// references; offers lock at this script + the bidder's stake cred.
+const WAYUP_OFFER_SCRIPT_PAYMENT_HASH: &str =
+    "27d46ecbec94b052d8f875cf3beafd0e8ca40e8ad069f677e0a128ea";
+
+/// Wayup marketplace fee: 2%.
+const WAYUP_MARKETPLACE_FEE_BPS: u64 = 200;
+
+/// Wayup minimum marketplace fee (1 ADA).
+const WAYUP_MIN_MARKETPLACE_FEE: u64 = 1_000_000;
+
+/// Wayup marketplace fee payout address — payment key hash (key credential).
+const WAYUP_MARKETPLACE_FEE_PAY_HASH: &str =
+    "5f08a64f580e581735070e1b1d2ce29ae6942ab45ccff5a1747d2283";
+
+/// Wayup marketplace fee payout address — staking key hash (key credential).
+const WAYUP_MARKETPLACE_FEE_STAKE_HASH: &str =
+    "28f17fdd2d8b8f559ad61e899e31eae90b9e209cbedb1ee8a8c6c7d1";
+
+/// Calculate the Wayup marketplace fee (2% of the locked amount, min 1 ADA).
+pub fn calculate_wayup_marketplace_fee(total_lovelace: u64) -> u64 {
+    (total_lovelace * WAYUP_MARKETPLACE_FEE_BPS / 10_000).max(WAYUP_MIN_MARKETPLACE_FEE)
+}
+
+/// Seller-receives breakdown for a Wayup offer (mirrors
+/// [`calculate_seller_receives`] but with Wayup's marketplace fee schedule).
+pub fn calculate_wayup_seller_receives(total_lovelace: u64, royalty_pct: f64) -> FeeBreakdown {
+    let marketplace_fee = calculate_wayup_marketplace_fee(total_lovelace);
+    let creator_royalty = calculate_royalty(total_lovelace, royalty_pct);
+    let seller_receives = total_lovelace
+        .saturating_sub(marketplace_fee)
+        .saturating_sub(creator_royalty);
+    FeeBreakdown {
+        marketplace_fee,
+        creator_royalty,
+        seller_receives,
+    }
+}
+
+/// The Wayup offer "frankenaddress" for a bidder: the Wayup payment script
+/// `27d46ecb…` combined with the bidder's stake key. (We assume a key staking
+/// credential — the standard wallet shape and what every observed offer uses.)
+pub fn wayup_offer_address(
+    buyer_stake_hash: &str,
+    network: Network,
+) -> Result<Address, TxBuildError> {
+    let payment = hex_to_28_bytes(WAYUP_OFFER_SCRIPT_PAYMENT_HASH)?;
+    let stake = hex_to_28_bytes(buyer_stake_hash)?;
+    Ok(Address::Shelley(ShelleyAddress::new(
+        network,
+        ShelleyPaymentPart::Script(Hash::from(payment)),
+        ShelleyDelegationPart::Key(Hash::from(stake)),
+    )))
+}
+
+/// Build the Wayup offer datum:
+/// ```text
+/// Constructor(0) [
+///     bidder_stake_cred: ByteString(28),
+///     payouts: [
+///         Payout(marketplace_fee_addr, {ADA: marketplace_fee}),
+///         Payout(buyer_addr, {policy_id: (1, {})}),   // collection-wide NFT
+///         Payout(royalty_addr, {ADA: royalty}),
+///     ]
+/// ]
+/// ```
+fn build_wayup_co_datum(req: &CollectionOfferRequest) -> Result<PlutusData, TxBuildError> {
+    let buyer_stake = req.buyer_stake_hash.as_ref().ok_or_else(|| {
+        TxBuildError::BuildFailed(
+            "Wayup offer requires buyer_stake_hash (datum field 0 + offer address)".into(),
+        )
+    })?;
+    let buyer_stake_bytes = hex_to_28_bytes(buyer_stake)?;
+
+    let marketplace_fee = calculate_wayup_marketplace_fee(req.total_lovelace);
+    let royalty = calculate_royalty(req.total_lovelace, req.royalty_pct);
+
+    // Payout 0: marketplace fee → Wayup's fixed key/key address.
+    let marketplace_payout = build_ada_payout(
+        &hex_to_28_bytes(WAYUP_MARKETPLACE_FEE_PAY_HASH)?,
+        true, // key payment
+        Some(&hex_to_28_bytes(WAYUP_MARKETPLACE_FEE_STAKE_HASH)?),
+        true, // key staking
+        marketplace_fee,
+    );
+
+    // Payout 1: NFT delivery → buyer address (collection-wide, flag=1).
+    let nft_payout = build_nft_payout(
+        &hex_to_28_bytes(&req.buyer_pkh)?,
+        Some(&buyer_stake_bytes),
+        &req.policy_id,
+    )?;
+
+    // Payout 2: creator royalty → royalty address.
+    let royalty_payout = build_ada_payout(
+        &hex_to_28_bytes(&req.royalty_pkh)?,
+        req.royalty_is_key,
+        req.royalty_stake_hash
+            .as_ref()
+            .map(|h| hex_to_28_bytes(h))
+            .transpose()?
+            .as_ref(),
+        req.royalty_stake_is_key,
+        royalty,
+    );
+
+    Ok(constr_indef(
+        0,
+        vec![
+            bytes(buyer_stake_bytes.to_vec()),
+            PlutusData::Array(pallas_primitives::MaybeIndefArray::Indef(vec![
+                marketplace_payout,
+                nft_payout,
+                royalty_payout,
+            ])),
+        ],
+    ))
+}
+
+/// Build a Wayup collection offer: datum + frankenaddress + fee breakdown.
+pub fn build_wayup_collection_offer(
+    req: &CollectionOfferRequest,
+) -> Result<CollectionOfferResult, TxBuildError> {
+    let datum = build_wayup_co_datum(req)?;
+    let datum_bytes = encode_plutus_data(&datum)?;
+    let buyer_stake = req
+        .buyer_stake_hash
+        .as_ref()
+        .ok_or_else(|| TxBuildError::BuildFailed("Wayup offer requires buyer_stake_hash".into()))?;
+    let script_address = wayup_offer_address(buyer_stake, req.network)?;
+    let fee_breakdown = calculate_wayup_seller_receives(req.total_lovelace, req.royalty_pct);
+
+    Ok(CollectionOfferResult {
+        script_address,
+        total_lovelace: req.total_lovelace,
+        datum_bytes,
+        fee_breakdown,
+    })
+}
+
+/// TX metadata mirroring Wayup's marker label: `{ 674: { "msg": "Wayup Transaction" } }`.
+fn build_wayup_metadata() -> Result<Vec<u8>, TxBuildError> {
+    use pallas_codec::minicbor::Encoder;
+    let mut buf = Vec::new();
+    let mut enc = Encoder::new(&mut buf);
+    enc.map(1)
+        .and_then(|e| e.u64(674))
+        .and_then(|e| e.map(1))
+        .and_then(|e| e.str("msg"))
+        .and_then(|e| e.str("Wayup Transaction"))
+        .map_err(|e| TxBuildError::BuildFailed(format!("metadata encode: {e}")))?;
+    Ok(buf)
+}
+
+/// Build a TX that places one or more Wayup collection offers.
+///
+/// Each offer is an output at the bidder's frankenaddress carrying the locked
+/// ADA and the offer datum **inline**. All requests must share the same bidder
+/// (same frankenaddress); the worker batches by bidder so this holds. A `674`
+/// marker label is attached. The voluntary ~1 ADA Wayup "supporter" output is
+/// intentionally omitted (not required for a valid, acceptable offer).
+pub fn build_wayup_collection_offers_tx(
+    deps: &super::TxDeps,
+    requests: &[CollectionOfferRequest],
+) -> Result<super::UnsignedTx, TxBuildError> {
+    use crate::helpers::input::add_utxo_input;
+    use crate::helpers::output::{build_change_output, create_ada_output};
+    use crate::selection;
+    use pallas_txbuilder::StagingTransaction;
+
+    if requests.is_empty() {
+        return Err(TxBuildError::BuildFailed("No offer requests".into()));
+    }
+
+    let offers: Vec<CollectionOfferResult> = requests
+        .iter()
+        .map(build_wayup_collection_offer)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let total_lovelace: u64 = offers.iter().map(|o| o.total_lovelace).sum();
+    let estimated_fee = selection::estimate_simple_fee(&deps.params);
+
+    let selected_utxos = selection::select_utxos_for_amount(
+        &deps.utxos,
+        total_lovelace,
+        estimated_fee,
+        &deps.params,
+    )?;
+
+    let input_amount: u64 = selected_utxos.iter().map(|u| u.lovelace).sum();
+    let has_native_assets = selected_utxos.iter().any(|u| !u.assets.is_empty());
+    let from_address = deps.from_address.clone();
+    let network_id = deps.network_id;
+    let metadata_cbor = build_wayup_metadata()?;
+
+    super::converge_fee(
+        |fee| {
+            let change = input_amount
+                .checked_sub(total_lovelace)
+                .and_then(|v| v.checked_sub(fee))
+                .ok_or(TxBuildError::InsufficientFunds {
+                    needed: total_lovelace + fee,
+                    available: input_amount,
+                })?;
+
+            let mut tx = StagingTransaction::new();
+
+            for utxo in &selected_utxos {
+                tx = add_utxo_input(tx, utxo)?;
+            }
+
+            // One inline-datum output per offer, at the bidder frankenaddress.
+            for offer in &offers {
+                let script_output =
+                    create_ada_output(offer.script_address.clone(), offer.total_lovelace)
+                        .set_inline_datum(offer.datum_bytes.clone());
+                tx = tx.output(script_output);
+            }
+
+            tx = tx.add_auxiliary_data(metadata_cbor.clone());
+
+            if change > 0 {
+                if has_native_assets {
+                    let input_refs: Vec<&UtxoApi> = selected_utxos.iter().collect();
+                    let change_output =
+                        build_change_output(from_address.clone(), change, &input_refs, None)?;
+                    tx = tx.output(change_output);
+                } else {
+                    tx = tx.output(create_ada_output(from_address.clone(), change));
+                }
+            }
+
+            Ok(tx.fee(fee).network_id(network_id))
+        },
+        estimated_fee,
+        &deps.params,
+    )
+}
+
+// ---------------------------------------------------------------------------
 // Cancel CO TX builder
 // ---------------------------------------------------------------------------
 
@@ -609,9 +875,65 @@ fn build_co_metadata_multi(
 const SCRIPT_REF_TX: &str = "9a32459bd4ef6bbafdeb8cf3b909d0e3e2ec806e4cc6268529280b0fc1d06f5b";
 const SCRIPT_REF_INDEX: u64 = 0;
 
+/// Script reference UTxO for the Wayup CO contract (PlutusV2),
+/// script hash `27d46ecb…128ea`. Published + unspent at this ref;
+/// reused like jpg.store's. Verified on-chain 2026-05-24.
+const WAYUP_SCRIPT_REF_TX: &str =
+    "78f636d8da3d244b8c82271f6059e5951044920bf839a69c01abc4a7ecb44787";
+const WAYUP_SCRIPT_REF_INDEX: u64 = 0;
+
 /// Cancel redeemer: Constructor(1, []) = d87a80
 /// (Verified from on-chain cancel TX a79712998e7e1bcf...)
+/// Wayup uses the same empty-Constr-1 cancel redeemer (verified
+/// from cancel TX ec1019f4…).
 const CANCEL_REDEEMER_HEX: &str = "d87a80";
+
+/// Per-marketplace cancel parameters. jpg.store and Wayup cancel
+/// with the *same* redeemer (`d87a80`), PlutusV2 cost model, and
+/// datum-in-witness; they differ only in the on-chain
+/// script-reference UTxO. The owner signer is per-request
+/// ([`CancelOfferRequest::owner_pkh`]) — jpg.store passes the
+/// bidder's **payment** cred, Wayup the bidder's **stake** cred
+/// (the offer frankenaddress's staking part / cancel signer).
+///
+/// `preliminary_ex_*` is the per-redeemer ex-units the builder
+/// declares when a request carries no measured value — i.e. the
+/// fallback used when the Maestro `/evaluate` pre-pass is
+/// unavailable (it's flaky, and the worker silently keeps these
+/// placeholders on eval failure). It MUST cover the contract's
+/// worst-case real cost, or the submitted TX runs out of script
+/// budget and is rejected. jpg.store cancels run ~0.5–1.3M mem;
+/// Wayup runs ~2.4–3.15M mem, so the two need different fallbacks.
+#[derive(Debug, Clone)]
+pub struct CancelContract {
+    script_ref_tx: &'static str,
+    script_ref_index: u64,
+    preliminary_ex_mem: u64,
+    preliminary_ex_steps: u64,
+}
+
+impl CancelContract {
+    pub fn jpg_store() -> Self {
+        Self {
+            script_ref_tx: SCRIPT_REF_TX,
+            script_ref_index: SCRIPT_REF_INDEX,
+            preliminary_ex_mem: CANCEL_PRELIMINARY_EX_UNITS_MEM,
+            preliminary_ex_steps: CANCEL_PRELIMINARY_EX_UNITS_STEPS,
+        }
+    }
+
+    pub fn wayup() -> Self {
+        Self {
+            script_ref_tx: WAYUP_SCRIPT_REF_TX,
+            script_ref_index: WAYUP_SCRIPT_REF_INDEX,
+            // Worst observed 3.15M mem / 817M steps + ~15% margin.
+            // 2 × 3.6M = 7.2M mem < 16.5M tx budget, so a 2-cancel
+            // batch still fits without a measured pre-pass.
+            preliminary_ex_mem: 3_600_000,
+            preliminary_ex_steps: 950_000_000,
+        }
+    }
+}
 
 /// Preliminary ex-units placeholder for the redeemer in pass 1 of the
 /// build/evaluate cycle. Sized generously so Maestro never returns
@@ -806,6 +1128,18 @@ pub fn build_cancel_offers_tx(
     deps: &super::TxDeps,
     requests: &[CancelOfferRequest],
 ) -> Result<super::UnsignedTx, TxBuildError> {
+    build_cancel_offers_tx_with(deps, requests, &CancelContract::jpg_store())
+}
+
+/// As [`build_cancel_offers_tx`], but for an explicit marketplace
+/// contract (jpg.store or Wayup). The two differ only in the
+/// script-reference UTxO; the redeemer, cost model, datum-in-witness,
+/// and the owner-signer (per request) are identical.
+pub fn build_cancel_offers_tx_with(
+    deps: &super::TxDeps,
+    requests: &[CancelOfferRequest],
+    contract: &CancelContract,
+) -> Result<super::UnsignedTx, TxBuildError> {
     use crate::builder::cost_models::PLUTUS_V2_COST_MODEL;
     use crate::helpers::output::{build_change_output, create_ada_output};
     use crate::selection;
@@ -836,7 +1170,7 @@ pub fn build_cancel_offers_tx(
     let network_id = deps.network_id;
 
     // Parse common data
-    let script_ref_bytes: [u8; 32] = hex::decode(SCRIPT_REF_TX)
+    let script_ref_bytes: [u8; 32] = hex::decode(contract.script_ref_tx)
         .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?
         .try_into()
         .map_err(|_| TxBuildError::InvalidHex("script ref tx hash".into()))?;
@@ -846,7 +1180,7 @@ pub fn build_cancel_offers_tx(
     let redeemer_bytes = hex::decode(CANCEL_REDEEMER_HEX)
         .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
 
-    let ref_input = Input::new(Hash::from(script_ref_bytes), SCRIPT_REF_INDEX);
+    let ref_input = Input::new(Hash::from(script_ref_bytes), contract.script_ref_index);
 
     let fee_tx_bytes: [u8; 32] = hex::decode(&fee_utxo.tx_hash)
         .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?
@@ -877,7 +1211,27 @@ pub fn build_cancel_offers_tx(
 
     let total_input = total_co_lovelace + fee_utxo_lovelace;
 
-    super::converge_fee(
+    // Witness count: the wallet payment key always signs the fee/collateral
+    // input. The cancel also requires the bidder's disclosed signer. When
+    // that signer's key differs from the payer's payment cred (Wayup, whose
+    // signer is the bidder's *stake* key), it's a second, distinct witness;
+    // when it matches (jpg.store, signer == payer payment key), one witness
+    // covers both. Under-budgeting the extra witness triggers
+    // `FeeTooSmallUTxO`.
+    let num_witnesses = {
+        use pallas_addresses::Address;
+        let payer_is_signer = matches!(
+            &from_address,
+            Address::Shelley(s) if s.payment().as_hash().as_slice() == owner_pkh_bytes.as_slice()
+        );
+        if payer_is_signer {
+            1
+        } else {
+            2
+        }
+    };
+
+    super::converge_fee_with_witnesses(
         |fee| {
             let output_value =
                 total_input
@@ -889,14 +1243,24 @@ pub fn build_cancel_offers_tx(
 
             let mut tx = StagingTransaction::new();
 
-            // Add all script inputs with their redeemers
-            for input in &script_inputs {
+            // Add all script inputs with their redeemers. Each CO carries
+            // its OWN ex-units (`script_inputs[i]` ↔ `requests[i]`), so a
+            // mixed batch pays each offer's real cost rather than the
+            // batch-wide max. Falls back per-redeemer to the contract's
+            // worst-case ex-units when no measured value is present (Maestro
+            // `/evaluate` pre-pass skipped or failed), so the submitted TX
+            // stays within budget. pallas re-sorts inputs at build time and
+            // keys each redeemer to its input, so insertion order here is
+            // irrelevant to the on-chain redeemer pointers.
+            for (i, input) in script_inputs.iter().enumerate() {
                 tx = tx.input(input.clone()).add_spend_redeemer(
                     input.clone(),
                     redeemer_bytes.clone(),
                     Some(ExUnits {
-                        mem: requests[0].ex_units_mem.unwrap_or(CANCEL_PRELIMINARY_EX_UNITS_MEM),
-                        steps: requests[0].ex_units_steps.unwrap_or(CANCEL_PRELIMINARY_EX_UNITS_STEPS),
+                        mem: requests[i].ex_units_mem.unwrap_or(contract.preliminary_ex_mem),
+                        steps: requests[i]
+                            .ex_units_steps
+                            .unwrap_or(contract.preliminary_ex_steps),
                     }),
                 );
             }
@@ -950,6 +1314,7 @@ pub fn build_cancel_offers_tx(
         },
         estimated_fee,
         &deps.params,
+        num_witnesses,
     )
 }
 
@@ -978,6 +1343,65 @@ mod tests {
         // Below threshold: fee should be minimum 2 ADA
         assert_eq!(calculate_marketplace_fee(5_000_000), 2_000_000);
         assert_eq!(calculate_marketplace_fee(10_000_000), 2_000_000);
+    }
+
+    #[test]
+    fn test_wayup_marketplace_fee() {
+        // 2% of the locked amount, min 1 ADA. Verified against real creates:
+        // 150 ADA → 3 ADA; 6 ADA → 1 ADA (min); 120 ADA → 2.4 ADA.
+        assert_eq!(calculate_wayup_marketplace_fee(150_000_000), 3_000_000);
+        assert_eq!(calculate_wayup_marketplace_fee(6_000_000), 1_000_000);
+        assert_eq!(calculate_wayup_marketplace_fee(120_000_000), 2_400_000);
+    }
+
+    /// Byte-exact reproduction of a real Wayup collection-offer datum
+    /// (create TX 3938ca11…, output #1, 6 ADA collection-wide offer). If this
+    /// matches, our datum is indistinguishable from one Wayup itself produced —
+    /// same hash, so accepters/indexers treat it identically.
+    #[test]
+    fn test_wayup_datum_byte_exact() {
+        let req = CollectionOfferRequest {
+            policy_id: "a316bcf768f0309be743b4b7d067f3348017bf0f00f6a29562aebda2".into(),
+            total_lovelace: 6_000_000,
+            buyer_pkh: "4a00e5040c2d7e201a9c20744ace64bf28d1cda55999a4931e406922".into(),
+            buyer_stake_hash: Some(
+                "cba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad".into(),
+            ),
+            // 0% → royalty floors to the 1 ADA minimum, matching the on-chain datum.
+            royalty_pct: 0.0,
+            royalty_pkh: "04bdd97da6dfacd1fb4c5d5e1a14292e4ee0f2015a46f8543e552c49".into(),
+            royalty_stake_hash: Some(
+                "8eaef6e3337032021c887b180b74dfc0ff625d167df78b77e476b68d".into(),
+            ),
+            royalty_is_key: true,
+            royalty_stake_is_key: true,
+            network: Network::Mainnet,
+        };
+        let datum = build_wayup_co_datum(&req).unwrap();
+        let bytes = encode_plutus_data(&datum).unwrap();
+        let expected = "d8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad9fd8799fd8799fd8799f581c5f08a64f580e581735070e1b1d2ce29ae6942ab45ccff5a1747d2283ffd8799fd8799fd8799f581c28f17fdd2d8b8f559ad61e899e31eae90b9e209cbedb1ee8a8c6c7d1ffffffffa140d8799f00a1401a000f4240ffffd8799fd8799fd8799f581c4a00e5040c2d7e201a9c20744ace64bf28d1cda55999a4931e406922ffd8799fd8799fd8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82adffffffffa1581ca316bcf768f0309be743b4b7d067f3348017bf0f00f6a29562aebda2d8799f01a0ffffd8799fd8799fd8799f581c04bdd97da6dfacd1fb4c5d5e1a14292e4ee0f2015a46f8543e552c49ffd8799fd8799fd8799f581c8eaef6e3337032021c887b180b74dfc0ff625d167df78b77e476b68dffffffffa140d8799f00a1401a000f4240ffffffff";
+        assert_eq!(hex::encode(&bytes), expected, "Wayup datum must be byte-exact to the on-chain offer");
+    }
+
+    /// The frankenaddress = Wayup payment script + bidder stake key, header 0x11.
+    #[test]
+    fn test_wayup_offer_address() {
+        let addr = wayup_offer_address(
+            "cba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad",
+            Network::Mainnet,
+        )
+        .unwrap();
+        // First byte of the address bytes is the header (0x11 = script pay + key stake, mainnet).
+        let bytes = addr.to_vec();
+        assert_eq!(bytes[0], 0x11);
+        assert_eq!(
+            hex::encode(&bytes[1..29]),
+            "27d46ecbec94b052d8f875cf3beafd0e8ca40e8ad069f677e0a128ea"
+        );
+        assert_eq!(
+            hex::encode(&bytes[29..57]),
+            "cba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad"
+        );
     }
 
     #[test]

--- a/cardano-tx/src/builder/mod.rs
+++ b/cardano-tx/src/builder/mod.rs
@@ -66,13 +66,27 @@ pub fn converge_fee(
     initial_estimate: u64,
     params: &TxBuildParams,
 ) -> Result<UnsignedTx, TxBuildError> {
+    converge_fee_with_witnesses(build_fn, initial_estimate, params, 1)
+}
+
+/// [`converge_fee`] that sizes the fee for `num_witnesses` vkey signatures.
+///
+/// Use this when the transaction needs a required-signer whose key differs
+/// from the wallet payer's (e.g. a Wayup cancel, authorised by the bidder's
+/// stake key). See [`crate::fee::calculate_fee_with_witnesses`].
+pub fn converge_fee_with_witnesses(
+    build_fn: impl Fn(u64) -> Result<StagingTransaction, TxBuildError>,
+    initial_estimate: u64,
+    params: &TxBuildParams,
+    num_witnesses: u32,
+) -> Result<UnsignedTx, TxBuildError> {
     // Round 1: build with rough estimate, calculate real fee
     let preliminary_tx = build_fn(initial_estimate)?;
-    let fee_round1 = crate::fee::calculate_fee(&preliminary_tx, params);
+    let fee_round1 = crate::fee::calculate_fee_with_witnesses(&preliminary_tx, params, num_witnesses);
 
     // Round 2: rebuild with round-1 fee, recalculate
     let tx_round2 = build_fn(fee_round1)?;
-    let final_fee = crate::fee::calculate_fee(&tx_round2, params);
+    let final_fee = crate::fee::calculate_fee_with_witnesses(&tx_round2, params, num_witnesses);
 
     // Final build with converged fee
     let staging = build_fn(final_fee)?;

--- a/cardano-tx/src/fee.rs
+++ b/cardano-tx/src/fee.rs
@@ -127,25 +127,55 @@ pub fn estimate_tx_size(tx: &StagingTransaction, num_witnesses: u32) -> u64 {
 /// Plutus script execution cost component derived from all redeemers in the TX:
 ///   `fee = base_fee + Σ(mem × price_mem_num / price_mem_den + steps × price_step_num / price_step_den)`
 pub fn calculate_fee(tx: &StagingTransaction, params: &crate::params::TxBuildParams) -> u64 {
+    calculate_fee_with_witnesses(tx, params, 1)
+}
+
+/// Like [`calculate_fee`] but sizes the transaction for `num_witnesses`
+/// distinct vkey signatures rather than the default single witness.
+///
+/// The default ([`calculate_fee`]) assumes one witness — correct when the
+/// wallet's payment key both pays the fee and authorises every script
+/// input. Transactions that require an additional required-signer whose
+/// key differs from the payer's must budget the extra witness, or the node
+/// rejects them with `FeeTooSmallUTxO`. A Wayup collection-offer cancel is
+/// the canonical case: it's authorised by the bidder's *stake* key, which
+/// is distinct from the wallet payment key that signs the fee input — two
+/// witnesses. (jpg.store authorises with the bidder's payment key, which
+/// *is* the payer, so one witness suffices.)
+pub fn calculate_fee_with_witnesses(
+    tx: &StagingTransaction,
+    params: &crate::params::TxBuildParams,
+    num_witnesses: u32,
+) -> u64 {
     use pallas_txbuilder::BuildConway;
+
+    let witnesses = num_witnesses.max(1);
 
     let base_fee = {
         let built = match tx.clone().build_conway_raw() {
             Ok(b) => b,
             Err(_) => {
-                let estimated_size = estimate_tx_size(tx, 1);
+                let estimated_size = estimate_tx_size(tx, witnesses);
                 return estimated_size * params.min_fee_coefficient + params.min_fee_constant;
             }
         };
 
-        let dummy_secret = pallas_crypto::key::ed25519::SecretKey::from([0u8; 32]);
-        let signed = match built.sign(&dummy_secret) {
-            Ok(s) => s,
-            Err(_) => {
-                let estimated_size = estimate_tx_size(tx, 1);
-                return estimated_size * params.min_fee_coefficient + params.min_fee_constant;
-            }
-        };
+        // Sign with `witnesses` distinct dummy keys so the measured size
+        // includes every vkey witness the node will require. Distinct seeds
+        // yield distinct pubkeys, so no witness is deduplicated away.
+        let mut signed = built;
+        for i in 0..witnesses {
+            let mut seed = [0u8; 32];
+            seed[..4].copy_from_slice(&i.to_le_bytes());
+            let dummy_secret = pallas_crypto::key::ed25519::SecretKey::from(seed);
+            signed = match signed.sign(&dummy_secret) {
+                Ok(s) => s,
+                Err(_) => {
+                    let estimated_size = estimate_tx_size(tx, witnesses);
+                    return estimated_size * params.min_fee_coefficient + params.min_fee_constant;
+                }
+            };
+        }
 
         let tx_size = signed.tx_bytes.0.len() as u64;
         tx_size * params.min_fee_coefficient + params.min_fee_constant
@@ -230,4 +260,76 @@ pub fn calculate_tx_fee(
     // Exact fee from exact signed tx size
     let tx_size = signed.tx_bytes.0.len() as u64;
     tx_size * protocol_params.min_fee_coefficient + protocol_params.min_fee_constant.ada.lovelace
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::params::TxBuildParams;
+    use pallas_addresses::Address;
+    use pallas_crypto::hash::Hash;
+    use pallas_txbuilder::{Input, StagingTransaction};
+
+    fn params() -> TxBuildParams {
+        TxBuildParams {
+            min_fee_coefficient: 44,
+            min_fee_constant: 155_381,
+            ..Default::default()
+        }
+    }
+
+    fn minimal_tx(fee: u64) -> StagingTransaction {
+        let addr = Address::from_bech32(
+            "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
+        )
+        .unwrap();
+        StagingTransaction::new()
+            .input(Input::new(Hash::from([0u8; 32]), 0))
+            .output(crate::helpers::output::create_ada_output(addr, 1_000_000))
+            .fee(fee)
+            .network_id(0)
+    }
+
+    /// Each additional witness is one VKeyWitness in the witness set:
+    /// vkey (32 + 2 CBOR) + signature (64 + 2 CBOR) + array element ≈ 101
+    /// bytes. The fee must grow by `~101 × min_fee_coefficient` per witness,
+    /// or a Wayup cancel (whose stake-key required-signer is a *second*
+    /// distinct witness) gets rejected with `FeeTooSmallUTxO`.
+    #[test]
+    fn extra_witness_adds_one_vkey_worth_of_fee() {
+        let p = params();
+        let tx = minimal_tx(200_000);
+        let one = calculate_fee_with_witnesses(&tx, &p, 1);
+        let two = calculate_fee_with_witnesses(&tx, &p, 2);
+        let delta = two - one;
+        // ~101 bytes × 44 = ~4444. Allow CBOR-encoding slack.
+        assert!(
+            (4_000..=5_000).contains(&delta),
+            "one extra witness should add ~one vkey of fee, got delta {delta}"
+        );
+    }
+
+    /// `calculate_fee` is the single-witness default — it must equal
+    /// `calculate_fee_with_witnesses(.., 1)`.
+    #[test]
+    fn default_fee_is_single_witness() {
+        let p = params();
+        let tx = minimal_tx(200_000);
+        assert_eq!(
+            calculate_fee(&tx, &p),
+            calculate_fee_with_witnesses(&tx, &p, 1)
+        );
+    }
+
+    /// Zero witnesses must floor to one — a transaction always needs at
+    /// least the payer's signature.
+    #[test]
+    fn zero_witnesses_floors_to_one() {
+        let p = params();
+        let tx = minimal_tx(200_000);
+        assert_eq!(
+            calculate_fee_with_witnesses(&tx, &p, 0),
+            calculate_fee_with_witnesses(&tx, &p, 1)
+        );
+    }
 }


### PR DESCRIPTION
Extends the collection-offer builder to support the Wayup marketplace (create + cancel) alongside jpg.store, and fixes two fee-calculation gaps that surfaced building real Wayup cancels.

## Wayup offer builders

- **Create** (`build_wayup_collection_offers_tx`): outputs at the bidder "frankenaddress" (Wayup payment script + bidder stake key) with the offer datum **inline** (CIP-32) and a `674` marker label. Datum field 0 = bidder stake cred; payout order `[marketplace, NFT, royalty]`; marketplace fee 2% / min 1 ADA. The datum encoder reuses the jpg payout/address helpers and is **byte-exact** to a real on-chain Wayup offer (test asserts reproduction of create `3938ca11…`'s datum, hash `0d46ce59…`).
- **Cancel** (`CancelContract` + `build_cancel_offers_tx_with`): provider-aware script reference + fallback ex-units; jpg and Wayup share the redeemer/cost-model and differ only in the script-ref UTxO and owner signer (jpg payment cred, Wayup stake cred).

## Fee fixes

- **Witness-aware fees** (`calculate_fee_with_witnesses` / `converge_fee_with_witnesses`): a Wayup cancel needs two distinct signatures (wallet payment key + bidder stake key), where jpg needs one. The cancel builder now budgets the extra witness when the disclosed signer differs from the payer — fixes `FeeTooSmallUTxO`.
- **Per-redeemer ex-units**: `build_cancel_offers_tx_with` applies each request's own ex-units (was `requests[0]` for all), so mixed cancel batches pay each offer's real cost instead of the batch-wide max.

## Tests

Byte-exact Wayup datum + frankenaddress tests, witness-fee regression tests (one extra witness ≈ one vkey of fee), per-redeemer behavior. Full suite green (179). Eval harnesses `examples/wayup_{create,cancel}_eval.rs`.