### PR TITLE
feature: Minting-engine support primitives + portal widget surface

### DIFF
--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -251,12 +251,19 @@ pub struct MintRecipientEntry {
 /// - `metadata` — optional CIP-25 JSON (`"721"` …) covering all assets under the policy.
 /// - `inputs` — explicit funding UTxOs to spend (e.g. a caller-managed pool UTxO for parallel
 ///   submission). `None` falls back to a single pure-ADA selection from `deps.utxos`.
+/// - `extra_self_outputs` — additional pure-ADA outputs paid to `deps.from_address`, in
+///   lovelace. Each becomes its own UTxO. The intended use is maintaining a fuel-UTxO pool
+///   inside the mint tx: the caller computes how many slots short of target the wallet is
+///   and passes that many lovelace amounts here. Drawn from the change side (input − recipient
+///   outputs − fee − extras = remainder change). Each amount must be ≥ the pure-ADA min UTxO;
+///   the builder rejects undersized entries before signing.
 pub fn build_cip25_mint_multi(
     deps: &TxDeps,
     policy: &MintingPolicy,
     mints: &[MintRecipientEntry],
     metadata: Option<&serde_json::Value>,
     inputs: Option<&[UtxoApi]>,
+    extra_self_outputs: Option<&[u64]>,
 ) -> Result<UnsignedTx, TxBuildError> {
     use pallas_primitives::Fragment;
 
@@ -331,12 +338,29 @@ pub fn build_cip25_mint_multi(
         None
     };
 
-    // Fee from real sizes: base + script + aux + per-output + per-mint + change output.
+    // Total extra-self-output lovelace and count (used by fee + needed + change calcs below).
+    let extras: &[u64] = extra_self_outputs.unwrap_or(&[]);
+    let total_extras_lovelace: u64 = extras.iter().sum();
+
+    // Pure-ADA min UTxO under current params. Sanity-check each extra rather than letting
+    // the ledger reject after a fee has been paid.
+    let min_pure_change = 228 * deps.params.coins_per_utxo_byte;
+    for (i, &amount) in extras.iter().enumerate() {
+        if amount < min_pure_change {
+            return Err(TxBuildError::BuildFailed(format!(
+                "extra_self_outputs[{i}] = {amount} lovelace < min_pure_utxo {min_pure_change}"
+            )));
+        }
+    }
+
+    // Fee from real sizes: base + script + aux + per-output + per-mint + extra outputs +
+    // change output.
     let estimated_tx_size = 300usize
         + script_bytes.len()
         + metadata_bytes.as_ref().map_or(0, |b| b.len())
         + groups.len() * 70
         + mints.len() * 50
+        + extras.len() * 70
         + 70;
     let base_fee =
         deps.params.min_fee_coefficient * estimated_tx_size as u64 + deps.params.min_fee_constant;
@@ -360,7 +384,7 @@ pub fn build_cip25_mint_multi(
     };
 
     let total_input_lovelace: u64 = chosen.iter().map(|u| u.lovelace).sum();
-    let total_needed = total_output_min_ada + fee;
+    let total_needed = total_output_min_ada + total_extras_lovelace + fee;
     if total_input_lovelace < total_needed {
         return Err(TxBuildError::InsufficientFunds {
             needed: total_needed,
@@ -413,19 +437,25 @@ pub fn build_cip25_mint_multi(
         tx = tx.output(output);
     }
 
+    // Extra self-outputs — pure-ADA UTxOs back to `deps.from_address`, one per requested
+    // pool slot. Sized + sanity-checked above; drawn from input change.
+    for &amount in extras {
+        tx = tx.output(create_ada_output(deps.from_address.clone(), amount));
+    }
+
     // Metadata.
     if let Some(aux) = metadata_bytes {
         tx = tx.add_auxiliary_data(aux);
     }
 
-    // Change. Inputs already cover `total_needed`.
-    let min_pure_change = 228 * deps.params.coins_per_utxo_byte;
-    let change_lovelace = total_input_lovelace - total_output_min_ada - fee;
+    // Change. Inputs already cover `total_needed` (recipient outputs + extras + fee).
+    let change_lovelace =
+        total_input_lovelace - total_output_min_ada - total_extras_lovelace - fee;
     if has_remaining_assets {
         // Must emit a change output to carry the inputs' native assets.
         if change_lovelace < min_pure_change {
             return Err(TxBuildError::InsufficientFunds {
-                needed: total_output_min_ada + fee + min_pure_change,
+                needed: total_output_min_ada + total_extras_lovelace + fee + min_pure_change,
                 available: total_input_lovelace,
             });
         }
@@ -923,7 +953,7 @@ mod tests {
                 recipient: test_recipient(2),
             },
         ];
-        let result = build_cip25_mint_multi(&deps_with(20_000_000), &test_policy(), &mints, None, None);
+        let result = build_cip25_mint_multi(&deps_with(20_000_000), &test_policy(), &mints, None, None, None);
         assert!(result.is_ok(), "multi-recipient mint failed: {result:?}");
         assert!(result.unwrap().fee > 0);
     }
@@ -955,6 +985,7 @@ mod tests {
             &mints,
             None,
             Some(std::slice::from_ref(&input)),
+            None,
         );
         assert!(result.is_ok(), "explicit-inputs mint failed: {result:?}");
     }
@@ -966,11 +997,58 @@ mod tests {
             quantity: 0,
             recipient: test_recipient(1),
         }];
-        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &mints, None, None).is_err());
+        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &mints, None, None, None).is_err());
     }
 
     #[test]
     fn test_build_cip25_mint_multi_empty_errors() {
-        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &[], None, None).is_err());
+        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &[], None, None, None).is_err());
+    }
+
+    /// `extra_self_outputs` adds pool-slot UTxOs back to `from_address` and the change
+    /// covers the leftover. With a 100 ADA input, a single 1 ADA recipient + ~0.5 ADA fee
+    /// + 4 × 10 ADA pool slots leaves ~58 ADA remainder change. Builder should succeed
+    /// and the resulting tx fee should be sized to include the extra outputs.
+    #[test]
+    fn test_build_cip25_mint_multi_with_extra_self_outputs() {
+        let mints = vec![MintRecipientEntry {
+            asset_name: "Pool001".to_string(),
+            quantity: 1,
+            recipient: test_recipient(7),
+        }];
+        let extras = [10_000_000u64; 4]; // 4 pool slots × 10 ADA
+        let result = build_cip25_mint_multi(
+            &deps_with(100_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            Some(&extras),
+        );
+        assert!(
+            result.is_ok(),
+            "mint with extra_self_outputs failed: {result:?}"
+        );
+    }
+
+    /// Pool slots below `min_pure_change` (under typical params ~1.1 ADA) must be rejected
+    /// before signing — the ledger would reject the tx and burn the fee otherwise.
+    #[test]
+    fn test_build_cip25_mint_multi_rejects_undersized_extras() {
+        let mints = vec![MintRecipientEntry {
+            asset_name: "TinyExtra".to_string(),
+            quantity: 1,
+            recipient: test_recipient(7),
+        }];
+        let extras = [500_000u64]; // 0.5 ADA — below min_pure_change
+        let result = build_cip25_mint_multi(
+            &deps_with(50_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            Some(&extras),
+        );
+        assert!(matches!(result, Err(TxBuildError::BuildFailed(_))));
     }
 }

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -290,7 +290,9 @@ pub fn build_cip25_mint_multi(
     let policy_id_bytes = decode_policy_id(&policy_id_hex)?;
 
     // Group mints by recipient (preserve first-seen order) → one output per recipient.
-    let mut groups: Vec<(String, Address, Vec<(String, u64)>)> = Vec::new();
+    // Tuple is `(recipient_bech32, recipient_address, Vec<(asset_name, quantity)>)`.
+    type RecipientGroup = (String, Address, Vec<(String, u64)>);
+    let mut groups: Vec<RecipientGroup> = Vec::new();
     for m in mints {
         let key = m
             .recipient
@@ -1006,8 +1008,8 @@ mod tests {
     }
 
     /// `extra_self_outputs` adds pool-slot UTxOs back to `from_address` and the change
-    /// covers the leftover. With a 100 ADA input, a single 1 ADA recipient + ~0.5 ADA fee
-    /// + 4 × 10 ADA pool slots leaves ~58 ADA remainder change. Builder should succeed
+    /// covers the leftover. With a 100 ADA input, a 1 ADA recipient, ~0.5 ADA fee,
+    /// and 4 × 10 ADA pool slots, ~58 ADA remains as change. Builder should succeed
     /// and the resulting tx fee should be sized to include the extra outputs.
     #[test]
     fn test_build_cip25_mint_multi_with_extra_self_outputs() {

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -148,6 +148,18 @@ pub fn build_cip25_mint(
         .network_id(network_id)
         .script(pallas_txbuilder::ScriptKind::Native, script_bytes);
 
+    // Apply the validity interval required by the policy's time locks. Without this a
+    // TimeLocked/TimeBounded/MultiSigTimeLocked mint is rejected on-chain because the
+    // native script's InvalidBefore/InvalidHereafter clauses have nothing to validate
+    // against. Non-time-locked policies return (None, None) and leave the tx unbounded.
+    let (valid_from_slot, invalid_hereafter_slot) = policy.validity_bounds();
+    if let Some(slot) = valid_from_slot {
+        tx = tx.valid_from_slot(slot);
+    }
+    if let Some(slot) = invalid_hereafter_slot {
+        tx = tx.invalid_from_slot(slot);
+    }
+
     // Add mint operations
     for (asset_name, quantity) in &assets_owned {
         let asset_name_bytes = decode_asset_name(asset_name);
@@ -213,6 +225,227 @@ pub fn build_burn(
         .collect();
 
     build_cip25_mint(deps, policy, &burn_assets, None, None)
+}
+
+/// A single NFT/RFT to mint and the address that receives it.
+#[derive(Debug, Clone)]
+pub struct MintRecipientEntry {
+    /// Asset name (display string or hex — normalized internally).
+    pub asset_name: String,
+    /// Quantity to mint (must be > 0; burns have no recipient — use `build_burn`).
+    pub quantity: u64,
+    /// Address that receives this asset.
+    pub recipient: Address,
+}
+
+/// Build a CIP-25 mint that fans out to many recipients in a single transaction.
+///
+/// Mints are grouped into one output per recipient, all under one native-script policy and
+/// one CIP-25 metadata blob. This is the batched-mint primitive behind the vending-machine
+/// batcher: many orders fulfilled per tx, bounded by tx size.
+///
+/// Fee and min-ADA are sized from the *actual* serialized metadata plus per-output/per-mint
+/// counts, so it stays correct for both lean (CID-pointer) and heavy (on-chain code) metadata.
+///
+/// - `mints` — per-asset `(name, quantity > 0, recipient)`; must be non-empty.
+/// - `metadata` — optional CIP-25 JSON (`"721"` …) covering all assets under the policy.
+/// - `inputs` — explicit funding UTxOs to spend (e.g. a caller-managed pool UTxO for parallel
+///   submission). `None` falls back to a single pure-ADA selection from `deps.utxos`.
+pub fn build_cip25_mint_multi(
+    deps: &TxDeps,
+    policy: &MintingPolicy,
+    mints: &[MintRecipientEntry],
+    metadata: Option<&serde_json::Value>,
+    inputs: Option<&[UtxoApi]>,
+) -> Result<UnsignedTx, TxBuildError> {
+    use pallas_primitives::Fragment;
+
+    if mints.is_empty() {
+        return Err(TxBuildError::BuildFailed("no mints provided".to_string()));
+    }
+    if let Some(bad) = mints.iter().find(|m| m.quantity == 0) {
+        return Err(TxBuildError::BuildFailed(format!(
+            "mint quantity must be > 0 for asset '{}'",
+            bad.asset_name
+        )));
+    }
+
+    let policy_id_hex = policy
+        .policy_id_hex()
+        .map_err(|e| TxBuildError::BuildFailed(format!("Failed to derive policy ID: {e}")))?;
+    let native_script = policy
+        .to_native_script()
+        .map_err(|e| TxBuildError::BuildFailed(format!("Failed to create native script: {e}")))?;
+    let script_bytes = native_script
+        .encode_fragment()
+        .map_err(|e| TxBuildError::BuildFailed(format!("Failed to encode script: {e}")))?;
+    verify_policy_id(&policy_id_hex, &script_bytes)?;
+    let policy_id_bytes = decode_policy_id(&policy_id_hex)?;
+
+    // Group mints by recipient (preserve first-seen order) → one output per recipient.
+    let mut groups: Vec<(String, Address, Vec<(String, u64)>)> = Vec::new();
+    for m in mints {
+        let key = m
+            .recipient
+            .to_bech32()
+            .map_err(|e| TxBuildError::BuildFailed(format!("invalid recipient address: {e}")))?;
+        if let Some(g) = groups.iter_mut().find(|(k, _, _)| *k == key) {
+            g.2.push((m.asset_name.clone(), m.quantity));
+        } else {
+            groups.push((key, m.recipient.clone(), vec![(m.asset_name.clone(), m.quantity)]));
+        }
+    }
+
+    let maestro_params = super::send::to_maestro_params(&deps.params);
+
+    // Per-recipient min-ADA (summed across outputs).
+    let mut per_group_min_ada: Vec<u64> = Vec::with_capacity(groups.len());
+    for (_key, _addr, items) in &groups {
+        let asset_ids: Vec<AssetId> = items
+            .iter()
+            .filter_map(|(name, _)| {
+                let hex = normalize_asset_name_to_hex(name);
+                format!("{policy_id_hex}.{hex}").parse().ok()
+            })
+            .collect();
+        per_group_min_ada.push(crate::calculate_min_ada_with_params(
+            &maestro_params,
+            &asset_ids,
+            &crate::OutputParams { datum_size: None },
+        ));
+    }
+    let total_output_min_ada: u64 = per_group_min_ada.iter().sum();
+
+    // Metadata aux bytes — measured so the fee is sized from the real metadata weight.
+    let assets_i64: Vec<(String, i64)> = mints
+        .iter()
+        .map(|m| (m.asset_name.clone(), m.quantity as i64))
+        .collect();
+    let metadata_bytes = if let Some(v) = metadata {
+        let final_metadata = prepare_cip25_metadata(v, &policy_id_hex, &assets_i64);
+        Some(
+            crate::metadata::cip25::build_cip25_auxiliary_data(&final_metadata)
+                .map_err(|e| TxBuildError::BuildFailed(format!("Metadata encoding failed: {e}")))?,
+        )
+    } else {
+        None
+    };
+
+    // Fee from real sizes: base + script + aux + per-output + per-mint + change output.
+    let estimated_tx_size = 300usize
+        + script_bytes.len()
+        + metadata_bytes.as_ref().map_or(0, |b| b.len())
+        + groups.len() * 70
+        + mints.len() * 50
+        + 70;
+    let base_fee =
+        deps.params.min_fee_coefficient * estimated_tx_size as u64 + deps.params.min_fee_constant;
+    let mut fee = base_fee + base_fee / 10;
+
+    // Inputs: explicit (caller-managed pool UTxO) or a single pure-ADA selection.
+    let chosen: Vec<UtxoApi> = match inputs {
+        Some(utxos) => {
+            if utxos.is_empty() {
+                return Err(TxBuildError::BuildFailed(
+                    "explicit inputs were empty".to_string(),
+                ));
+            }
+            utxos.to_vec()
+        }
+        None => {
+            let (selected, _total, _assets) =
+                select_utxos_for_mint(total_output_min_ada, fee, deps)?;
+            selected.into_iter().cloned().collect()
+        }
+    };
+
+    let total_input_lovelace: u64 = chosen.iter().map(|u| u.lovelace).sum();
+    let total_needed = total_output_min_ada + fee;
+    if total_input_lovelace < total_needed {
+        return Err(TxBuildError::InsufficientFunds {
+            needed: total_needed,
+            available: total_input_lovelace,
+        });
+    }
+
+    // Native assets carried by the inputs pass straight through to change (mint-only).
+    let mut input_native_assets: HashMap<(String, String), u64> = HashMap::new();
+    for u in &chosen {
+        accumulate_native_assets(u, &mut input_native_assets);
+    }
+    let has_remaining_assets = !input_native_assets.is_empty();
+
+    // Assemble the transaction.
+    let refs: Vec<&UtxoApi> = chosen.iter().collect();
+    let mut tx = crate::helpers::input::add_utxo_inputs(StagingTransaction::new(), &refs)?;
+    tx = tx
+        .network_id(deps.network_id)
+        .script(pallas_txbuilder::ScriptKind::Native, script_bytes);
+
+    // Validity interval from the policy's time locks (same as the single-recipient path).
+    let (valid_from_slot, invalid_hereafter_slot) = policy.validity_bounds();
+    if let Some(slot) = valid_from_slot {
+        tx = tx.valid_from_slot(slot);
+    }
+    if let Some(slot) = invalid_hereafter_slot {
+        tx = tx.invalid_from_slot(slot);
+    }
+
+    // Mint entries.
+    for m in mints {
+        let name_bytes = decode_asset_name(&m.asset_name);
+        tx = tx
+            .mint_asset(Hash::from(policy_id_bytes), name_bytes, m.quantity as i64)
+            .map_err(|e| TxBuildError::BuildFailed(format!("Failed to add mint: {e}")))?;
+    }
+
+    // One output per recipient.
+    for ((_key, addr, items), min_ada) in groups.iter().zip(per_group_min_ada.iter()) {
+        let mut output = create_ada_output(addr.clone(), *min_ada);
+        for (name, qty) in items {
+            let name_bytes = decode_asset_name(name);
+            output = output
+                .add_asset(Hash::from(policy_id_bytes), name_bytes, *qty)
+                .map_err(|e| {
+                    TxBuildError::BuildFailed(format!("Failed to add asset to output: {e}"))
+                })?;
+        }
+        tx = tx.output(output);
+    }
+
+    // Metadata.
+    if let Some(aux) = metadata_bytes {
+        tx = tx.add_auxiliary_data(aux);
+    }
+
+    // Change. Inputs already cover `total_needed`.
+    let min_pure_change = 228 * deps.params.coins_per_utxo_byte;
+    let change_lovelace = total_input_lovelace - total_output_min_ada - fee;
+    if has_remaining_assets {
+        // Must emit a change output to carry the inputs' native assets.
+        if change_lovelace < min_pure_change {
+            return Err(TxBuildError::InsufficientFunds {
+                needed: total_output_min_ada + fee + min_pure_change,
+                available: total_input_lovelace,
+            });
+        }
+        let mut change_output = create_ada_output(deps.from_address.clone(), change_lovelace);
+        let asset_map: HashMap<AssetId, u64> = input_native_assets
+            .into_iter()
+            .filter_map(|((p, n), q)| AssetId::new(p, n).ok().map(|id| (id, q)))
+            .collect();
+        change_output = add_assets_from_map(change_output, &asset_map)?;
+        tx = tx.output(change_output);
+    } else if change_lovelace >= min_pure_change {
+        tx = tx.output(create_ada_output(deps.from_address.clone(), change_lovelace));
+    } else {
+        // Dust below a viable change output → fold into the fee to keep the tx balanced.
+        fee += change_lovelace;
+    }
+
+    tx = tx.fee(fee);
+
+    Ok(UnsignedTx { staging: tx, fee })
 }
 
 // ============================================================================
@@ -611,5 +844,133 @@ mod tests {
 
         let unsigned = result.unwrap();
         assert!(unsigned.fee > 0);
+    }
+
+    #[test]
+    fn test_build_cip25_mint_time_locked_applies_validity() {
+        // A TimeLocked policy must build without error: the builder is responsible for
+        // applying the validity interval the native script requires. Before the fix this
+        // path produced a tx the ledger would reject (no validity bound for the time lock).
+        let policy = MintingPolicy::TimeLocked {
+            key_hash: "9ad4da1c6da54e41ecbab2758323f1abcc7b6e6643f5b930065fcb29".to_string(),
+            before_slot: 90_000_000,
+        };
+
+        let deps = super::super::TxDeps {
+            utxos: vec![UtxoApi {
+                tx_hash: "a".repeat(64),
+                output_index: 0,
+                lovelace: 10_000_000,
+                assets: vec![],
+                tags: vec![],
+            }],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+
+        let assets = vec![("TimeLockedNFT".to_string(), 1i64)];
+        let result = build_cip25_mint(&deps, &policy, &assets, None, None);
+        assert!(result.is_ok(), "time-locked mint failed to build: {result:?}");
+
+        // Sanity: the policy reports the upper bound the builder must apply.
+        assert_eq!(policy.validity_bounds(), (None, Some(90_000_000)));
+    }
+
+    fn test_policy() -> MintingPolicy {
+        MintingPolicy::SingleKey {
+            key_hash: "9ad4da1c6da54e41ecbab2758323f1abcc7b6e6643f5b930065fcb29".to_string(),
+        }
+    }
+
+    /// Deterministic, valid testnet address from a seed byte (enterprise / no stake).
+    fn test_recipient(seed: u8) -> Address {
+        let kh = Hash::<28>::from([seed; 28]);
+        pallas_addresses::ShelleyAddress::new(
+            pallas_addresses::Network::Testnet,
+            pallas_addresses::ShelleyPaymentPart::key_hash(kh),
+            pallas_addresses::ShelleyDelegationPart::Null,
+        )
+        .into()
+    }
+
+    fn deps_with(lovelace: u64) -> super::super::TxDeps {
+        super::super::TxDeps {
+            utxos: vec![UtxoApi {
+                tx_hash: "a".repeat(64),
+                output_index: 0,
+                lovelace,
+                assets: vec![],
+                tags: vec![],
+            }],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        }
+    }
+
+    #[test]
+    fn test_build_cip25_mint_multi_two_recipients() {
+        let mints = vec![
+            MintRecipientEntry {
+                asset_name: "Foo001".to_string(),
+                quantity: 1,
+                recipient: test_recipient(1),
+            },
+            MintRecipientEntry {
+                asset_name: "Foo002".to_string(),
+                quantity: 1,
+                recipient: test_recipient(2),
+            },
+        ];
+        let result = build_cip25_mint_multi(&deps_with(20_000_000), &test_policy(), &mints, None, None);
+        assert!(result.is_ok(), "multi-recipient mint failed: {result:?}");
+        assert!(result.unwrap().fee > 0);
+    }
+
+    #[test]
+    fn test_build_cip25_mint_multi_explicit_inputs() {
+        // deps carries no UTxOs — the explicit pool UTxO must be used instead.
+        let deps = super::super::TxDeps {
+            utxos: vec![],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        let input = UtxoApi {
+            tx_hash: "b".repeat(64),
+            output_index: 1,
+            lovelace: 10_000_000,
+            assets: vec![],
+            tags: vec![],
+        };
+        let mints = vec![MintRecipientEntry {
+            asset_name: "Bar001".to_string(),
+            quantity: 1,
+            recipient: test_recipient(3),
+        }];
+        let result = build_cip25_mint_multi(
+            &deps,
+            &test_policy(),
+            &mints,
+            None,
+            Some(std::slice::from_ref(&input)),
+        );
+        assert!(result.is_ok(), "explicit-inputs mint failed: {result:?}");
+    }
+
+    #[test]
+    fn test_build_cip25_mint_multi_rejects_zero_quantity() {
+        let mints = vec![MintRecipientEntry {
+            asset_name: "X".to_string(),
+            quantity: 0,
+            recipient: test_recipient(1),
+        }];
+        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &mints, None, None).is_err());
+    }
+
+    #[test]
+    fn test_build_cip25_mint_multi_empty_errors() {
+        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &[], None, None).is_err());
     }
 }

--- a/cardano-tx/src/intents/native_scripts.rs
+++ b/cardano-tx/src/intents/native_scripts.rs
@@ -97,9 +97,12 @@ impl MintingPolicy {
                 let mut key_array = [0u8; 28];
                 key_array.copy_from_slice(&key_bytes);
 
+                // "Mint only before `before_slot`": the script requires the transaction's
+                // upper validity bound to be at/before the slot (`InvalidHereafter`). After
+                // that slot no further mint can ever validate → supply is frozen forever.
                 Ok(NativeScript::ScriptAll(vec![
                     NativeScript::ScriptPubkey(key_array.into()),
-                    NativeScript::InvalidBefore(*before_slot),
+                    NativeScript::InvalidHereafter(*before_slot),
                 ]))
             }
 
@@ -121,10 +124,13 @@ impl MintingPolicy {
                 let mut key_array = [0u8; 28];
                 key_array.copy_from_slice(&key_bytes);
 
+                // "Mint only within [`after_slot`, `before_slot`]": the lower bound is enforced
+                // with `InvalidBefore(after_slot)` (tx must start at/after the slot) and the
+                // upper bound with `InvalidHereafter(before_slot)` (tx must end at/before it).
                 Ok(NativeScript::ScriptAll(vec![
                     NativeScript::ScriptPubkey(key_array.into()),
-                    NativeScript::InvalidHereafter(*after_slot),
-                    NativeScript::InvalidBefore(*before_slot),
+                    NativeScript::InvalidBefore(*after_slot),
+                    NativeScript::InvalidHereafter(*before_slot),
                 ]))
             }
 
@@ -198,11 +204,36 @@ impl MintingPolicy {
                     sig_scripts.push(NativeScript::ScriptPubkey(key_array.into()));
                 }
 
+                // As with `TimeLocked`, the deadline is an upper validity bound:
+                // mint only before `before_slot`, then the multisig supply is frozen.
                 Ok(NativeScript::ScriptAll(vec![
                     NativeScript::ScriptNOfK(*required, sig_scripts),
-                    NativeScript::InvalidBefore(*before_slot),
+                    NativeScript::InvalidHereafter(*before_slot),
                 ]))
             }
+        }
+    }
+
+    /// Transaction validity bounds (in slots) a mint under this policy must set so the
+    /// native-script time locks are satisfied. Returns `(valid_from, invalid_hereafter)`:
+    /// `valid_from` is the lower bound (`StagingTransaction::valid_from_slot`) and
+    /// `invalid_hereafter` the upper bound / TTL (`StagingTransaction::invalid_from_slot`).
+    ///
+    /// A time-locked mint that omits these bounds is rejected on-chain (`ScriptWitnessNotValidating`),
+    /// so the mint builders apply them automatically from this method. Non-time-locked
+    /// policies return `(None, None)`.
+    pub fn validity_bounds(&self) -> (Option<u64>, Option<u64>) {
+        match self {
+            Self::TimeLocked { before_slot, .. } => (None, Some(*before_slot)),
+            Self::TimeBounded {
+                after_slot,
+                before_slot,
+                ..
+            } => (Some(*after_slot), Some(*before_slot)),
+            Self::MultiSigTimeLocked { before_slot, .. } => (None, Some(*before_slot)),
+            Self::WalletDerived
+            | Self::SingleKey { .. }
+            | Self::MultiSig { .. } => (None, None),
         }
     }
 
@@ -386,6 +417,107 @@ mod tests {
         assert_eq!(
             hex::encode(hash1),
             "88263ccf789c6849955b76a287a34d3732c925a1561d260906abfcf9"
+        );
+    }
+
+    fn script_all_clauses(policy: &MintingPolicy) -> Vec<NativeScript> {
+        match policy.to_native_script().unwrap() {
+            NativeScript::ScriptAll(clauses) => clauses,
+            other => panic!("expected ScriptAll, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_time_locked_deadline_is_upper_bound() {
+        // "Mint only before before_slot" must encode as InvalidHereafter (upper bound),
+        // NOT InvalidBefore — otherwise the policy would allow mints only *after* the slot.
+        let policy = MintingPolicy::TimeLocked {
+            key_hash: TEST_KEY_HASH.to_string(),
+            before_slot: 50_000_000,
+        };
+        let clauses = script_all_clauses(&policy);
+        assert!(
+            clauses
+                .iter()
+                .any(|c| matches!(c, NativeScript::InvalidHereafter(s) if *s == 50_000_000)),
+            "TimeLocked must use InvalidHereafter(before_slot)"
+        );
+        assert!(
+            !clauses
+                .iter()
+                .any(|c| matches!(c, NativeScript::InvalidBefore(_))),
+            "TimeLocked must not use InvalidBefore"
+        );
+    }
+
+    #[test]
+    fn test_time_bounded_window_uses_both_bounds() {
+        let policy = MintingPolicy::TimeBounded {
+            key_hash: TEST_KEY_HASH.to_string(),
+            after_slot: 40_000_000,
+            before_slot: 50_000_000,
+        };
+        let clauses = script_all_clauses(&policy);
+        // lower bound = after_slot (InvalidBefore), upper bound = before_slot (InvalidHereafter)
+        assert!(clauses
+            .iter()
+            .any(|c| matches!(c, NativeScript::InvalidBefore(s) if *s == 40_000_000)));
+        assert!(clauses
+            .iter()
+            .any(|c| matches!(c, NativeScript::InvalidHereafter(s) if *s == 50_000_000)));
+    }
+
+    #[test]
+    fn test_multisig_time_locked_deadline_is_upper_bound() {
+        let policy = MintingPolicy::MultiSigTimeLocked {
+            required: 2,
+            key_hashes: vec![TEST_KEY_HASH.to_string(), TEST_KEY_HASH.to_string()],
+            before_slot: 50_000_000,
+        };
+        let clauses = script_all_clauses(&policy);
+        assert!(clauses
+            .iter()
+            .any(|c| matches!(c, NativeScript::InvalidHereafter(s) if *s == 50_000_000)));
+        assert!(!clauses
+            .iter()
+            .any(|c| matches!(c, NativeScript::InvalidBefore(_))));
+    }
+
+    #[test]
+    fn test_validity_bounds() {
+        assert_eq!(MintingPolicy::WalletDerived.validity_bounds(), (None, None));
+        assert_eq!(
+            MintingPolicy::SingleKey {
+                key_hash: TEST_KEY_HASH.to_string()
+            }
+            .validity_bounds(),
+            (None, None)
+        );
+        assert_eq!(
+            MintingPolicy::TimeLocked {
+                key_hash: TEST_KEY_HASH.to_string(),
+                before_slot: 50_000_000,
+            }
+            .validity_bounds(),
+            (None, Some(50_000_000))
+        );
+        assert_eq!(
+            MintingPolicy::TimeBounded {
+                key_hash: TEST_KEY_HASH.to_string(),
+                after_slot: 40_000_000,
+                before_slot: 50_000_000,
+            }
+            .validity_bounds(),
+            (Some(40_000_000), Some(50_000_000))
+        );
+        assert_eq!(
+            MintingPolicy::MultiSigTimeLocked {
+                required: 2,
+                key_hashes: vec![TEST_KEY_HASH.to_string(), TEST_KEY_HASH.to_string()],
+                before_slot: 50_000_000,
+            }
+            .validity_bounds(),
+            (None, Some(50_000_000))
         );
     }
 

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -75,6 +75,7 @@ mod app {
         FungiblesRow,
         // Auth / admin
         MnemonicDisplay,
+        WalletList,
     }
 
     impl Story {
@@ -137,6 +138,7 @@ mod app {
                 Self::PersonaStrip,
                 Self::FungiblesRow,
                 Self::MnemonicDisplay,
+                Self::WalletList,
             ]
         }
 
@@ -192,6 +194,7 @@ mod app {
                 Self::PersonaStrip => "Persona Strip",
                 Self::FungiblesRow => "Fungibles Row",
                 Self::MnemonicDisplay => "Mnemonic Display",
+                Self::WalletList => "Wallet List",
             }
         }
 
@@ -242,7 +245,7 @@ mod app {
                 Self::ImageTextEditor => "Media",
                 Self::TxCart => "TX Cart",
                 Self::GroupedSection | Self::OfferTile => "Layout",
-                Self::MnemonicDisplay => "Auth / Admin",
+                Self::MnemonicDisplay | Self::WalletList => "Auth / Admin",
             }
         }
 
@@ -378,6 +381,9 @@ mod app {
                 Self::MnemonicDisplay => {
                     "BIP-39 mnemonic shown once during provisioning / Art. 20 export — numbered grid, copy CTA, confirmation gate"
                 }
+                Self::WalletList => {
+                    "Per-client wallet roster — Primary at top, Collections grouped, Custom folded below, with archive actions"
+                }
             }
         }
     }
@@ -456,6 +462,7 @@ mod app {
             stories::wallet_identity_header::WalletIdentityHeaderStoryState,
         // Auth / admin
         mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState,
+        wallet_list_state: stories::wallet_list::WalletListState,
     }
 
     impl StorybookApp {
@@ -534,6 +541,7 @@ mod app {
                 wallet_identity_header_state:
                     stories::wallet_identity_header::WalletIdentityHeaderStoryState::default(),
                 mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState::default(),
+                wallet_list_state: stories::wallet_list::WalletListState::default(),
             }
         }
 
@@ -741,6 +749,9 @@ mod app {
                                 ui,
                                 &mut self.mnemonic_display_state,
                             ),
+                            Story::WalletList => {
+                                stories::wallet_list::show(ui, &mut self.wallet_list_state)
+                            }
                         }
                     });
                 });

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -73,6 +73,8 @@ mod app {
         WalletIdentityHeader,
         PersonaStrip,
         FungiblesRow,
+        // Auth / admin
+        MnemonicDisplay,
     }
 
     impl Story {
@@ -134,6 +136,7 @@ mod app {
                 Self::WalletIdentityHeader,
                 Self::PersonaStrip,
                 Self::FungiblesRow,
+                Self::MnemonicDisplay,
             ]
         }
 
@@ -188,6 +191,7 @@ mod app {
                 Self::WalletIdentityHeader => "Wallet Identity Header",
                 Self::PersonaStrip => "Persona Strip",
                 Self::FungiblesRow => "Fungibles Row",
+                Self::MnemonicDisplay => "Mnemonic Display",
             }
         }
 
@@ -238,6 +242,7 @@ mod app {
                 Self::ImageTextEditor => "Media",
                 Self::TxCart => "TX Cart",
                 Self::GroupedSection | Self::OfferTile => "Layout",
+                Self::MnemonicDisplay => "Auth / Admin",
             }
         }
 
@@ -370,6 +375,9 @@ mod app {
                 Self::FungiblesRow => {
                     "Compact row for a fungible token holding (name, ticker chip, quantity, optional ADA value)"
                 }
+                Self::MnemonicDisplay => {
+                    "BIP-39 mnemonic shown once during provisioning / Art. 20 export — numbered grid, copy CTA, confirmation gate"
+                }
             }
         }
     }
@@ -446,6 +454,8 @@ mod app {
         // Wallet
         wallet_identity_header_state:
             stories::wallet_identity_header::WalletIdentityHeaderStoryState,
+        // Auth / admin
+        mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState,
     }
 
     impl StorybookApp {
@@ -523,6 +533,7 @@ mod app {
                 tx_cart_state: stories::tx_cart::TxCartStoryState::default(),
                 wallet_identity_header_state:
                     stories::wallet_identity_header::WalletIdentityHeaderStoryState::default(),
+                mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState::default(),
             }
         }
 
@@ -726,6 +737,10 @@ mod app {
                             ),
                             Story::PersonaStrip => stories::persona_strip::show(ui),
                             Story::FungiblesRow => stories::fungibles_row::show(ui),
+                            Story::MnemonicDisplay => stories::mnemonic_display::show(
+                                ui,
+                                &mut self.mnemonic_display_state,
+                            ),
                         }
                     });
                 });

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -76,6 +76,7 @@ mod app {
         // Auth / admin
         MnemonicDisplay,
         WalletList,
+        CollectionList,
     }
 
     impl Story {
@@ -139,6 +140,7 @@ mod app {
                 Self::FungiblesRow,
                 Self::MnemonicDisplay,
                 Self::WalletList,
+                Self::CollectionList,
             ]
         }
 
@@ -195,6 +197,7 @@ mod app {
                 Self::FungiblesRow => "Fungibles Row",
                 Self::MnemonicDisplay => "Mnemonic Display",
                 Self::WalletList => "Wallet List",
+                Self::CollectionList => "Collection List",
             }
         }
 
@@ -245,7 +248,7 @@ mod app {
                 Self::ImageTextEditor => "Media",
                 Self::TxCart => "TX Cart",
                 Self::GroupedSection | Self::OfferTile => "Layout",
-                Self::MnemonicDisplay | Self::WalletList => "Auth / Admin",
+                Self::MnemonicDisplay | Self::WalletList | Self::CollectionList => "Auth / Admin",
             }
         }
 
@@ -384,6 +387,9 @@ mod app {
                 Self::WalletList => {
                     "Per-client wallet roster — Primary at top, Collections grouped, Custom folded below, with archive actions"
                 }
+                Self::CollectionList => {
+                    "Per-client collections list — title, status/standard/network chips, supply progress, policy_id copy, Test mint / Seed stubs actions"
+                }
             }
         }
     }
@@ -463,6 +469,7 @@ mod app {
         // Auth / admin
         mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState,
         wallet_list_state: stories::wallet_list::WalletListState,
+        collection_list_state: stories::collection_list::CollectionListState,
     }
 
     impl StorybookApp {
@@ -542,6 +549,7 @@ mod app {
                     stories::wallet_identity_header::WalletIdentityHeaderStoryState::default(),
                 mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState::default(),
                 wallet_list_state: stories::wallet_list::WalletListState::default(),
+                collection_list_state: stories::collection_list::CollectionListState::default(),
             }
         }
 
@@ -751,6 +759,9 @@ mod app {
                             ),
                             Story::WalletList => {
                                 stories::wallet_list::show(ui, &mut self.wallet_list_state)
+                            }
+                            Story::CollectionList => {
+                                stories::collection_list::show(ui, &mut self.collection_list_state)
                             }
                         }
                     });

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -14,6 +14,8 @@ pub struct CollectionListState {
     pub last_test_mint: Option<String>,
     /// Last seed-stubs action observed.
     pub last_seed_stubs: Option<String>,
+    /// Last activity action observed.
+    pub last_activity: Option<String>,
     /// Last open-wallet action observed.
     pub last_open_wallet: Option<u32>,
 }
@@ -44,6 +46,7 @@ fn row(
         minted_count,
         test_mint_open: false,
         seed_stubs_open: false,
+        activity_open: false,
     }
 }
 
@@ -413,6 +416,9 @@ fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionLis
             }
             CollectionListAction::SeedStubs { policy_id } => {
                 state.last_seed_stubs = Some(policy_id);
+            }
+            CollectionListAction::Activity { policy_id } => {
+                state.last_activity = Some(policy_id);
             }
             CollectionListAction::OpenWallet { account_index } => {
                 state.last_open_wallet = Some(account_index);

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -1,0 +1,422 @@
+//! Story: `CollectionList` — the per-client collections list rendered on
+//! the admin portal dashboard. Covers the realistic mix: fresh draft,
+//! mid-mint ingesting, live with a real fill %, plus standard/network
+//! variants (cip25 / cip68, preprod / mainnet) and the 2-column grid.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::collection_list::{
+    CollectionList, CollectionListAction, CollectionListLayout, CollectionRow,
+};
+
+#[derive(Default)]
+pub struct CollectionListState {
+    /// Last test-mint action observed — proves the action channel is wired.
+    pub last_test_mint: Option<String>,
+    /// Last seed-stubs action observed.
+    pub last_seed_stubs: Option<String>,
+    /// Last open-wallet action observed.
+    pub last_open_wallet: Option<u32>,
+}
+
+/// Construct a sample row. The widget does no truncation itself — the
+/// host pre-formats `policy_id_short` so the truncation strategy
+/// (prefix/suffix widths) lives where the data lives.
+#[allow(clippy::too_many_arguments)]
+fn row(
+    policy_id: &str,
+    wallet_account_index: u32,
+    title: &str,
+    status: &str,
+    standard: &str,
+    network: &str,
+    total_supply: u64,
+    minted_count: u64,
+) -> CollectionRow {
+    CollectionRow {
+        policy_id: policy_id.to_string(),
+        policy_id_short: truncate_middle(policy_id, 8, 6),
+        wallet_account_index,
+        title: title.to_string(),
+        status: status.to_string(),
+        standard: standard.to_string(),
+        network: network.to_string(),
+        total_supply,
+        minted_count,
+        test_mint_open: false,
+        seed_stubs_open: false,
+    }
+}
+
+fn truncate_middle(s: &str, prefix: usize, suffix: usize) -> String {
+    if s.len() <= prefix + suffix + 1 {
+        return s.to_string();
+    }
+    let p: String = s.chars().take(prefix).collect();
+    let q: String = s
+        .chars()
+        .rev()
+        .take(suffix)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("{p}…{q}")
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
+    ui.label(
+        egui::RichText::new(
+            "Per-client collections list. Each card surfaces the title, status, \
+             standard, network, supply progress, and a copy-able policy_id. \
+             Action buttons fire `CollectionListAction` events; the parent owns \
+             the forms below.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(16.0);
+
+    // ── Variant 1: fresh draft, no inventory yet ───────────────────────
+    ui.label(
+        egui::RichText::new("Fresh draft — supply target set, no mints yet")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Right after `+ Create collection`. Status is `draft`, mint count is 0. \
+             The supply bar is empty; the copy button on the policy_id is the \
+             primary value of the card for `mintctl clone-policy` operators.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![row(
+        "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
+        4,
+        "Foobar",
+        "draft",
+        "cip25",
+        "cardano:preprod",
+        1000,
+        0,
+    )];
+    let resp = CollectionList::new(&rows)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 2: mid-mint, ingesting ─────────────────────────────────
+    ui.label(
+        egui::RichText::new("Mid-mint — ingesting with a partial fill")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "The supply bar fills as `minted_count / total_supply`. Status chip \
+             colour-codes the lifecycle phase (ingesting / ready / live / paused).",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
+            4,
+            "Foobar",
+            "ingesting",
+            "cip25",
+            "cardano:preprod",
+            1000,
+            340,
+        ),
+        row(
+            "a8d4e1c7b2f5a9d3c6e0b4f7a1c8e2d5b9a6c3f0e7d4b1a8c5e2f9b6a3d0e7",
+            5,
+            "Black Flag (preprod)",
+            "ready",
+            "cip25",
+            "cardano:preprod",
+            500,
+            0,
+        ),
+    ];
+    let resp = CollectionList::new(&rows)
+        .with_columns(2)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 3: live + cip68 ────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Live mint — CIP-68 with progress")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Live status drives the bar fill to green. CIP-68 standard chip is a \
+             distinct soft-teal to distinguish from CIP-25's soft-purple.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![row(
+        "5c3a8e4d2f1b7a9c6e0d3b5f8a2c4e7d1b9f6a3c0e5d8b2f7a4c1e6d3b9f0a8",
+        7,
+        "Live Collection",
+        "live",
+        "cip68",
+        "cardano:mainnet",
+        2000,
+        1247,
+    )];
+    let resp = CollectionList::new(&rows)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 4: 2-column grid, mixed statuses ───────────────────────
+    ui.label(
+        egui::RichText::new("Mixed — 2-column grid across the lifecycle")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "`with_columns(2)` packs cards into a grid. Status chips give a \
+             scannable summary — draft / ingesting / ready / live / paused / \
+             sold_out / ended each have their own palette.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
+            4,
+            "Foobar",
+            "draft",
+            "cip25",
+            "cardano:preprod",
+            1000,
+            0,
+        ),
+        row(
+            "a8d4e1c7b2f5a9d3c6e0b4f7a1c8e2d5b9a6c3f0e7d4b1a8c5e2f9b6a3d0e7",
+            5,
+            "Black Flag (preprod)",
+            "ingesting",
+            "cip25",
+            "cardano:preprod",
+            500,
+            120,
+        ),
+        row(
+            "5c3a8e4d2f1b7a9c6e0d3b5f8a2c4e7d1b9f6a3c0e5d8b2f7a4c1e6d3b9f0a8",
+            7,
+            "Live Collection",
+            "live",
+            "cip68",
+            "cardano:mainnet",
+            2000,
+            1247,
+        ),
+        row(
+            "9b7a3c1e5d8f2a4c6e9d1b3f7a5c8e0d2b4f6a9c1e3d5b7f0a8c2e4d6b9f1c3",
+            6,
+            "Paused Drop",
+            "paused",
+            "cip25",
+            "cardano:mainnet",
+            10000,
+            6432,
+        ),
+        row(
+            "1e3d5b7f0a8c2e4d6b9f1c3a5e7d9b1f3a5c7e9d1b3f5a7c9e1d3b5f7a9c1e3",
+            8,
+            "Sold Out Genesis",
+            "sold_out",
+            "cip68",
+            "cardano:mainnet",
+            333,
+            333,
+        ),
+        row(
+            "0a2c4e6d8b0f2a4c6e8d0b2f4a6c8e0d2b4f6a8c0e2d4b6f8a0c2e4d6b8f0a2",
+            9,
+            "Ended Mint",
+            "ended",
+            "cip25",
+            "cardano:mainnet",
+            10000,
+            8413,
+        ),
+    ];
+    let resp = CollectionList::new(&rows)
+        .with_columns(2)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 5: form-open toggles ───────────────────────────────────
+    ui.label(
+        egui::RichText::new("Toggle states — Test mint / Seed stubs open")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "When the parent has a form open for a collection, it sets \
+             `test_mint_open` / `seed_stubs_open` on the row VM. The widget \
+             renders the button label as `− Test mint` instead of `🧪 Test mint` \
+             for a clear close-affordance.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let mut rows = vec![
+        row(
+            "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
+            4,
+            "Foobar (test-mint open)",
+            "ready",
+            "cip25",
+            "cardano:preprod",
+            1000,
+            0,
+        ),
+        row(
+            "a8d4e1c7b2f5a9d3c6e0b4f7a1c8e2d5b9a6c3f0e7d4b1a8c5e2f9b6a3d0e7",
+            5,
+            "Black Flag (seed-stubs open)",
+            "draft",
+            "cip25",
+            "cardano:preprod",
+            500,
+            0,
+        ),
+    ];
+    rows[0].test_mint_open = true;
+    rows[1].seed_stubs_open = true;
+    let resp = CollectionList::new(&rows)
+        .with_columns(2)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 6: list layout ─────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("List layout — compact for dense surfaces")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "`with_layout(List)` collapses each collection to a single horizontal \
+             row — same chips, no supply bar, no separate footer. Good for an \
+             admin index view of dozens of collections.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let _ = CollectionList::new(&rows)
+        .with_layout(CollectionListLayout::List)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .show(ui);
+
+    // ── Action receipt ─────────────────────────────────────────────────
+    if state.last_test_mint.is_some()
+        || state.last_seed_stubs.is_some()
+        || state.last_open_wallet.is_some()
+    {
+        ui.add_space(16.0);
+        ui.separator();
+        ui.add_space(8.0);
+        ui.label(
+            egui::RichText::new("Action receipts")
+                .color(ACCENT)
+                .strong()
+                .small(),
+        );
+        if let Some(p) = &state.last_test_mint {
+            ui.colored_label(
+                egui::Color32::LIGHT_GREEN,
+                format!("✓ test-mint requested for {}", truncate_middle(p, 8, 6)),
+            );
+        }
+        if let Some(p) = &state.last_seed_stubs {
+            ui.colored_label(
+                egui::Color32::LIGHT_GREEN,
+                format!("✓ seed-stubs requested for {}", truncate_middle(p, 8, 6)),
+            );
+        }
+        if let Some(idx) = state.last_open_wallet {
+            ui.colored_label(
+                egui::Color32::LIGHT_GREEN,
+                format!("✓ open-wallet requested for #{idx}"),
+            );
+        }
+    }
+}
+
+fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionListState) {
+    for a in actions {
+        match a {
+            CollectionListAction::TestMint { policy_id } => {
+                state.last_test_mint = Some(policy_id);
+            }
+            CollectionListAction::SeedStubs { policy_id } => {
+                state.last_seed_stubs = Some(policy_id);
+            }
+            CollectionListAction::OpenWallet { account_index } => {
+                state.last_open_wallet = Some(account_index);
+            }
+        }
+    }
+}

--- a/ui/_storybook-egui/src/stories/mnemonic_display.rs
+++ b/ui/_storybook-egui/src/stories/mnemonic_display.rs
@@ -1,0 +1,116 @@
+//! Story: `MnemonicDisplay` — the moment-of-truth widget for showing a
+//! freshly-generated BIP-39 phrase exactly once.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::mnemonic_display::MnemonicDisplay;
+
+#[derive(Default)]
+pub struct MnemonicDisplayState {
+    pub copied_24: bool,
+    pub confirmed_24: bool,
+    pub copied_12: bool,
+}
+
+const SAMPLE_24: &str = "abandon ability able about above absent absorb abstract absurd abuse \
+                         access accident account accuse achieve acid acoustic acquire across \
+                         act action actor actress actual";
+
+const SAMPLE_12: &str =
+    "legal winner thank year wave sausage worth useful legal winner thank yellow";
+
+pub fn show(ui: &mut egui::Ui, state: &mut MnemonicDisplayState) {
+    ui.label(
+        egui::RichText::new(
+            "BIP-39 mnemonic display — shown once when provisioning a new client or on \
+             GDPR Art. 20 export.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(16.0);
+
+    // ── Variant 1: 24 words + confirmation gate ────────────────────────
+    ui.label(
+        egui::RichText::new("24-word phrase, with confirmation gate")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "The default provisioning flow: parent renders this then enables a \"Continue\" \
+             button only once `confirmed` flips true.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let out = MnemonicDisplay::new(SAMPLE_24)
+        .with_confirmation(&mut state.confirmed_24)
+        .show(ui);
+    if out.copy_clicked {
+        state.copied_24 = true;
+    }
+    if state.copied_24 {
+        ui.add_space(4.0);
+        ui.colored_label(egui::Color32::LIGHT_GREEN, "✓ copied");
+    }
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 2: 12 words, no confirmation ───────────────────────────
+    ui.label(
+        egui::RichText::new("12-word phrase, no confirmation gate")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "For lower-stakes flows where the parent already has a confirmation step \
+             (e.g. an export modal that closes on its own dismiss button).",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let out = MnemonicDisplay::new(SAMPLE_12).show(ui);
+    if out.copy_clicked {
+        state.copied_12 = true;
+    }
+    if state.copied_12 {
+        ui.add_space(4.0);
+        ui.colored_label(egui::Color32::LIGHT_GREEN, "✓ copied");
+    }
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 3: warning banner suppressed ───────────────────────────
+    ui.label(
+        egui::RichText::new("Banner suppressed (parent provides messaging)")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Use when the surrounding modal already carries the warning text, to avoid \
+             duplicate copy.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let style = egui_widgets::mnemonic_display::MnemonicDisplayStyle {
+        show_warning: false,
+        ..Default::default()
+    };
+    let _ = MnemonicDisplay::new(SAMPLE_24).with_style(style).show(ui);
+}

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -64,3 +64,4 @@ pub mod offer_tile;
 pub mod fungibles_row;
 pub mod persona_strip;
 pub mod wallet_identity_header;
+pub mod wallet_list;

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -9,6 +9,7 @@ pub mod icon_gallery;
 pub mod marquee;
 pub mod mesh_playground;
 pub mod metric_card;
+pub mod mnemonic_display;
 pub mod perspective_text;
 pub mod pip_row;
 pub mod printing_timeline;

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -2,6 +2,7 @@ pub mod asset_card;
 pub mod async_data;
 pub mod buttons;
 pub mod card_browser;
+pub mod collection_list;
 pub mod distribution;
 pub mod flip_counter;
 pub mod formatting;

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -4,7 +4,7 @@
 
 use crate::{ACCENT, TEXT_MUTED};
 use egui_widgets::wallet_list::{
-    WalletList, WalletListAction, WalletListRole, WalletListRow,
+    WalletList, WalletListAction, WalletListLayout, WalletListRole, WalletListRow,
 };
 
 #[derive(Default)]
@@ -238,4 +238,212 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
         ),
     ];
     let _ = WalletList::new(&rows).show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 5: card layout — single Primary ────────────────────────
+    ui.label(
+        egui::RichText::new("Card layout — single Primary")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Taller tile with a filled role pill, heading-sized label, and the \
+             address on its own footer line. Use when wallet identity is the \
+             focal element of the surface (an \"Identities\" sub-page, say) \
+             rather than one row in a long list.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![row(
+        0,
+        "Primary",
+        WalletListRole::Primary,
+        "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+        false,
+        false,
+    )];
+    let _ = WalletList::new(&rows)
+        .with_layout(WalletListLayout::Card)
+        .show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 6: card layout — multi-bucket with archived ────────────
+    ui.label(
+        egui::RichText::new("Card layout — multiple wallets, with archived")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Section headers still apply; archived tiles dim and lose the Archive \
+             button. The same row VMs feed both layouts — only the per-card geometry \
+             differs.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            0,
+            "Primary",
+            WalletListRole::Primary,
+            "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+            false,
+            false,
+        ),
+        row(
+            1,
+            "Aliens",
+            WalletListRole::Collection,
+            "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22",
+            true,
+            false,
+        ),
+        row(
+            2,
+            "Nikepig",
+            WalletListRole::Collection,
+            "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff",
+            true,
+            false,
+        ),
+        row(
+            3,
+            "JRYNers",
+            WalletListRole::Collection,
+            "addr_test1vrkxs3l5dt8jjlxhykqwa45dz8gj7nl2q6m3wt4kx07a8e02",
+            true,
+            true,
+        ),
+        row(
+            7,
+            "Cold storage",
+            WalletListRole::Custom,
+            "addr_test1vzv87fxqt9jrlxh2v9rxe6f55l9a5anq5tkwgmf2pl0099aa",
+            false,
+            false,
+        ),
+    ];
+    let _ = WalletList::new(&rows)
+        .with_layout(WalletListLayout::Card)
+        .show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 7: card layout, 2-column grid ──────────────────────────
+    ui.label(
+        egui::RichText::new("Card layout — 2-column grid")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "`.with_columns(2)` packs cards into a grid. Per-bucket clamped so the \
+             single Primary card still fills the surface width; Collections wraps \
+             at 2-wide. Last row of an odd-count bucket leaves a trailing empty \
+             cell to keep the grid aligned.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            0,
+            "Primary",
+            WalletListRole::Primary,
+            "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+            false,
+            false,
+        ),
+        row(
+            1,
+            "Aliens",
+            WalletListRole::Collection,
+            "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22",
+            true,
+            false,
+        ),
+        row(
+            2,
+            "Nikepig",
+            WalletListRole::Collection,
+            "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff",
+            true,
+            false,
+        ),
+        row(
+            3,
+            "Toolheads",
+            WalletListRole::Collection,
+            "addr_test1vqahjlw2qspx9chgxctf48k0wq2g9j8a6fl74xg7q34fab10",
+            true,
+            false,
+        ),
+        row(
+            4,
+            "JRYNers",
+            WalletListRole::Collection,
+            "addr_test1vrkxs3l5dt8jjlxhykqwa45dz8gj7nl2q6m3wt4kx07a8e02",
+            true,
+            false,
+        ),
+        row(
+            5,
+            "IslaNOVA",
+            WalletListRole::Collection,
+            "addr_test1vp7ckag5jdtwfse5fy0adyfeesn5tep4qz0u9rmskg2bc491",
+            true,
+            false,
+        ),
+    ];
+    let _ = WalletList::new(&rows)
+        .with_layout(WalletListLayout::Card)
+        .with_columns(2)
+        .show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 8: list layout, 2-column grid ──────────────────────────
+    ui.label(
+        egui::RichText::new("List layout — 2-column grid")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "The same `with_columns(2)` applies to the compact list mode for dense \
+             surfaces. List rows are tighter, so 2 columns is the usable max — \
+             3+ crowds the truncated address.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let _ = WalletList::new(&rows)
+        .with_layout(WalletListLayout::List)
+        .with_columns(2)
+        .show(ui);
 }

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -147,6 +147,11 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
             WalletListAction::Archive { account_index } => {
                 state.last_archived = Some(account_index);
             }
+            // The story doesn't enable `with_view_button`, so this arm
+            // is unreachable in practice — kept for exhaustive matching
+            // since `WalletListAction` is non-exhaustive in shape but
+            // not in attribute.
+            WalletListAction::ViewUtxos { .. } => {}
         }
     }
     if let Some(idx) = state.last_archived {

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -32,6 +32,7 @@ fn row(
         role,
         auto_created,
         archived_at: if archived { Some(1_700_000_000) } else { None },
+        pool: None,
     }
 }
 
@@ -152,6 +153,9 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
             // since `WalletListAction` is non-exhaustive in shape but
             // not in attribute.
             WalletListAction::ViewUtxos { .. } => {}
+            // Same — story doesn't trigger archive flow, so restore
+            // never fires; arm kept for exhaustive matching.
+            WalletListAction::Unarchive { .. } => {}
         }
     }
     if let Some(idx) = state.last_archived {

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -1,0 +1,241 @@
+//! Story: `WalletList` — the per-client wallet roster on the admin portal
+//! dashboard. Covers the realistic layouts: fresh client (1 wallet), client
+//! with collections, mixed roles, and archived rows.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::wallet_list::{
+    WalletList, WalletListAction, WalletListRole, WalletListRow,
+};
+
+#[derive(Default)]
+pub struct WalletListState {
+    /// Last archive action received, for demoing the action channel.
+    pub last_archived: Option<u32>,
+}
+
+/// Build a sample row. `full_addr` is the canonical bech32 string the copy
+/// button writes to the clipboard; the inline display is a middle-elided
+/// truncation of it.
+fn row(
+    account_index: u32,
+    label: &str,
+    role: WalletListRole,
+    full_addr: &str,
+    auto_created: bool,
+    archived: bool,
+) -> WalletListRow {
+    WalletListRow {
+        account_index,
+        label: label.to_string(),
+        address_short: truncate_middle(full_addr, 14, 8),
+        address_full: Some(full_addr.to_string()),
+        role,
+        auto_created,
+        archived_at: if archived { Some(1_700_000_000) } else { None },
+    }
+}
+
+/// Middle-elision used by the portal — same prefix/suffix idea as
+/// `frontend::app::truncate_middle` but local to the story so the widget
+/// crate doesn't take on a truncation utility.
+fn truncate_middle(s: &str, prefix: usize, suffix: usize) -> String {
+    if s.len() <= prefix + suffix + 1 {
+        return s.to_string();
+    }
+    let p: String = s.chars().take(prefix).collect();
+    let q: String = s
+        .chars()
+        .rev()
+        .take(suffix)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("{p}…{q}")
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
+    ui.label(
+        egui::RichText::new(
+            "Per-client wallet roster — Primary at the top, Collections grouped, \
+             Custom folded below. Section headers appear when more than one bucket \
+             is populated. Each row shows the bech32 enterprise address (truncated) \
+             with a copy-to-clipboard icon.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(16.0);
+
+    // ── Variant 1: fresh client (single Primary) ───────────────────────
+    ui.label(
+        egui::RichText::new("Fresh client — single Primary wallet")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Right after self-provision. No collections yet. No section header — \
+             the widget collapses to a clean one-row layout.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![row(
+        0,
+        "Primary",
+        WalletListRole::Primary,
+        "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+        false,
+        false,
+    )];
+    let _ = WalletList::new(&rows).show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 2: client with a couple of collections ─────────────────
+    ui.label(
+        egui::RichText::new("With collections — section headers appear")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Once a second bucket is populated, the widget surfaces \"Primary\" \
+             and \"Collections (N)\" headers so users can scan.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            0,
+            "Primary",
+            WalletListRole::Primary,
+            "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+            false,
+            false,
+        ),
+        row(
+            1,
+            "Aliens",
+            WalletListRole::Collection,
+            "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22",
+            true,
+            false,
+        ),
+        row(
+            2,
+            "Nikepig",
+            WalletListRole::Collection,
+            "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff",
+            true,
+            false,
+        ),
+    ];
+    let resp = WalletList::new(&rows).show(ui);
+    for a in resp.actions {
+        match a {
+            WalletListAction::Archive { account_index } => {
+                state.last_archived = Some(account_index);
+            }
+        }
+    }
+    if let Some(idx) = state.last_archived {
+        ui.add_space(4.0);
+        ui.colored_label(
+            egui::Color32::LIGHT_GREEN,
+            format!("✓ archive requested for #{idx}"),
+        );
+    }
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 3: many collections + an archived row ──────────────────
+    ui.label(
+        egui::RichText::new("Many collections, with one archived")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Archived rows render dimmed with an \"archived\" chip and no Archive \
+             button (the action is idempotent server-side but the affordance would \
+             be confusing).",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(
+            0,
+            "Primary",
+            WalletListRole::Primary,
+            "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+            false,
+            false,
+        ),
+        row(1, "Aliens", WalletListRole::Collection, "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22", true, false),
+        row(2, "Nikepig", WalletListRole::Collection, "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff", true, false),
+        row(3, "Toolheads", WalletListRole::Collection, "addr_test1vqahjlw2qspx9chgxctf48k0wq2g9j8a6fl74xg7q34fab10", true, false),
+        row(4, "JRYNers", WalletListRole::Collection, "addr_test1vrkxs3l5dt8jjlxhykqwa45dz8gj7nl2q6m3wt4kx07a8e02", true, true),
+        row(5, "IslaNOVA", WalletListRole::Collection, "addr_test1vp7ckag5jdtwfse5fy0adyfeesn5tep4qz0u9rmskg2bc491", true, false),
+    ];
+    let _ = WalletList::new(&rows).show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 4: mixed roles including Custom ────────────────────────
+    ui.label(
+        egui::RichText::new("Mixed — including a Custom wallet")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Advanced users may add operator-named wallets outside the collection \
+             lifecycle. They get their own bucket below Collections.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row(0, "Primary", WalletListRole::Primary, "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465", false, false),
+        row(1, "Aliens", WalletListRole::Collection, "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22", true, false),
+        row(
+            7,
+            "Cold storage",
+            WalletListRole::Custom,
+            "addr_test1vzv87fxqt9jrlxh2v9rxe6f55l9a5anq5tkwgmf2pl0099aa",
+            false,
+            false,
+        ),
+        row(
+            8,
+            "Treasury",
+            WalletListRole::Custom,
+            "addr_test1vqgs5gzlr8hxpwsxnq6kfdsr2vd9s7y3wlxc6n83sjaa44cc",
+            false,
+            false,
+        ),
+    ];
+    let _ = WalletList::new(&rows).show(ui);
+}

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -1,0 +1,598 @@
+//! Collection roster — the per-client collections list rendered on the
+//! admin portal dashboard. Sibling to [`crate::wallet_list`] and shares
+//! its API shape: VM rows in, action stream out, no widget-owned state.
+//!
+//! ## Why it's a widget
+//!
+//! The portal's `render_client_detail` was rendering collections as a
+//! single horizontal `for c in collections` line — fine for one
+//! collection, falls apart at five. More importantly, the `policy_id`
+//! was truncated without a copy affordance, which is exactly what an
+//! operator running `mintctl clone-policy` needs to grab. Pushing this
+//! into a widget gives us:
+//!
+//! - card layout that scales to a multi-collection client
+//! - per-card `policy_id` truncation + copy-to-clipboard button
+//! - per-card supply progress (mint count / total) with a thin bar
+//! - per-card action row (Test mint, Seed stubs) wired through a
+//!   `CollectionListAction` enum so the parent stays in charge of the
+//!   forms below the card
+//! - status/standard/network rendered as filled chips with consistent
+//!   colours across screens (status from
+//!   [`crate::wallet_list::WalletList`]'s `status_colour` lookup)
+//!
+//! ## What it does NOT do
+//!
+//! - **No async, no inbox.** Actions are returned in the response struct.
+//! - **No state.** Form-open vs form-closed is read from
+//!   `CollectionRow::test_mint_open` / `seed_stubs_open` — the parent
+//!   owns the truth.
+//! - **No "+ Create collection" button.** That stays on the section
+//!   header in the parent layout (see `app.rs::render_client_detail`)
+//!   so the widget composes cleanly with the parent's header chrome.
+//!
+//! ## Layouts
+//!
+//! Two presentations share the same row VM:
+//!
+//! - [`CollectionListLayout::Card`] (default) — full card with title,
+//!   chips, supply bar, footer, action row. Used by the portal.
+//! - [`CollectionListLayout::List`] — compact one-row-per-collection;
+//!   useful for dense surfaces (e.g. an admin index view).
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! let rows: Vec<CollectionRow> = detail.collections.iter().map(to_vm).collect();
+//! let resp = CollectionList::new(&rows)
+//!     .with_columns(2)
+//!     .with_test_mint(true)
+//!     .with_seed_stubs(true)
+//!     .show(ui);
+//! for action in resp.actions {
+//!     match action {
+//!         CollectionListAction::TestMint { policy_id } => { /* dispatch */ }
+//!         CollectionListAction::SeedStubs { policy_id } => { /* dispatch */ }
+//!         CollectionListAction::OpenWallet { account_index } => { /* dispatch */ }
+//!     }
+//! }
+//! ```
+
+use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
+
+// ─────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────
+
+/// View-model for a single collection row. Pre-formatted by the
+/// caller — the widget does no truncation, no enum mapping, and no
+/// status-string interpretation beyond the chip colour lookup.
+#[derive(Clone, Debug)]
+pub struct CollectionRow {
+    /// Full hex policy_id (56 chars). Written to the clipboard when
+    /// the user clicks the copy icon.
+    pub policy_id: String,
+    /// Pre-truncated `policy_id` for inline display (e.g. middle-elided
+    /// to `7f2b6f15…8922e0`). Caller picks the prefix/suffix widths.
+    pub policy_id_short: String,
+    /// BIP-44 account index of the wallet that owns the mint key for
+    /// this collection. Renders as `wallet #N`, clickable to open that
+    /// wallet's UTxO window via [`CollectionListAction::OpenWallet`].
+    pub wallet_account_index: u32,
+    /// Display title (operator-set, e.g. "Foobar").
+    pub title: String,
+    /// Lifecycle status: `draft` / `ingesting` / `ready` / `live` /
+    /// `paused` / `sold_out` / `ended`. Unknown values render neutral
+    /// grey. Lowercase by convention; the widget uppercases for display.
+    pub status: String,
+    /// CIP-25 / CIP-68 standard (lowercase: `cip25` / `cip68`). Drives
+    /// the standard-chip colour; unknown values render neutral grey.
+    pub standard: String,
+    /// Network the collection is provisioned on, in canonical form
+    /// (`cardano:preprod` / `cardano:mainnet`). The widget strips the
+    /// `cardano:` prefix when rendering the chip.
+    pub network: String,
+    /// Total minted supply target. Rendered as `minted_count /
+    /// total_supply` + a thin progress bar.
+    pub total_supply: u64,
+    /// Number of assets already minted. The progress bar fills based on
+    /// `minted_count / total_supply`.
+    pub minted_count: u64,
+    /// `true` when the parent has the Test-mint form open below this
+    /// row. The widget renders the button label as `− Test mint` so
+    /// the user has a clear "close" affordance.
+    pub test_mint_open: bool,
+    /// `true` when the parent has the Seed-stubs form open below this
+    /// row. Same toggle treatment as `test_mint_open`.
+    pub seed_stubs_open: bool,
+}
+
+/// Actions emitted while the widget was on screen this frame. Parent
+/// drains and dispatches.
+#[derive(Clone, Debug)]
+pub enum CollectionListAction {
+    /// User clicked the Test-mint toggle. The parent decides whether to
+    /// open/close the form for this `policy_id`.
+    TestMint { policy_id: String },
+    /// User clicked the Seed-stubs toggle. Same as above.
+    SeedStubs { policy_id: String },
+    /// User clicked the `wallet #N` link in the footer. Parent opens
+    /// that wallet's UTxO panel (or whatever it does for wallet focus).
+    OpenWallet { account_index: u32 },
+}
+
+/// Rendering style. Both styles share the same row VM and action emission —
+/// only the per-row geometry differs.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CollectionListLayout {
+    /// Taller card with title, chips, supply bar, footer, action row.
+    /// Default — the portal's main collections grid.
+    #[default]
+    Card,
+    /// Compact one-row-per-collection. Useful for dense indexes; less
+    /// information density loss vs the card's two extra rows.
+    List,
+}
+
+/// Builder.
+pub struct CollectionList<'a> {
+    rows: &'a [CollectionRow],
+    layout: CollectionListLayout,
+    columns: usize,
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+}
+
+/// Response — drained actions for this frame.
+#[derive(Default, Debug)]
+pub struct CollectionListResponse {
+    pub actions: Vec<CollectionListAction>,
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Colours — kept private. Status palette mirrors the portal's
+// previous `status_colour()` helper so the visual semantics survive
+// the widget extraction.
+// ─────────────────────────────────────────────────────────────────────
+
+const ROW_BG: Color32 = Color32::from_rgb(22, 22, 32);
+const ROW_STROKE: Color32 = Color32::from_rgb(40, 40, 56);
+const META_GREY: Color32 = Color32::from_gray(140);
+const KEYHASH_GREY: Color32 = Color32::from_gray(120);
+
+// Standard chips: CIP-25 = soft purple, CIP-68 = soft teal. Distinct
+// enough to scan at a glance; tonal palette matches the wallet-role
+// chips (cool blue / soft green / neutral grey).
+const STD_CIP25_CHIP: Color32 = Color32::from_rgb(190, 170, 220);
+const STD_CIP68_CHIP: Color32 = Color32::from_rgb(170, 220, 200);
+const STD_UNKNOWN_CHIP: Color32 = Color32::from_gray(150);
+
+// Network chip is intentionally muted — it's environmental context,
+// not the primary identity of the collection.
+const NETWORK_CHIP: Color32 = Color32::from_rgb(120, 130, 150);
+
+// Progress bar — base track + filled portion. Fill colour shifts by
+// status (live = green, otherwise neutral cyan) so an at-a-glance scan
+// distinguishes "in progress" from "actively minting".
+const BAR_TRACK: Color32 = Color32::from_rgb(30, 30, 44);
+const BAR_FILL_NEUTRAL: Color32 = Color32::from_rgb(120, 160, 200);
+const BAR_FILL_LIVE: Color32 = Color32::from_rgb(140, 200, 140);
+
+impl<'a> CollectionList<'a> {
+    pub fn new(rows: &'a [CollectionRow]) -> Self {
+        Self {
+            rows,
+            layout: CollectionListLayout::default(),
+            columns: 1,
+            show_test_mint: false,
+            show_seed_stubs: false,
+        }
+    }
+
+    /// Switch the per-row presentation. See [`CollectionListLayout`].
+    pub fn with_layout(mut self, layout: CollectionListLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    /// Lay rows out as a grid this many columns wide. Default `1`.
+    /// Per-bucket clamp: a single-row collection still uses the full
+    /// surface width even when 2+ cols are configured — keeps the
+    /// layout from leaving a trailing empty cell that reads as a bug.
+    pub fn with_columns(mut self, cols: usize) -> Self {
+        self.columns = cols.max(1);
+        self
+    }
+
+    /// Show the per-card "Test mint" button. Off by default since the
+    /// host may not have a mint-form to render. Click → emits
+    /// [`CollectionListAction::TestMint`].
+    pub fn with_test_mint(mut self, enabled: bool) -> Self {
+        self.show_test_mint = enabled;
+        self
+    }
+
+    /// Show the per-card "Seed stubs" button. Off by default. Click →
+    /// emits [`CollectionListAction::SeedStubs`]. The portal uses this
+    /// for the local testing path; `mintctl clone-policy` replaces it
+    /// for realistic inventory but the toggle remains useful for quick
+    /// one-off seeding.
+    pub fn with_seed_stubs(mut self, enabled: bool) -> Self {
+        self.show_seed_stubs = enabled;
+        self
+    }
+
+    pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
+        let mut response = CollectionListResponse::default();
+
+        if self.rows.is_empty() {
+            return response;
+        }
+
+        // Per-grid clamp: a 1-row layout renders full-width even when
+        // 2+ columns are configured.
+        let effective_cols = self.columns.min(self.rows.len()).max(1);
+
+        let gap = match self.layout {
+            CollectionListLayout::Card => 8.0,
+            CollectionListLayout::List => 4.0,
+        };
+
+        let chunks: Vec<&[CollectionRow]> = self.rows.chunks(effective_cols).collect();
+        let last_chunk = chunks.len().saturating_sub(1);
+        for (chunk_idx, chunk) in chunks.iter().enumerate() {
+            if effective_cols == 1 {
+                for r in chunk.iter() {
+                    render_one(
+                        ui,
+                        r,
+                        self.layout,
+                        self.show_test_mint,
+                        self.show_seed_stubs,
+                        &mut response,
+                    );
+                }
+            } else {
+                ui.columns(effective_cols, |cols| {
+                    for (i, r) in chunk.iter().enumerate() {
+                        render_one(
+                            &mut cols[i],
+                            r,
+                            self.layout,
+                            self.show_test_mint,
+                            self.show_seed_stubs,
+                            &mut response,
+                        );
+                    }
+                });
+            }
+            if chunk_idx < last_chunk {
+                ui.add_space(gap);
+            }
+        }
+
+        response
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────
+
+fn render_one(
+    ui: &mut Ui,
+    row: &CollectionRow,
+    layout: CollectionListLayout,
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+    response: &mut CollectionListResponse,
+) {
+    match layout {
+        CollectionListLayout::Card => render_card(ui, row, show_test_mint, show_seed_stubs, response),
+        CollectionListLayout::List => render_list_row(ui, row, show_test_mint, show_seed_stubs, response),
+    }
+}
+
+fn render_card(
+    ui: &mut Ui,
+    row: &CollectionRow,
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+    response: &mut CollectionListResponse,
+) {
+    Frame::new()
+        .fill(ROW_BG)
+        .stroke(Stroke::new(1.0, ROW_STROKE))
+        .corner_radius(CornerRadius::same(8))
+        .inner_margin(Margin::symmetric(14, 12))
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width());
+
+            // ── Title row: title + chips + (right) action buttons ──
+            ui.horizontal(|ui| {
+                ui.label(RichText::new(&row.title).heading());
+
+                // Status chip — filled tag using the status colour. The
+                // chip is the strongest secondary signal after the title,
+                // so it sits closest to it.
+                status_chip(ui, &row.status);
+                standard_chip(ui, &row.standard);
+                network_chip(ui, &row.network);
+
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        if show_test_mint {
+                            let label = if row.test_mint_open {
+                                "− Test mint"
+                            } else {
+                                "🧪 Test mint"
+                            };
+                            if ui
+                                .small_button(RichText::new(label).small())
+                                .on_hover_text(
+                                    "Open the test-mint form for this collection \
+                                     (operator/super-admin only)",
+                                )
+                                .clicked()
+                            {
+                                response.actions.push(CollectionListAction::TestMint {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                        if show_seed_stubs {
+                            let label = if row.seed_stubs_open {
+                                "− Seed stubs"
+                            } else {
+                                "+ Seed stubs"
+                            };
+                            if ui
+                                .small_button(RichText::new(label).small())
+                                .on_hover_text(
+                                    "Seed placeholder mintable assets \
+                                     (testing-only — real ingest replaces this)",
+                                )
+                                .clicked()
+                            {
+                                response.actions.push(CollectionListAction::SeedStubs {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                    },
+                );
+            });
+
+            ui.add_space(8.0);
+
+            // ── Supply: text + progress bar ──────────────────────────
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(format!("{} / {}", row.minted_count, row.total_supply))
+                        .monospace()
+                        .small()
+                        .color(META_GREY),
+                );
+                let pct = if row.total_supply == 0 {
+                    0.0
+                } else {
+                    (row.minted_count as f32 / row.total_supply as f32).clamp(0.0, 1.0)
+                };
+                let label = if pct >= 1.0 {
+                    "minted out".to_string()
+                } else {
+                    format!("{:.0}%", pct * 100.0)
+                };
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        ui.label(RichText::new(label).small().color(KEYHASH_GREY));
+                    },
+                );
+            });
+
+            // Thin progress bar — caps at the surface width so it
+            // mirrors the card chrome.
+            ui.add_space(2.0);
+            let bar_fill_colour = if row.status == "live" {
+                BAR_FILL_LIVE
+            } else {
+                BAR_FILL_NEUTRAL
+            };
+            let pct = if row.total_supply == 0 {
+                0.0
+            } else {
+                (row.minted_count as f32 / row.total_supply as f32).clamp(0.0, 1.0)
+            };
+            draw_thin_bar(ui, pct, bar_fill_colour);
+
+            ui.add_space(10.0);
+
+            // ── Footer: wallet ref + policy_id + copy ───────────────
+            ui.horizontal(|ui| {
+                // wallet #N — clickable. The link surfaces the
+                // collection ↔ wallet relationship; clicking opens
+                // that wallet's UTxO panel (parent handles the wiring).
+                let wallet_text = format!("wallet #{}", row.wallet_account_index);
+                if ui
+                    .small_button(RichText::new(wallet_text).small().color(META_GREY))
+                    .on_hover_text("Open this wallet's UTxOs")
+                    .clicked()
+                {
+                    response.actions.push(CollectionListAction::OpenWallet {
+                        account_index: row.wallet_account_index,
+                    });
+                }
+                ui.label(
+                    RichText::new("·")
+                        .color(KEYHASH_GREY)
+                        .monospace()
+                        .small(),
+                );
+                ui.label(
+                    RichText::new(&row.policy_id_short)
+                        .monospace()
+                        .small()
+                        .color(KEYHASH_GREY),
+                );
+                if ui
+                    .small_button(RichText::new("📋").small())
+                    .on_hover_text("Copy policy_id to clipboard")
+                    .clicked()
+                {
+                    ui.ctx().copy_text(row.policy_id.clone());
+                }
+            });
+        });
+}
+
+fn render_list_row(
+    ui: &mut Ui,
+    row: &CollectionRow,
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+    response: &mut CollectionListResponse,
+) {
+    Frame::new()
+        .fill(ROW_BG)
+        .stroke(Stroke::new(1.0, ROW_STROKE))
+        .corner_radius(CornerRadius::same(4))
+        .inner_margin(Margin::symmetric(10, 7))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(RichText::new(&row.title).strong());
+                status_chip(ui, &row.status);
+                ui.label(
+                    RichText::new(format!("{}/{}", row.minted_count, row.total_supply))
+                        .monospace()
+                        .small()
+                        .color(META_GREY),
+                );
+                standard_chip(ui, &row.standard);
+                network_chip(ui, &row.network);
+                ui.label(
+                    RichText::new(format!(
+                        "wallet #{} · {}",
+                        row.wallet_account_index, row.policy_id_short
+                    ))
+                    .color(KEYHASH_GREY)
+                    .monospace()
+                    .small(),
+                );
+
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        if show_test_mint {
+                            let label = if row.test_mint_open {
+                                "− Test mint"
+                            } else {
+                                "🧪 Test mint"
+                            };
+                            if ui.small_button(RichText::new(label).small()).clicked() {
+                                response.actions.push(CollectionListAction::TestMint {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                        if show_seed_stubs {
+                            let label = if row.seed_stubs_open {
+                                "− Seed stubs"
+                            } else {
+                                "+ Seed stubs"
+                            };
+                            if ui.small_button(RichText::new(label).small()).clicked() {
+                                response.actions.push(CollectionListAction::SeedStubs {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                        if ui
+                            .small_button(RichText::new("📋").small())
+                            .on_hover_text("Copy policy_id to clipboard")
+                            .clicked()
+                        {
+                            ui.ctx().copy_text(row.policy_id.clone());
+                        }
+                    },
+                );
+            });
+        });
+}
+
+/// Filled chip with the status text in uppercase. Colour mirrors the
+/// portal's previous `status_colour()` helper.
+fn status_chip(ui: &mut Ui, status: &str) {
+    let (fg, bg) = status_chip_colours(status);
+    chip(ui, &status.to_uppercase(), fg, bg);
+}
+
+fn standard_chip(ui: &mut Ui, standard: &str) {
+    let colour = match standard.to_ascii_lowercase().as_str() {
+        "cip25" => STD_CIP25_CHIP,
+        "cip68" => STD_CIP68_CHIP,
+        _ => STD_UNKNOWN_CHIP,
+    };
+    chip(ui, &standard.to_uppercase(), Color32::from_rgb(20, 20, 30), colour);
+}
+
+fn network_chip(ui: &mut Ui, network: &str) {
+    // `cardano:preprod` → `preprod`, `cardano:mainnet` → `mainnet`.
+    let trimmed = network
+        .strip_prefix("cardano:")
+        .unwrap_or(network)
+        .to_uppercase();
+    chip(ui, &trimmed, Color32::WHITE, NETWORK_CHIP);
+}
+
+fn chip(ui: &mut Ui, text: &str, fg: Color32, bg: Color32) {
+    Frame::new()
+        .fill(bg)
+        .corner_radius(CornerRadius::same(3))
+        .inner_margin(Margin::symmetric(6, 1))
+        .show(ui, |ui| {
+            ui.label(RichText::new(text).color(fg).small().strong());
+        });
+}
+
+/// Status-to-chip-colour palette. Foreground is dark-on-light for the
+/// vibrant statuses (live / ready / ingesting / sold_out), light-on-dark
+/// for the neutral ones (draft / paused / ended). Same RGB values as the
+/// portal's previous `status_colour()` helper.
+fn status_chip_colours(status: &str) -> (Color32, Color32) {
+    match status {
+        "draft" => (Color32::from_rgb(20, 20, 30), Color32::from_gray(170)),
+        "ingesting" => (
+            Color32::from_rgb(20, 20, 30),
+            Color32::from_rgb(180, 180, 220),
+        ),
+        "ready" => (
+            Color32::from_rgb(20, 20, 30),
+            Color32::from_rgb(180, 220, 220),
+        ),
+        "live" => (Color32::from_rgb(20, 20, 30), Color32::LIGHT_GREEN),
+        "paused" => (Color32::from_rgb(20, 20, 30), Color32::LIGHT_YELLOW),
+        "sold_out" => (
+            Color32::from_rgb(20, 20, 30),
+            Color32::from_rgb(220, 180, 240),
+        ),
+        "ended" => (Color32::WHITE, Color32::from_gray(140)),
+        _ => (Color32::from_rgb(20, 20, 30), Color32::from_gray(160)),
+    }
+}
+
+/// Thin horizontal progress bar — 4 px tall, full surface width.
+fn draw_thin_bar(ui: &mut Ui, pct: f32, fill: Color32) {
+    let height = 4.0;
+    let (rect, _) =
+        ui.allocate_exact_size(egui::vec2(ui.available_width(), height), egui::Sense::hover());
+    let painter = ui.painter();
+    let corner = CornerRadius::same(2);
+    painter.rect_filled(rect, corner, BAR_TRACK);
+    if pct > 0.0 {
+        let mut filled = rect;
+        filled.set_width(rect.width() * pct);
+        painter.rect_filled(filled, corner, fill);
+    }
+}

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -105,6 +105,9 @@ pub struct CollectionRow {
     /// `true` when the parent has the Seed-stubs form open below this
     /// row. Same toggle treatment as `test_mint_open`.
     pub seed_stubs_open: bool,
+    /// `true` when the parent has the Activity panel open below this
+    /// row. Same toggle treatment as the form-open flags.
+    pub activity_open: bool,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -116,6 +119,9 @@ pub enum CollectionListAction {
     TestMint { policy_id: String },
     /// User clicked the Seed-stubs toggle. Same as above.
     SeedStubs { policy_id: String },
+    /// User clicked the Activity toggle — open/close the recent-mint
+    /// activity panel for this `policy_id`.
+    Activity { policy_id: String },
     /// User clicked the `wallet #N` link in the footer. Parent opens
     /// that wallet's UTxO panel (or whatever it does for wallet focus).
     OpenWallet { account_index: u32 },
@@ -141,6 +147,7 @@ pub struct CollectionList<'a> {
     columns: usize,
     show_test_mint: bool,
     show_seed_stubs: bool,
+    show_activity: bool,
 }
 
 /// Response — drained actions for this frame.
@@ -186,6 +193,7 @@ impl<'a> CollectionList<'a> {
             columns: 1,
             show_test_mint: false,
             show_seed_stubs: false,
+            show_activity: false,
         }
     }
 
@@ -222,6 +230,15 @@ impl<'a> CollectionList<'a> {
         self
     }
 
+    /// Show the per-card "Activity" toggle. Off by default. Click → emits
+    /// [`CollectionListAction::Activity`]; host opens/closes the recent
+    /// mint-activity panel below the card and polls
+    /// `PortalAction::FetchMintActivity` while open.
+    pub fn with_activity(mut self, enabled: bool) -> Self {
+        self.show_activity = enabled;
+        self
+    }
+
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
@@ -249,6 +266,7 @@ impl<'a> CollectionList<'a> {
                         self.layout,
                         self.show_test_mint,
                         self.show_seed_stubs,
+                        self.show_activity,
                         &mut response,
                     );
                 }
@@ -261,6 +279,7 @@ impl<'a> CollectionList<'a> {
                             self.layout,
                             self.show_test_mint,
                             self.show_seed_stubs,
+                            self.show_activity,
                             &mut response,
                         );
                     }
@@ -279,17 +298,33 @@ impl<'a> CollectionList<'a> {
 // Internals
 // ─────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)]
 fn render_one(
     ui: &mut Ui,
     row: &CollectionRow,
     layout: CollectionListLayout,
     show_test_mint: bool,
     show_seed_stubs: bool,
+    show_activity: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
-        CollectionListLayout::Card => render_card(ui, row, show_test_mint, show_seed_stubs, response),
-        CollectionListLayout::List => render_list_row(ui, row, show_test_mint, show_seed_stubs, response),
+        CollectionListLayout::Card => render_card(
+            ui,
+            row,
+            show_test_mint,
+            show_seed_stubs,
+            show_activity,
+            response,
+        ),
+        CollectionListLayout::List => render_list_row(
+            ui,
+            row,
+            show_test_mint,
+            show_seed_stubs,
+            show_activity,
+            response,
+        ),
     }
 }
 
@@ -298,6 +333,7 @@ fn render_card(
     row: &CollectionRow,
     show_test_mint: bool,
     show_seed_stubs: bool,
+    show_activity: bool,
     response: &mut CollectionListResponse,
 ) {
     Frame::new()
@@ -356,6 +392,25 @@ fn render_card(
                                 .clicked()
                             {
                                 response.actions.push(CollectionListAction::SeedStubs {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                        if show_activity {
+                            let label = if row.activity_open {
+                                "− Activity"
+                            } else {
+                                "📜 Activity"
+                            };
+                            if ui
+                                .small_button(RichText::new(label).small())
+                                .on_hover_text(
+                                    "Recent mint activity for this collection — \
+                                     fetched from the engine's mint_log",
+                                )
+                                .clicked()
+                            {
+                                response.actions.push(CollectionListAction::Activity {
                                     policy_id: row.policy_id.clone(),
                                 });
                             }
@@ -452,6 +507,7 @@ fn render_list_row(
     row: &CollectionRow,
     show_test_mint: bool,
     show_seed_stubs: bool,
+    show_activity: bool,
     response: &mut CollectionListResponse,
 ) {
     Frame::new()
@@ -504,6 +560,18 @@ fn render_list_row(
                             };
                             if ui.small_button(RichText::new(label).small()).clicked() {
                                 response.actions.push(CollectionListAction::SeedStubs {
+                                    policy_id: row.policy_id.clone(),
+                                });
+                            }
+                        }
+                        if show_activity {
+                            let label = if row.activity_open {
+                                "− Activity"
+                            } else {
+                                "📜 Activity"
+                            };
+                            if ui.small_button(RichText::new(label).small()).clicked() {
+                                response.actions.push(CollectionListAction::Activity {
                                     policy_id: row.policy_id.clone(),
                                 });
                             }

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -106,7 +106,8 @@ pub use wallet_identity_header::{
     truncate_stake, WalletIdentityAction, WalletIdentityConfig, WalletIdentityHeader,
 };
 pub use wallet_list::{
-    WalletList, WalletListAction, WalletListResponse, WalletListRole, WalletListRow,
+    WalletList, WalletListAction, WalletListLayout, WalletListResponse, WalletListRole,
+    WalletListRow,
 };
 pub use pip_row::{
     HoverInfo, HoveredBin, HoveredPip, Pip, PipRowConfig, PipRowData, PipRowResponse,

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -112,7 +112,7 @@ pub use collection_list::{
 };
 pub use wallet_list::{
     WalletList, WalletListAction, WalletListLayout, WalletListResponse, WalletListRole,
-    WalletListRow,
+    WalletListRow, WalletPoolBadge, WalletPoolBadgeHealth,
 };
 pub use pip_row::{
     HoverInfo, HoveredBin, HoveredPip, Pip, PipRowConfig, PipRowData, PipRowResponse,

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -4,6 +4,7 @@ pub mod animated_counter;
 pub mod asset_card;
 pub mod buttons;
 pub mod card_browser;
+pub mod collection_list;
 pub mod donut_chart;
 #[cfg(target_arch = "wasm32")]
 pub mod file_upload;
@@ -104,6 +105,10 @@ pub use metric_card::{MetricCard, Trend};
 pub use persona_strip::{PersonaStrip, PersonaStripConfig};
 pub use wallet_identity_header::{
     truncate_stake, WalletIdentityAction, WalletIdentityConfig, WalletIdentityHeader,
+};
+pub use collection_list::{
+    CollectionList, CollectionListAction, CollectionListLayout, CollectionListResponse,
+    CollectionRow,
 };
 pub use wallet_list::{
     WalletList, WalletListAction, WalletListLayout, WalletListResponse, WalletListRole,

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -31,6 +31,7 @@ pub mod theme;
 pub mod trait_filter;
 pub mod utils;
 pub mod wallet_identity_header;
+pub mod wallet_list;
 #[cfg(all(target_arch = "wasm32", feature = "cardano"))]
 pub mod wallet;
 #[cfg(all(target_arch = "wasm32", feature = "cardano"))]
@@ -103,6 +104,9 @@ pub use metric_card::{MetricCard, Trend};
 pub use persona_strip::{PersonaStrip, PersonaStripConfig};
 pub use wallet_identity_header::{
     truncate_stake, WalletIdentityAction, WalletIdentityConfig, WalletIdentityHeader,
+};
+pub use wallet_list::{
+    WalletList, WalletListAction, WalletListResponse, WalletListRole, WalletListRow,
 };
 pub use pip_row::{
     HoverInfo, HoveredBin, HoveredPip, Pip, PipRowConfig, PipRowData, PipRowResponse,

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -16,6 +16,7 @@ pub mod image_loader;
 pub mod listing_grid;
 pub mod marquee;
 pub mod metric_card;
+pub mod mnemonic_display;
 pub mod persona_strip;
 pub mod pip_row;
 pub mod printing_timeline;

--- a/ui/egui-widgets/src/mnemonic_display.rs
+++ b/ui/egui-widgets/src/mnemonic_display.rs
@@ -1,0 +1,205 @@
+//! BIP-39 mnemonic display with copy-to-clipboard + optional confirmation gate.
+//!
+//! Designed for the moment-of-truth UX where the platform hands a fresh
+//! mnemonic to a client EXACTLY ONCE — provisioning a new client wallet,
+//! GDPR Art. 20 export, etc. Visual emphasis on sensitivity:
+//!
+//! - the words sit on a dark inset card with a warning header
+//! - the copy CTA is a single button (operator types nothing)
+//! - a confirmation checkbox can gate dismissal until the user explicitly
+//!   acknowledges they've recorded the phrase
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! // Minimum — just display + copy:
+//! let out = MnemonicDisplay::new(&mnemonic).show(ui);
+//! if out.copy_clicked { /* feedback */ }
+//!
+//! // With confirmation gate:
+//! let mut confirmed = false;
+//! let out = MnemonicDisplay::new(&mnemonic)
+//!     .with_confirmation(&mut confirmed)
+//!     .show(ui);
+//! if confirmed { /* let the user click "Continue" */ }
+//! ```
+//!
+//! The widget owns no state across frames; the caller persists the bool
+//! it passes to [`with_confirmation`]. That keeps the widget composable
+//! with parent dialogs / modals that already manage flow state.
+
+use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
+
+/// Layout settings the consumer can tweak before rendering.
+#[derive(Debug, Clone, Copy)]
+pub struct MnemonicDisplayStyle {
+    /// Number of columns in the words grid. v1 default: 4 (works for 12 / 16 /
+    /// 20 / 24 word phrases; renders any other count with a ragged last row).
+    pub columns: usize,
+    /// Width allocated to each word cell. Constrains the widget so it
+    /// doesn't grow unboundedly inside a wide parent.
+    pub cell_width: f32,
+    /// Show the warning banner above the words. On by default — turn off
+    /// only if the parent already carries equivalent messaging.
+    pub show_warning: bool,
+}
+
+impl Default for MnemonicDisplayStyle {
+    fn default() -> Self {
+        Self {
+            columns: 4,
+            cell_width: 110.0,
+            show_warning: true,
+        }
+    }
+}
+
+/// Builder for the mnemonic display.
+pub struct MnemonicDisplay<'a> {
+    mnemonic: &'a str,
+    confirmed: Option<&'a mut bool>,
+    style: MnemonicDisplayStyle,
+}
+
+impl<'a> MnemonicDisplay<'a> {
+    /// Construct a display with default styling. `mnemonic` is the
+    /// whitespace-separated BIP-39 phrase; the widget splits it into words
+    /// without validating word count or BIP-39 wordlist membership (caller
+    /// is responsible for handing us a valid phrase).
+    pub fn new(mnemonic: &'a str) -> Self {
+        Self {
+            mnemonic,
+            confirmed: None,
+            style: MnemonicDisplayStyle::default(),
+        }
+    }
+
+    /// Render a confirmation checkbox below the words. When the user ticks
+    /// it, `*confirmed` becomes `true`. Parent flow gates "Continue" on
+    /// this. Skip the call to render without a checkbox at all.
+    pub fn with_confirmation(mut self, confirmed: &'a mut bool) -> Self {
+        self.confirmed = Some(confirmed);
+        self
+    }
+
+    /// Override the layout style.
+    pub fn with_style(mut self, style: MnemonicDisplayStyle) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub fn show(self, ui: &mut Ui) -> MnemonicDisplayOutput {
+        let words: Vec<&str> = self.mnemonic.split_whitespace().collect();
+        let style = self.style;
+
+        let mut output = MnemonicDisplayOutput::default();
+
+        // ── Warning banner ───────────────────────────────────────────────
+        if style.show_warning {
+            Frame::new()
+                .fill(Color32::from_rgb(50, 35, 10))
+                .stroke(Stroke::new(1.0, Color32::from_rgb(180, 140, 60)))
+                .corner_radius(CornerRadius::same(4))
+                .inner_margin(Margin::symmetric(12, 8))
+                .show(ui, |ui| {
+                    ui.label(
+                        RichText::new("⚠  This phrase is shown ONCE. Write it down.")
+                            .color(Color32::from_rgb(240, 210, 140))
+                            .strong(),
+                    );
+                    ui.label(
+                        RichText::new(
+                            "Anyone with these words controls the wallet. Store offline; \
+                             never paste into chat, email, or screenshots.",
+                        )
+                        .color(Color32::from_rgb(200, 180, 140))
+                        .small(),
+                    );
+                });
+            ui.add_space(10.0);
+        }
+
+        // ── Words grid ───────────────────────────────────────────────────
+        Frame::new()
+            .fill(Color32::from_rgb(16, 16, 24))
+            .stroke(Stroke::new(1.0, Color32::from_rgb(40, 40, 56)))
+            .corner_radius(CornerRadius::same(6))
+            .inner_margin(Margin::same(14))
+            .show(ui, |ui| {
+                let cols = style.columns.max(1);
+                let rows = words.len().div_ceil(cols);
+                for r in 0..rows {
+                    ui.horizontal(|ui| {
+                        for c in 0..cols {
+                            let idx = r * cols + c;
+                            if let Some(word) = words.get(idx) {
+                                render_word_cell(ui, idx + 1, word, style.cell_width);
+                            }
+                        }
+                    });
+                }
+            });
+
+        ui.add_space(10.0);
+
+        // ── Copy + confirm row ───────────────────────────────────────────
+        ui.horizontal(|ui| {
+            let copy_resp = ui.button("📋  Copy to clipboard");
+            if copy_resp.clicked() {
+                ui.ctx().copy_text(self.mnemonic.to_string());
+                output.copy_clicked = true;
+            }
+            ui.label(
+                RichText::new(
+                    "(prefer writing it down — clipboard contents can leak to other apps)",
+                )
+                .color(Color32::from_gray(140))
+                .small(),
+            );
+        });
+
+        if let Some(confirmed) = self.confirmed {
+            ui.add_space(8.0);
+            ui.checkbox(
+                confirmed,
+                RichText::new("I have securely recorded this recovery phrase")
+                    .strong(),
+            );
+            output.confirmed = *confirmed;
+        }
+
+        output
+    }
+}
+
+/// What happened while the widget was on screen this frame. Caller drives
+/// parent-level flow off these (e.g. show a "Copied!" toast when
+/// `copy_clicked` flips true; enable "Continue" button when `confirmed`).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MnemonicDisplayOutput {
+    /// User clicked the copy button this frame.
+    pub copy_clicked: bool,
+    /// User has the confirmation checkbox ticked. Always `false` if the
+    /// caller didn't supply [`MnemonicDisplay::with_confirmation`].
+    pub confirmed: bool,
+}
+
+fn render_word_cell(ui: &mut Ui, number: usize, word: &str, width: f32) {
+    Frame::new()
+        .fill(Color32::from_rgb(24, 24, 36))
+        .stroke(Stroke::new(1.0, Color32::from_rgb(50, 50, 70)))
+        .corner_radius(CornerRadius::same(3))
+        .inner_margin(Margin::symmetric(8, 5))
+        .show(ui, |ui| {
+            ui.set_min_width(width);
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(format!("{number:>2}."))
+                        .color(Color32::from_gray(120))
+                        .monospace()
+                        .small(),
+                );
+                ui.label(RichText::new(word).monospace().strong());
+            });
+        });
+}

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -26,11 +26,24 @@
 //! - **No add-wallet form.** That stays as a parent-owned inline form
 //!   immediately below the list (see `app.rs::render_client_detail`).
 //!
+//! ## Layouts
+//!
+//! Two presentations driven from the same `WalletListRow` VM:
+//!
+//! - [`WalletListLayout::List`] (default) — compact one-row-per-wallet,
+//!   used today by the portal's main dashboard.
+//! - [`WalletListLayout::Card`] — taller tiles with a filled role pill,
+//!   a heading-sized label, and a footer line for the address. Better
+//!   when wallet identity is the focal element (e.g. an "Identities &
+//!   wallets" sub-page); leaves room for future per-card slots (balance,
+//!   collection count) without re-doing the layout.
+//!
 //! ## Usage
 //!
 //! ```ignore
 //! let rows: Vec<WalletListRow> = detail.wallets.iter().map(to_vm).collect();
 //! let resp = WalletList::new(&rows)
+//!     .with_layout(WalletListLayout::Card)
 //!     .with_can_archive_primary(false)
 //!     .show(ui);
 //! for action in resp.actions {
@@ -100,9 +113,25 @@ pub enum WalletListAction {
     Archive { account_index: u32 },
 }
 
+/// Rendering style. Both styles share the same row VM, bucketing, and
+/// action emission — only the per-row geometry differs.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WalletListLayout {
+    /// Compact horizontal row (default). Scannable when many wallets are
+    /// on screen — the current portal dashboard look.
+    #[default]
+    List,
+    /// Taller tile with a filled role pill, large title, and the address
+    /// on a dedicated footer line. Good when wallet identity is the
+    /// focal element rather than one entry in a long list.
+    Card,
+}
+
 /// Builder.
 pub struct WalletList<'a> {
     rows: &'a [WalletListRow],
+    layout: WalletListLayout,
+    columns: usize,
     can_archive_primary: bool,
     show_section_headers_for_single: bool,
 }
@@ -135,9 +164,28 @@ impl<'a> WalletList<'a> {
     pub fn new(rows: &'a [WalletListRow]) -> Self {
         Self {
             rows,
+            layout: WalletListLayout::default(),
+            columns: 1,
             can_archive_primary: false,
             show_section_headers_for_single: false,
         }
+    }
+
+    /// Switch the per-row presentation. See [`WalletListLayout`].
+    pub fn with_layout(mut self, layout: WalletListLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
+    /// Lay rows out as a grid this many columns wide. Default `1`
+    /// (single-column stack). Per-bucket clamped to `min(cols,
+    /// rows_in_bucket)` so a one-wallet bucket (e.g. Primary) still uses
+    /// the full surface width when the configured count would otherwise
+    /// leave dead space. Set to 2–3 for card layouts on wide surfaces;
+    /// list mode tolerates 2 cols, more than that crowds the address.
+    pub fn with_columns(mut self, cols: usize) -> Self {
+        self.columns = cols.max(1);
+        self
     }
 
     /// Override the safety default and allow the Primary row to be
@@ -184,6 +232,8 @@ impl<'a> WalletList<'a> {
             "Primary",
             &primary,
             show_headers,
+            self.layout,
+            self.columns,
             self.can_archive_primary,
             &mut response,
         );
@@ -199,6 +249,8 @@ impl<'a> WalletList<'a> {
             "Collections",
             &collections,
             show_headers,
+            self.layout,
+            self.columns,
             /* allow_archive = */ true,
             &mut response,
         );
@@ -212,6 +264,8 @@ impl<'a> WalletList<'a> {
             "Custom",
             &custom,
             show_headers,
+            self.layout,
+            self.columns,
             /* allow_archive = */ true,
             &mut response,
         );
@@ -224,11 +278,15 @@ impl<'a> WalletList<'a> {
 // Internals
 // ─────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::too_many_arguments)] // honest set of knobs; bundling them
+                                     // into a struct would just move the args.
 fn render_bucket(
     ui: &mut Ui,
     title: &str,
     rows: &[&WalletListRow],
     show_header: bool,
+    layout: WalletListLayout,
+    columns: usize,
     allow_archive: bool,
     response: &mut WalletListResponse,
 ) {
@@ -254,9 +312,56 @@ fn render_bucket(
         ui.add_space(4.0);
     }
 
-    for r in rows {
-        render_row(ui, r, allow_archive, response);
-        ui.add_space(4.0);
+    // Card mode wants a touch more breathing room between tiles than the
+    // dense list mode does.
+    let gap = match layout {
+        WalletListLayout::List => 4.0,
+        WalletListLayout::Card => 8.0,
+    };
+
+    // Per-bucket clamp: a 1-row bucket (Primary) renders full-width even
+    // when the caller asked for 2+ columns; a 5-row bucket honours the
+    // configured grid. Keeps each bucket from leaving empty trailing
+    // columns that look like a layout bug.
+    let effective_cols = columns.min(rows.len()).max(1);
+
+    let chunks: Vec<&[&WalletListRow]> = rows.chunks(effective_cols).collect();
+    let last_chunk = chunks.len().saturating_sub(1);
+    for (chunk_idx, chunk) in chunks.iter().enumerate() {
+        if effective_cols == 1 {
+            // Single-column — render directly into the bucket's UI, no
+            // nested `ui.columns` wrapper (which would add layout cost
+            // for zero visual gain).
+            for r in chunk.iter() {
+                render_one(ui, r, layout, allow_archive, response);
+            }
+        } else {
+            // Multi-column — split into `effective_cols` equal sub-UIs.
+            // The last chunk may be short; the closure simply doesn't
+            // touch the trailing columns and they stay empty (preserves
+            // grid alignment with cells above).
+            ui.columns(effective_cols, |cols| {
+                for (i, r) in chunk.iter().enumerate() {
+                    render_one(&mut cols[i], r, layout, allow_archive, response);
+                }
+            });
+        }
+        if chunk_idx < last_chunk {
+            ui.add_space(gap);
+        }
+    }
+}
+
+fn render_one(
+    ui: &mut Ui,
+    row: &WalletListRow,
+    layout: WalletListLayout,
+    allow_archive: bool,
+    response: &mut WalletListResponse,
+) {
+    match layout {
+        WalletListLayout::List => render_row(ui, row, allow_archive, response),
+        WalletListLayout::Card => render_card(ui, row, allow_archive, response),
     }
 }
 
@@ -364,6 +469,120 @@ fn render_row(
                         );
                     },
                 );
+            });
+        });
+}
+
+fn render_card(
+    ui: &mut Ui,
+    row: &WalletListRow,
+    allow_archive: bool,
+    response: &mut WalletListResponse,
+) {
+    let archived = row.archived_at.is_some();
+    let (fill, stroke) = match (row.role, archived) {
+        (_, true) => (ROW_BG_ARCHIVED, ROW_STROKE),
+        (WalletListRole::Primary, false) => (ROW_BG_PRIMARY, ROW_STROKE_PRIMARY),
+        _ => (ROW_BG, ROW_STROKE),
+    };
+    let (role_text, role_colour) = match row.role {
+        WalletListRole::Primary => ("PRIMARY", ROLE_PRIMARY_CHIP),
+        WalletListRole::Collection => ("COLLECTION", ROLE_COLLECTION_CHIP),
+        WalletListRole::Custom => ("CUSTOM", ROLE_CUSTOM_CHIP),
+    };
+
+    Frame::new()
+        .fill(fill)
+        .stroke(Stroke::new(1.0, stroke))
+        .corner_radius(CornerRadius::same(8))
+        .inner_margin(Margin::symmetric(14, 12))
+        .show(ui, |ui| {
+            // Take the full available width — when laid out in a grid the
+            // parent column already constrains us; when single-column we
+            // grow to the surface width.
+            ui.set_width(ui.available_width());
+
+            // ── Title row: label + #N + role pill + meta chips,
+            //    right-aligned archive button ──────────────────────────
+            //
+            // Role is co-located with name + number (no banner above) so
+            // the strongest visual cue is the *identity*, with role
+            // qualifying it. Archive lives at the far right.
+            ui.horizontal(|ui| {
+                let title = RichText::new(&row.label).heading();
+                let title = if archived { title.color(META_GREY) } else { title };
+                ui.label(title);
+                ui.label(
+                    RichText::new(format!("#{}", row.account_index))
+                        .monospace()
+                        .color(META_GREY),
+                );
+
+                // Filled role pill — same palette as the inline list
+                // chip but with a stronger background so it reads as a
+                // proper tag rather than coloured text.
+                Frame::new()
+                    .fill(role_colour)
+                    .corner_radius(CornerRadius::same(3))
+                    .inner_margin(Margin::symmetric(7, 1))
+                    .show(ui, |ui| {
+                        ui.label(
+                            RichText::new(role_text)
+                                .color(Color32::from_rgb(20, 20, 30))
+                                .small()
+                                .strong(),
+                        );
+                    });
+
+                if row.auto_created && row.role != WalletListRole::Collection {
+                    ui.colored_label(META_GREY, RichText::new("auto").small());
+                }
+                if archived {
+                    ui.colored_label(
+                        Color32::LIGHT_YELLOW,
+                        RichText::new("archived").small(),
+                    );
+                }
+
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        let can_archive = !archived
+                            && (row.role != WalletListRole::Primary || allow_archive);
+                        if can_archive
+                            && ui
+                                .small_button(RichText::new("Archive").small())
+                                .on_hover_text(
+                                    "Soft-delete this wallet (reversible — historical \
+                                     collections still resolve their key_hash)",
+                                )
+                                .clicked()
+                        {
+                            response.actions.push(WalletListAction::Archive {
+                                account_index: row.account_index,
+                            });
+                        }
+                    },
+                );
+            });
+
+            ui.add_space(8.0);
+
+            // ── Footer: address + copy ─────────────────────────────
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(&row.address_short)
+                        .monospace()
+                        .color(KEYHASH_GREY),
+                );
+                if let Some(full) = &row.address_full {
+                    let copy = ui
+                        .small_button(RichText::new("📋").small())
+                        .on_hover_text("Copy address to clipboard");
+                    if copy.clicked() {
+                        ui.ctx().copy_text(full.clone());
+                    }
+                }
             });
         });
 }

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -73,6 +73,28 @@ pub enum WalletListRole {
     Custom,
 }
 
+/// Optional pool-health pill rendered on the wallet card. Set on rows
+/// whose UTxOs have been fetched at least once; absent on rows where the
+/// host hasn't refreshed (the card doesn't gain a "no data" badge — it
+/// simply doesn't render the pill). The widget renders fuel count +
+/// total ADA + a coloured dot for the health bucket.
+#[derive(Clone, Debug)]
+pub struct WalletPoolBadge {
+    pub fuel_count: u32,
+    pub total_lovelace: u64,
+    pub health: WalletPoolBadgeHealth,
+}
+
+/// Health bucket — a local enum so the widget crate stays
+/// shared-types-free. Hosts map their canonical
+/// `WalletPoolHealth` to this at the VM boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalletPoolBadgeHealth {
+    Empty,
+    Low,
+    Healthy,
+}
+
 /// View-model for a single wallet row. Pre-formatted by the caller — the
 /// widget does no truncation itself.
 #[derive(Clone, Debug)]
@@ -99,6 +121,10 @@ pub struct WalletListRow {
     /// Unix seconds of archive, or `None` if active. Archived rows render
     /// dimmed with an "archived" chip.
     pub archived_at: Option<i64>,
+    /// Optional fuel-pool summary. Rendered as a single-line inline pill
+    /// below the address: `🟢 20 fuel · 230 ADA`. `None` → no pill (the
+    /// host hasn't refreshed UTxOs for this wallet yet).
+    pub pool: Option<WalletPoolBadge>,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -111,6 +137,10 @@ pub enum WalletListAction {
     /// [`WalletList::with_can_archive_primary`] is left at the default
     /// `false`, so the parent doesn't need to defend against it again.
     Archive { account_index: u32 },
+    /// User clicked the Restore button on an archived row. Symmetric
+    /// to [`Archive`]; only emitted from archived rows (the widget
+    /// swaps Archive ↔ Restore based on `archived_at`).
+    Unarchive { account_index: u32 },
     /// User clicked the "View UTxOs" button on a row. Only emitted
     /// when [`WalletList::with_view_button`] is `true`; the parent
     /// owns the panel state (toggle / refresh / cache) and the
@@ -449,21 +479,36 @@ fn render_row(
                 ui.with_layout(
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
-                        // Archive button — placed first because of the
-                        // right-to-left layout (it ends up rightmost).
-                        // Hidden for Primary (unless explicitly enabled)
-                        // and already-archived rows.
-                        let can_archive = !archived
-                            && (row.role != WalletListRole::Primary || allow_archive);
-                        if can_archive {
-                            let clicked = ui
-                                .small_button(RichText::new("Archive").small())
+                        // Archive ↔ Restore — placed first because of
+                        // the right-to-left layout (ends up rightmost).
+                        // Archive hidden for Primary (unless explicitly
+                        // enabled). Restore appears only on archived
+                        // rows; clicking flips the wallet back to active.
+                        if archived {
+                            if ui
+                                .small_button(RichText::new("Restore").small())
                                 .on_hover_text(
-                                    "Soft-delete this wallet (reversible — historical \
-                                     collections still resolve their key_hash)",
+                                    "Bring this wallet back from archived. \
+                                     Clears `archived_at`; no key material touched.",
                                 )
-                                .clicked();
-                            if clicked {
+                                .clicked()
+                            {
+                                response.actions.push(WalletListAction::Unarchive {
+                                    account_index: row.account_index,
+                                });
+                            }
+                        } else {
+                            let can_archive =
+                                row.role != WalletListRole::Primary || allow_archive;
+                            if can_archive
+                                && ui
+                                    .small_button(RichText::new("Archive").small())
+                                    .on_hover_text(
+                                        "Soft-delete this wallet (reversible — historical \
+                                         collections still resolve their key_hash)",
+                                    )
+                                    .clicked()
+                            {
                                 response.actions.push(WalletListAction::Archive {
                                     account_index: row.account_index,
                                 });
@@ -586,20 +631,35 @@ fn render_card(
                 ui.with_layout(
                     egui::Layout::right_to_left(egui::Align::Center),
                     |ui| {
-                        let can_archive = !archived
-                            && (row.role != WalletListRole::Primary || allow_archive);
-                        if can_archive
-                            && ui
-                                .small_button(RichText::new("Archive").small())
+                        if archived {
+                            if ui
+                                .small_button(RichText::new("Restore").small())
                                 .on_hover_text(
-                                    "Soft-delete this wallet (reversible — historical \
-                                     collections still resolve their key_hash)",
+                                    "Bring this wallet back from archived. \
+                                     Clears `archived_at`; no key material touched.",
                                 )
                                 .clicked()
-                        {
-                            response.actions.push(WalletListAction::Archive {
-                                account_index: row.account_index,
-                            });
+                            {
+                                response.actions.push(WalletListAction::Unarchive {
+                                    account_index: row.account_index,
+                                });
+                            }
+                        } else {
+                            let can_archive =
+                                row.role != WalletListRole::Primary || allow_archive;
+                            if can_archive
+                                && ui
+                                    .small_button(RichText::new("Archive").small())
+                                    .on_hover_text(
+                                        "Soft-delete this wallet (reversible — historical \
+                                         collections still resolve their key_hash)",
+                                    )
+                                    .clicked()
+                            {
+                                response.actions.push(WalletListAction::Archive {
+                                    account_index: row.account_index,
+                                });
+                            }
                         }
                         if view_button
                             && ui
@@ -633,5 +693,29 @@ fn render_card(
                     }
                 }
             });
+
+            // ── Pool badge (optional) — fuel-UTxO count + total ADA.
+            // Only rendered when the host has cached UTxOs for this
+            // wallet (i.e. user has hit Refresh at least once). The dot
+            // is `●` (U+25CF) rather than 🟢/🟡/🔴 because the latter
+            // (U+1F7E0..2) are outside egui's `default_fonts` and
+            // render as the missing-glyph box.
+            if let Some(pool) = &row.pool {
+                ui.add_space(4.0);
+                ui.horizontal(|ui| {
+                    let fg = match pool.health {
+                        WalletPoolBadgeHealth::Empty => Color32::from_rgb(220, 130, 130),
+                        WalletPoolBadgeHealth::Low => Color32::from_rgb(220, 200, 130),
+                        WalletPoolBadgeHealth::Healthy => Color32::from_rgb(150, 210, 160),
+                    };
+                    ui.label(RichText::new("●").small().color(fg));
+                    let ada_whole = pool.total_lovelace / 1_000_000;
+                    ui.label(
+                        RichText::new(format!("{} fuel · {} ADA", pool.fuel_count, ada_whole))
+                            .small()
+                            .color(fg),
+                    );
+                });
+            }
         });
 }

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -111,6 +111,11 @@ pub enum WalletListAction {
     /// [`WalletList::with_can_archive_primary`] is left at the default
     /// `false`, so the parent doesn't need to defend against it again.
     Archive { account_index: u32 },
+    /// User clicked the "View UTxOs" button on a row. Only emitted
+    /// when [`WalletList::with_view_button`] is `true`; the parent
+    /// owns the panel state (toggle / refresh / cache) and the
+    /// indexer round-trip.
+    ViewUtxos { account_index: u32 },
 }
 
 /// Rendering style. Both styles share the same row VM, bucketing, and
@@ -134,6 +139,7 @@ pub struct WalletList<'a> {
     columns: usize,
     can_archive_primary: bool,
     show_section_headers_for_single: bool,
+    view_button: bool,
 }
 
 /// Response — drained actions for this frame.
@@ -168,7 +174,18 @@ impl<'a> WalletList<'a> {
             columns: 1,
             can_archive_primary: false,
             show_section_headers_for_single: false,
+            view_button: false,
         }
+    }
+
+    /// Show a per-row "UTxOs" button alongside Archive. Off by
+    /// default — surfaces an extra affordance which only makes
+    /// sense when the parent has somewhere to render the panel
+    /// (e.g. the portal dashboard). Click → emits
+    /// [`WalletListAction::ViewUtxos`].
+    pub fn with_view_button(mut self, enabled: bool) -> Self {
+        self.view_button = enabled;
+        self
     }
 
     /// Switch the per-row presentation. See [`WalletListLayout`].
@@ -235,6 +252,7 @@ impl<'a> WalletList<'a> {
             self.layout,
             self.columns,
             self.can_archive_primary,
+            self.view_button,
             &mut response,
         );
 
@@ -252,6 +270,7 @@ impl<'a> WalletList<'a> {
             self.layout,
             self.columns,
             /* allow_archive = */ true,
+            self.view_button,
             &mut response,
         );
 
@@ -267,6 +286,7 @@ impl<'a> WalletList<'a> {
             self.layout,
             self.columns,
             /* allow_archive = */ true,
+            self.view_button,
             &mut response,
         );
 
@@ -288,6 +308,7 @@ fn render_bucket(
     layout: WalletListLayout,
     columns: usize,
     allow_archive: bool,
+    view_button: bool,
     response: &mut WalletListResponse,
 ) {
     if rows.is_empty() {
@@ -333,7 +354,7 @@ fn render_bucket(
             // nested `ui.columns` wrapper (which would add layout cost
             // for zero visual gain).
             for r in chunk.iter() {
-                render_one(ui, r, layout, allow_archive, response);
+                render_one(ui, r, layout, allow_archive, view_button, response);
             }
         } else {
             // Multi-column — split into `effective_cols` equal sub-UIs.
@@ -342,7 +363,7 @@ fn render_bucket(
             // grid alignment with cells above).
             ui.columns(effective_cols, |cols| {
                 for (i, r) in chunk.iter().enumerate() {
-                    render_one(&mut cols[i], r, layout, allow_archive, response);
+                    render_one(&mut cols[i], r, layout, allow_archive, view_button, response);
                 }
             });
         }
@@ -357,11 +378,12 @@ fn render_one(
     row: &WalletListRow,
     layout: WalletListLayout,
     allow_archive: bool,
+    view_button: bool,
     response: &mut WalletListResponse,
 ) {
     match layout {
-        WalletListLayout::List => render_row(ui, row, allow_archive, response),
-        WalletListLayout::Card => render_card(ui, row, allow_archive, response),
+        WalletListLayout::List => render_row(ui, row, allow_archive, view_button, response),
+        WalletListLayout::Card => render_card(ui, row, allow_archive, view_button, response),
     }
 }
 
@@ -369,6 +391,7 @@ fn render_row(
     ui: &mut Ui,
     row: &WalletListRow,
     allow_archive: bool,
+    view_button: bool,
     response: &mut WalletListResponse,
 ) {
     let archived = row.archived_at.is_some();
@@ -447,6 +470,21 @@ fn render_row(
                             }
                         }
 
+                        // View-UTxOs button. Opt-in via
+                        // `with_view_button(true)` since not every
+                        // host has a panel to render them into.
+                        if view_button {
+                            let clicked = ui
+                                .small_button(RichText::new("UTxOs").small())
+                                .on_hover_text("View on-chain UTxOs for this wallet")
+                                .clicked();
+                            if clicked {
+                                response.actions.push(WalletListAction::ViewUtxos {
+                                    account_index: row.account_index,
+                                });
+                            }
+                        }
+
                         // Copy-to-clipboard icon button — copies the full
                         // address (not the truncation) so the value is
                         // usable. egui has a built-in clipboard helper;
@@ -477,6 +515,7 @@ fn render_card(
     ui: &mut Ui,
     row: &WalletListRow,
     allow_archive: bool,
+    view_button: bool,
     response: &mut WalletListResponse,
 ) {
     let archived = row.archived_at.is_some();
@@ -559,6 +598,16 @@ fn render_card(
                                 .clicked()
                         {
                             response.actions.push(WalletListAction::Archive {
+                                account_index: row.account_index,
+                            });
+                        }
+                        if view_button
+                            && ui
+                                .small_button(RichText::new("UTxOs").small())
+                                .on_hover_text("View on-chain UTxOs for this wallet")
+                                .clicked()
+                        {
+                            response.actions.push(WalletListAction::ViewUtxos {
                                 account_index: row.account_index,
                             });
                         }

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -1,0 +1,369 @@
+//! Wallet roster — the per-client list rendered on the admin portal
+//! dashboard. Groups wallets by role (Primary → Collections → Custom), keeps
+//! the layout scannable when one wallet is present and structured when many
+//! are.
+//!
+//! ## Why it's a widget
+//!
+//! The portal's `render_client_detail` was rendering a flat `for w in
+//! wallets` loop. That falls apart the moment a client has 5+ collection
+//! wallets: no grouping, no visual hierarchy, archive button mashed against
+//! the key-hash. Pushing this into a widget gives us:
+//!
+//! - section headers (Primary / Collections / Custom) with a row count
+//! - a single-wallet "compact" layout that skips the section header
+//! - per-row role chip with consistent colours across screens
+//! - a uniform `WalletListAction` action stream for the host to handle —
+//!   today only `Archive`, but trivial to extend to Rename / SetDefault / etc.
+//!
+//! ## What it does NOT do
+//!
+//! - **No async, no inbox.** Actions are returned in the response struct;
+//!   the parent fires whatever IO it needs.
+//! - **No state.** Selection / hover are intentionally absent — wallet rows
+//!   are clickable in a future revision; this version mirrors the read-only
+//!   list the portal already had.
+//! - **No add-wallet form.** That stays as a parent-owned inline form
+//!   immediately below the list (see `app.rs::render_client_detail`).
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! let rows: Vec<WalletListRow> = detail.wallets.iter().map(to_vm).collect();
+//! let resp = WalletList::new(&rows)
+//!     .with_can_archive_primary(false)
+//!     .show(ui);
+//! for action in resp.actions {
+//!     match action {
+//!         WalletListAction::Archive { account_index } => { /* dispatch */ }
+//!     }
+//! }
+//! ```
+
+use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
+
+// ─────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────
+
+/// Logical role of a wallet within a client. Mirrors
+/// `shared_types::client_management::WalletRole`; we keep a local copy so
+/// the widget crate doesn't take a hard dependency on it (shared-types
+/// lives in a different workspace).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WalletListRole {
+    /// `account_index = 0`, exactly one per client. Highlighted at the top.
+    Primary,
+    /// Per-collection wallet, auto-created on collection provisioning.
+    Collection,
+    /// Operator-named wallet (rare; advanced users).
+    Custom,
+}
+
+/// View-model for a single wallet row. Pre-formatted by the caller — the
+/// widget does no truncation itself.
+#[derive(Clone, Debug)]
+pub struct WalletListRow {
+    /// BIP-44 account index. Rendered as `#N` in monospace.
+    pub account_index: u32,
+    /// Display name. "Primary" / collection title / operator-set label.
+    pub label: String,
+    /// Pre-truncated wallet identity for inline display — typically the
+    /// bech32 enterprise address (e.g. `addr_test1vp…9fc465`). Caller
+    /// picks the truncation strategy (prefix/suffix widths).
+    pub address_short: String,
+    /// Full, un-truncated value to write to the clipboard when the user
+    /// clicks the copy icon. `None` hides the copy button — useful when
+    /// no canonical "copy this" value exists (e.g. row only shows a
+    /// derived placeholder).
+    pub address_full: Option<String>,
+    /// Role bucket — drives section placement + chip colour.
+    pub role: WalletListRole,
+    /// `true` if the wallet was auto-provisioned. Renders an "auto" chip
+    /// unless the role is `Collection` (where every wallet is auto, so the
+    /// chip would be noise).
+    pub auto_created: bool,
+    /// Unix seconds of archive, or `None` if active. Archived rows render
+    /// dimmed with an "archived" chip.
+    pub archived_at: Option<i64>,
+}
+
+/// Actions emitted while the widget was on screen this frame. Parent
+/// drains and dispatches.
+#[derive(Clone, Debug)]
+pub enum WalletListAction {
+    /// User clicked the archive button on the row with this
+    /// `account_index`. The widget already enforces the
+    /// "Primary cannot be archived" rule when
+    /// [`WalletList::with_can_archive_primary`] is left at the default
+    /// `false`, so the parent doesn't need to defend against it again.
+    Archive { account_index: u32 },
+}
+
+/// Builder.
+pub struct WalletList<'a> {
+    rows: &'a [WalletListRow],
+    can_archive_primary: bool,
+    show_section_headers_for_single: bool,
+}
+
+/// Response — drained actions for this frame.
+#[derive(Default, Debug)]
+pub struct WalletListResponse {
+    pub actions: Vec<WalletListAction>,
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Colours — kept private. The chip palette matches `mnemonic_display`
+// (cool blue for "platform-managed", soft green for "collection",
+// neutral grey for "custom"); rebalance here, not at the call site.
+// ─────────────────────────────────────────────────────────────────────
+
+const ROLE_PRIMARY_CHIP: Color32 = Color32::from_rgb(150, 180, 230);
+const ROLE_COLLECTION_CHIP: Color32 = Color32::from_rgb(180, 220, 180);
+const ROLE_CUSTOM_CHIP: Color32 = Color32::from_gray(150);
+const META_GREY: Color32 = Color32::from_gray(140);
+const KEYHASH_GREY: Color32 = Color32::from_gray(120);
+const SECTION_HEADER: Color32 = Color32::from_gray(170);
+const ROW_BG: Color32 = Color32::from_rgb(22, 22, 32);
+const ROW_BG_PRIMARY: Color32 = Color32::from_rgb(26, 30, 44);
+const ROW_BG_ARCHIVED: Color32 = Color32::from_rgb(18, 18, 24);
+const ROW_STROKE: Color32 = Color32::from_rgb(40, 40, 56);
+const ROW_STROKE_PRIMARY: Color32 = Color32::from_rgb(60, 80, 110);
+
+impl<'a> WalletList<'a> {
+    pub fn new(rows: &'a [WalletListRow]) -> Self {
+        Self {
+            rows,
+            can_archive_primary: false,
+            show_section_headers_for_single: false,
+        }
+    }
+
+    /// Override the safety default and allow the Primary row to be
+    /// archived. The portal never enables this — archiving the primary
+    /// orphans the client's on-chain identity — but tooling that's about
+    /// to purge a client (`offboard` flow) may want to.
+    pub fn with_can_archive_primary(mut self, allow: bool) -> Self {
+        self.can_archive_primary = allow;
+        self
+    }
+
+    /// Force section headers even when only one bucket is populated. Off
+    /// by default — a fresh client with a single Primary wallet shouldn't
+    /// see a "Primary (1)" header floating above one row.
+    pub fn with_section_headers_for_single(mut self, force: bool) -> Self {
+        self.show_section_headers_for_single = force;
+        self
+    }
+
+    pub fn show(self, ui: &mut Ui) -> WalletListResponse {
+        let mut response = WalletListResponse::default();
+
+        // Bucket the rows in a stable order: Primary → Collections (by
+        // account_index ASC) → Custom (by account_index ASC).
+        let mut primary: Vec<&WalletListRow> = Vec::new();
+        let mut collections: Vec<&WalletListRow> = Vec::new();
+        let mut custom: Vec<&WalletListRow> = Vec::new();
+        for r in self.rows {
+            match r.role {
+                WalletListRole::Primary => primary.push(r),
+                WalletListRole::Collection => collections.push(r),
+                WalletListRole::Custom => custom.push(r),
+            }
+        }
+        collections.sort_by_key(|r| r.account_index);
+        custom.sort_by_key(|r| r.account_index);
+
+        let populated_buckets =
+            usize::from(!primary.is_empty()) + usize::from(!collections.is_empty()) + usize::from(!custom.is_empty());
+        let show_headers = self.show_section_headers_for_single || populated_buckets > 1;
+
+        render_bucket(
+            ui,
+            "Primary",
+            &primary,
+            show_headers,
+            self.can_archive_primary,
+            &mut response,
+        );
+
+        if !primary.is_empty()
+            && (!collections.is_empty() || !custom.is_empty())
+        {
+            ui.add_space(8.0);
+        }
+
+        render_bucket(
+            ui,
+            "Collections",
+            &collections,
+            show_headers,
+            /* allow_archive = */ true,
+            &mut response,
+        );
+
+        if !collections.is_empty() && !custom.is_empty() {
+            ui.add_space(8.0);
+        }
+
+        render_bucket(
+            ui,
+            "Custom",
+            &custom,
+            show_headers,
+            /* allow_archive = */ true,
+            &mut response,
+        );
+
+        response
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────
+
+fn render_bucket(
+    ui: &mut Ui,
+    title: &str,
+    rows: &[&WalletListRow],
+    show_header: bool,
+    allow_archive: bool,
+    response: &mut WalletListResponse,
+) {
+    if rows.is_empty() {
+        return;
+    }
+
+    if show_header {
+        ui.add_space(2.0);
+        ui.horizontal(|ui| {
+            ui.label(
+                RichText::new(title)
+                    .color(SECTION_HEADER)
+                    .small()
+                    .strong(),
+            );
+            ui.label(
+                RichText::new(format!("({})", rows.len()))
+                    .color(META_GREY)
+                    .small(),
+            );
+        });
+        ui.add_space(4.0);
+    }
+
+    for r in rows {
+        render_row(ui, r, allow_archive, response);
+        ui.add_space(4.0);
+    }
+}
+
+fn render_row(
+    ui: &mut Ui,
+    row: &WalletListRow,
+    allow_archive: bool,
+    response: &mut WalletListResponse,
+) {
+    let archived = row.archived_at.is_some();
+    let (fill, stroke) = match (row.role, archived) {
+        (_, true) => (ROW_BG_ARCHIVED, ROW_STROKE),
+        (WalletListRole::Primary, false) => (ROW_BG_PRIMARY, ROW_STROKE_PRIMARY),
+        _ => (ROW_BG, ROW_STROKE),
+    };
+
+    Frame::new()
+        .fill(fill)
+        .stroke(Stroke::new(1.0, stroke))
+        .corner_radius(CornerRadius::same(4))
+        .inner_margin(Margin::symmetric(10, 7))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                // ── Account index ────────────────────────────────────
+                ui.label(
+                    RichText::new(format!("#{}", row.account_index))
+                        .monospace()
+                        .color(if archived { META_GREY } else { Color32::from_gray(200) }),
+                );
+
+                // ── Label ───────────────────────────────────────────
+                let label_text = RichText::new(&row.label).strong();
+                let label_text = if archived {
+                    label_text.color(META_GREY)
+                } else {
+                    label_text
+                };
+                ui.label(label_text);
+
+                // ── Role chip ───────────────────────────────────────
+                let (chip_text, chip_colour) = match row.role {
+                    WalletListRole::Primary => ("primary", ROLE_PRIMARY_CHIP),
+                    WalletListRole::Collection => ("collection", ROLE_COLLECTION_CHIP),
+                    WalletListRole::Custom => ("custom", ROLE_CUSTOM_CHIP),
+                };
+                ui.colored_label(chip_colour, RichText::new(chip_text).small());
+
+                // 'collection' wallets are always auto-created — chipping
+                // both would be noise. Show 'auto' only outside that bucket.
+                if row.auto_created && row.role != WalletListRole::Collection {
+                    ui.colored_label(META_GREY, RichText::new("auto").small());
+                }
+
+                if archived {
+                    ui.colored_label(
+                        Color32::LIGHT_YELLOW,
+                        RichText::new("archived").small(),
+                    );
+                }
+
+                // ── Address (right-aligned with copy + archive) ─────
+                ui.with_layout(
+                    egui::Layout::right_to_left(egui::Align::Center),
+                    |ui| {
+                        // Archive button — placed first because of the
+                        // right-to-left layout (it ends up rightmost).
+                        // Hidden for Primary (unless explicitly enabled)
+                        // and already-archived rows.
+                        let can_archive = !archived
+                            && (row.role != WalletListRole::Primary || allow_archive);
+                        if can_archive {
+                            let clicked = ui
+                                .small_button(RichText::new("Archive").small())
+                                .on_hover_text(
+                                    "Soft-delete this wallet (reversible — historical \
+                                     collections still resolve their key_hash)",
+                                )
+                                .clicked();
+                            if clicked {
+                                response.actions.push(WalletListAction::Archive {
+                                    account_index: row.account_index,
+                                });
+                            }
+                        }
+
+                        // Copy-to-clipboard icon button — copies the full
+                        // address (not the truncation) so the value is
+                        // usable. egui has a built-in clipboard helper;
+                        // we don't need to round-trip through a parent
+                        // action. Hidden when no `address_full` is set.
+                        if let Some(full) = &row.address_full {
+                            let copy = ui
+                                .small_button(RichText::new("📋").small())
+                                .on_hover_text("Copy address to clipboard");
+                            if copy.clicked() {
+                                ui.ctx().copy_text(full.clone());
+                            }
+                        }
+
+                        ui.label(
+                            RichText::new(&row.address_short)
+                                .color(KEYHASH_GREY)
+                                .monospace()
+                                .small(),
+                        );
+                    },
+                );
+            });
+        });
+}

--- a/ui/wallet-core/src/cip30.rs
+++ b/ui/wallet-core/src/cip30.rs
@@ -67,6 +67,12 @@ export async function getUsedAddresses(api) {
     return await api.getUsedAddresses();
 }
 
+export async function getRewardAddresses(api) {
+    // CIP-30: returns hex-encoded stake addresses. Used by the CIP-8 signData
+    // flow — the stake key is what signs message payloads.
+    return await api.getRewardAddresses();
+}
+
 export async function getChangeAddress(api) {
     return await api.getChangeAddress();
 }
@@ -156,6 +162,9 @@ extern "C" {
 
     #[wasm_bindgen(js_name = getUsedAddresses, catch)]
     pub async fn get_used_addresses_js(api: &JsValue) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(js_name = getRewardAddresses, catch)]
+    pub async fn get_reward_addresses_js(api: &JsValue) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = getChangeAddress, catch)]
     pub async fn get_change_address_js(api: &JsValue) -> Result<JsValue, JsValue>;
@@ -269,6 +278,14 @@ impl WalletApi {
     /// Get used addresses (hex-encoded)
     pub async fn used_addresses(&self) -> Result<Vec<String>, WalletError> {
         let result = get_used_addresses_js(&self.api).await?;
+        let array = js_sys::Array::from(&result);
+        Ok(array.iter().filter_map(|v| v.as_string()).collect())
+    }
+
+    /// Get reward (stake) addresses (hex-encoded). Required for the CIP-8
+    /// `signData` flow — the stake key is what signs message payloads.
+    pub async fn reward_addresses(&self) -> Result<Vec<String>, WalletError> {
+        let result = get_reward_addresses_js(&self.api).await?;
         let array = js_sys::Array::from(&result);
         Ok(array.iter().filter_map(|v| v.as_string()).collect())
     }


### PR DESCRIPTION
Sets up the shared-crates side of the on-chain minting engine work + the
portal UI it surfaces. **Prereq** for the partner PR in `cnft.dev-workers`,
which adds the engine's `extra_self_outputs` consumer + the
`CollectionList` integration on the client portal.

## What's in this PR

### `cardano-tx` — `extra_self_outputs` on the multi-recipient mint builder

New optional parameter on `build_cip25_mint_multi`:

```rust
pub fn build_cip25_mint_multi(
    deps: &TxDeps,
    policy: &MintingPolicy,
    mints: &[MintRecipientEntry],
    metadata: Option<&serde_json::Value>,
    inputs: Option<&[UtxoApi]>,
    extra_self_outputs: Option<&[u64]>,   // ← new
) -> Result<UnsignedTx, TxBuildError>
```

Each entry becomes a pure-ADA output paid back to `deps.from_address`,
drawn from the input change. The minting engine uses this to maintain a
fuel-UTxO pool *inside the mint tx itself* — every mint tops the pool
back up to a target count, so the first mint after funding effectively
performs the splitter work as a side-effect, and subsequent mints
self-balance. No separate splitter tx needed.

Builder validates each extra ≥ `min_pure_change` before signing
(otherwise the ledger would reject the tx and burn the fee). Fee
estimation + change calc updated to account for the extras.

**Tests:** existing 4 mint-multi tests updated to pass `None` (no
behaviour change). 2 new tests added: `_with_extra_self_outputs` (4 ×
10 ADA extras from a 100 ADA input — succeeds) and
`_rejects_undersized_extras` (0.5 ADA extra — fails before signing).
All 6 tests pass.

**Breaking change** for direct callers of `build_cip25_mint_multi`.
Only one exists in this org (`services/minting-core` in
`cnft.dev-workers`), updated in the partner PR.

**Drive-by:** extracted a `RecipientGroup = (String, Address, Vec<(String,
u64)>)` type alias to fix a pre-existing `clippy::type_complexity` warning
in the same function.

### `ui/egui-widgets` — `CollectionList` widget + `WalletPoolBadge` + `Unarchive` action

**New: `collection_list` module.** Per-client collections list rendered
on the portal dashboard. Card + List layouts, builder pattern matching
`WalletList`:

```rust
CollectionList::new(&rows)
    .with_columns(2)
    .with_test_mint(true)
    .with_seed_stubs(true)
    .with_activity(true)
    .show(ui)
```

Card fields: title, status/standard/network chips, supply progress bar,
copy-able `policy_id`, clickable wallet ref. `CollectionListAction`
enum: `TestMint` / `SeedStubs` / `Activity` / `OpenWallet`. Per-card
toggle state (`test_mint_open`, `seed_stubs_open`, `activity_open`)
flows in via the row VM so button labels render the correct `−` vs `+`
affordance.

**New on `WalletList`: `WalletPoolBadge` + `WalletPoolBadgeHealth`.**
Optional `pool` field on `WalletListRow` renders a fuel-pool summary
under the address: `● 20 fuel · 230 ADA`. Health colour comes from
the bucket (Empty / Low / Healthy). Widget stays free of
shared-types dependencies — host maps from its canonical pool-stats
type at the VM boundary.

**New on `WalletList`: `WalletListAction::Unarchive`.** Archived cards
now render a "Restore" button where Archive normally sits — both card
and list paths. Closes the lifecycle gap (you could archive but never
get back).

**Bug fix.** Pool badge dot was `🟢/🟡/🔴` (Unicode U+1F7E0-2). These
codepoints are outside `egui`'s `default_fonts` and rendered as the
missing-glyph box. Swapped to colored `●` (U+25CF, in the default
font) — the text colour itself encodes the bucket.

### `ui/_storybook-egui` — new `CollectionList` story + drive-by fix

**New story:** `stories/collection_list.rs` registered under the
"Auth / Admin" category. Six variants cover the realistic mix: fresh
draft, ingesting + ready (CIP-25 preprod), live + CIP-68 mainnet,
mixed-status 2-column grid (draft / ingesting / live / paused /
sold_out / ended chips), form-open toggle states, compact list
layout. Action receipts panel at the bottom proves the
`CollectionListAction` channel is wired.

**Drive-by:** `stories/wallet_list.rs`'s action-match arm wasn't
covering `WalletListAction::ViewUtxos` (added some weeks ago in the
utxo-3 task). Storybook hadn't been recompiled since; building
broke under `-D warnings` until the missing arm was added.

## Sequencing

This PR is intended to land before the partner PR in `cnft.dev-workers`
(rev bump in that workspace's `Cargo.toml` against this commit). Build
order otherwise:

1. Land this → tag a `cardano-tx` + `egui-widgets` rev.
2. Partner PR: bump `cardano-tx` + `egui-widgets` rev pins; consume
   `extra_self_outputs` from the engine + `CollectionList` from the
   portal.

## What's NOT in this PR

- The chunked-job extraction surveyed in the partner PR's
  `docs/design/CHUNKED_JOBS.md`. Existing alarm-chain pattern lives
  in `cnft.dev-workers` (`workers/collection-ownership`); extraction
  is a separate dedicated PR, not bundled here.
- Any consumer code for `extra_self_outputs` or `CollectionList` —
  those live in the partner PR.

## Verification

```
nix develop -c cargo test -p cardano-tx
nix develop -c cargo clippy -p cardano-tx -p egui-widgets -p storybook-egui \
    --all-targets --target wasm32-unknown-unknown -- -D warnings
```

All green.