### PR TITLE
feature: cardano-tx mint throughput and widget updates

### DIFF
--- a/cardano-tx/examples/wayup_create_eval.rs
+++ b/cardano-tx/examples/wayup_create_eval.rs
@@ -63,7 +63,10 @@ fn main() {
 
     let unsigned = build_wayup_collection_offers_tx(&deps, &[mk(10_000_000), mk(25_000_000)])
         .expect("build wayup create");
-    let built = unsigned.staging.build_conway_raw().expect("build_conway_raw");
+    let built = unsigned
+        .staging
+        .build_conway_raw()
+        .expect("build_conway_raw");
 
     eprintln!("converged fee: {} lovelace", unsigned.fee);
     println!("{}", hex::encode(&built.tx_bytes.0));

--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -8,7 +8,9 @@
 //! - NFT delivery to the buyer (any NFT from the target policy)
 
 use cardano_assets::UtxoApi;
-use pallas_addresses::{Address, Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart};
+use pallas_addresses::{
+    Address, Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart,
+};
 use pallas_crypto::hash::Hash;
 use pallas_primitives::conway::PlutusData;
 
@@ -45,7 +47,8 @@ const MIN_MARKETPLACE_FEE: u64 = 2_000_000;
 const MIN_ROYALTY: u64 = 1_000_000;
 
 /// jpg.store marketplace fee script payment credential.
-const MARKETPLACE_FEE_SCRIPT_HASH: &str = "84cc25ea4c29951d40b443b95bbc5676bc425470f96376d1984af9ab";
+const MARKETPLACE_FEE_SCRIPT_HASH: &str =
+    "84cc25ea4c29951d40b443b95bbc5676bc425470f96376d1984af9ab";
 
 /// jpg.store marketplace fee staking credential (script).
 const MARKETPLACE_FEE_STAKE_HASH: &str = "2c967f4bd28944b06462e13c5e3f5d5fa6e03f8567569438cd833e6d";
@@ -251,7 +254,13 @@ fn build_nft_payout(
     // Value: Map { policy_id_bytes: Constructor(0) [1, Map {}] }
     let nft_value = PlutusData::Map(pallas_primitives::KeyValuePairs::Def(vec![(
         bytes(policy_bytes),
-        constr_indef(0, vec![int(1), PlutusData::Map(pallas_primitives::KeyValuePairs::Def(vec![]))]),
+        constr_indef(
+            0,
+            vec![
+                int(1),
+                PlutusData::Map(pallas_primitives::KeyValuePairs::Def(vec![])),
+            ],
+        ),
     )]));
 
     Ok(constr_indef(0, vec![address, nft_value]))
@@ -282,7 +291,10 @@ fn build_datum_address(
             // Some(StakingHash(credential))
             constr_indef(
                 0,
-                vec![constr_indef(0, vec![constr_indef(stake_tag, vec![bytes(hash.to_vec())])])],
+                vec![constr_indef(
+                    0,
+                    vec![constr_indef(stake_tag, vec![bytes(hash.to_vec())])],
+                )],
             )
         }
         None => constr_indef(1, vec![]), // None
@@ -366,7 +378,7 @@ pub fn build_collection_offer_tx(
 ) -> Result<super::UnsignedTx, TxBuildError> {
     use crate::helpers::input::add_utxo_input;
     use crate::helpers::output::{build_change_output, create_ada_output};
-    
+
     use crate::selection;
     use pallas_crypto::hash::Hasher;
     use pallas_txbuilder::StagingTransaction;
@@ -423,12 +435,8 @@ pub fn build_collection_offer_tx(
             if change > 0 {
                 if has_native_assets {
                     let input_refs: Vec<&UtxoApi> = selected_utxos.iter().collect();
-                    let change_output = build_change_output(
-                        from_address.clone(),
-                        change,
-                        &input_refs,
-                        None,
-                    )?;
+                    let change_output =
+                        build_change_output(from_address.clone(), change, &input_refs, None)?;
                     tx = tx.output(change_output);
                 } else {
                     tx = tx.output(create_ada_output(from_address.clone(), change));
@@ -454,7 +462,7 @@ pub fn build_collection_offers_tx(
 ) -> Result<super::UnsignedTx, TxBuildError> {
     use crate::helpers::input::add_utxo_input;
     use crate::helpers::output::{build_change_output, create_ada_output};
-    
+
     use crate::selection;
     use pallas_crypto::hash::Hasher;
     use pallas_txbuilder::StagingTransaction;
@@ -531,12 +539,8 @@ pub fn build_collection_offers_tx(
             if change > 0 {
                 if has_native_assets {
                     let input_refs: Vec<&UtxoApi> = selected_utxos.iter().collect();
-                    let change_output = build_change_output(
-                        from_address.clone(),
-                        change,
-                        &input_refs,
-                        None,
-                    )?;
+                    let change_output =
+                        build_change_output(from_address.clone(), change, &input_refs, None)?;
                     tx = tx.output(change_output);
                 } else {
                     tx = tx.output(create_ada_output(from_address.clone(), change));
@@ -560,9 +564,7 @@ fn build_co_metadata(datum_cbor: &[u8], policy_id: &str) -> Result<Vec<u8>, TxBu
 /// Each offer's datum CBOR is hex-encoded, chunked into 64-char strings across
 /// sequential labels starting at 50. Each offer ends with a `policy_id::index`
 /// label. Label 30 contains version "5".
-fn build_co_metadata_multi(
-    offers: &[(&[u8], &str)],
-) -> Result<Vec<u8>, TxBuildError> {
+fn build_co_metadata_multi(offers: &[(&[u8], &str)]) -> Result<Vec<u8>, TxBuildError> {
     use pallas_codec::minicbor::Encoder;
 
     // Collect all metadata entries: (label, value_string)
@@ -1028,8 +1030,8 @@ pub fn build_cancel_offer_tx(
 
     let owner_pkh_bytes: [u8; 28] = hex_to_28_bytes(&req.owner_pkh)?;
 
-    let redeemer_bytes = hex::decode(CANCEL_REDEEMER_HEX)
-        .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
+    let redeemer_bytes =
+        hex::decode(CANCEL_REDEEMER_HEX).map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
 
     let script_input = Input::new(Hash::from(co_tx_bytes), req.co_output_index);
     let ref_input = Input::new(Hash::from(script_ref_bytes), SCRIPT_REF_INDEX);
@@ -1047,12 +1049,13 @@ pub fn build_cancel_offer_tx(
 
     super::converge_fee(
         |fee| {
-            let output_value = total_input
-                .checked_sub(fee)
-                .ok_or(TxBuildError::InsufficientFunds {
-                    needed: fee,
-                    available: total_input,
-                })?;
+            let output_value =
+                total_input
+                    .checked_sub(fee)
+                    .ok_or(TxBuildError::InsufficientFunds {
+                        needed: fee,
+                        available: total_input,
+                    })?;
 
             let mut tx = StagingTransaction::new()
                 .input(script_input.clone())
@@ -1063,7 +1066,9 @@ pub fn build_cancel_offer_tx(
                     redeemer_bytes.clone(),
                     Some(ExUnits {
                         mem: req.ex_units_mem.unwrap_or(CANCEL_PRELIMINARY_EX_UNITS_MEM),
-                        steps: req.ex_units_steps.unwrap_or(CANCEL_PRELIMINARY_EX_UNITS_STEPS),
+                        steps: req
+                            .ex_units_steps
+                            .unwrap_or(CANCEL_PRELIMINARY_EX_UNITS_STEPS),
                     }),
                 )
                 .language_view(ScriptKind::PlutusV2, PLUTUS_V2_COST_MODEL.to_vec())
@@ -1177,8 +1182,8 @@ pub fn build_cancel_offers_tx_with(
 
     let owner_pkh_bytes: [u8; 28] = hex_to_28_bytes(&requests[0].owner_pkh)?;
 
-    let redeemer_bytes = hex::decode(CANCEL_REDEEMER_HEX)
-        .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
+    let redeemer_bytes =
+        hex::decode(CANCEL_REDEEMER_HEX).map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
 
     let ref_input = Input::new(Hash::from(script_ref_bytes), contract.script_ref_index);
 
@@ -1257,7 +1262,9 @@ pub fn build_cancel_offers_tx_with(
                     input.clone(),
                     redeemer_bytes.clone(),
                     Some(ExUnits {
-                        mem: requests[i].ex_units_mem.unwrap_or(contract.preliminary_ex_mem),
+                        mem: requests[i]
+                            .ex_units_mem
+                            .unwrap_or(contract.preliminary_ex_mem),
                         steps: requests[i]
                             .ex_units_steps
                             .unwrap_or(contract.preliminary_ex_steps),
@@ -1323,8 +1330,7 @@ pub fn build_cancel_offers_tx_with(
 // ---------------------------------------------------------------------------
 
 fn hex_to_28_bytes(hex_str: &str) -> Result<[u8; 28], TxBuildError> {
-    let decoded = hex::decode(hex_str)
-        .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
+    let decoded = hex::decode(hex_str).map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?;
     decoded
         .try_into()
         .map_err(|_| TxBuildError::InvalidHex("expected 28 bytes".into()))
@@ -1380,7 +1386,11 @@ mod tests {
         let datum = build_wayup_co_datum(&req).unwrap();
         let bytes = encode_plutus_data(&datum).unwrap();
         let expected = "d8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82ad9fd8799fd8799fd8799f581c5f08a64f580e581735070e1b1d2ce29ae6942ab45ccff5a1747d2283ffd8799fd8799fd8799f581c28f17fdd2d8b8f559ad61e899e31eae90b9e209cbedb1ee8a8c6c7d1ffffffffa140d8799f00a1401a000f4240ffffd8799fd8799fd8799f581c4a00e5040c2d7e201a9c20744ace64bf28d1cda55999a4931e406922ffd8799fd8799fd8799f581ccba51a2e5b5b802a0402a87b762d2ecc6b1a9b6d0dd708daf07b82adffffffffa1581ca316bcf768f0309be743b4b7d067f3348017bf0f00f6a29562aebda2d8799f01a0ffffd8799fd8799fd8799f581c04bdd97da6dfacd1fb4c5d5e1a14292e4ee0f2015a46f8543e552c49ffd8799fd8799fd8799f581c8eaef6e3337032021c887b180b74dfc0ff625d167df78b77e476b68dffffffffa140d8799f00a1401a000f4240ffffffff";
-        assert_eq!(hex::encode(&bytes), expected, "Wayup datum must be byte-exact to the on-chain offer");
+        assert_eq!(
+            hex::encode(&bytes),
+            expected,
+            "Wayup datum must be byte-exact to the on-chain offer"
+        );
     }
 
     /// The frankenaddress = Wayup payment script + bidder stake key, header 0x11.
@@ -1470,7 +1480,11 @@ mod tests {
             let addr = Address::from_bech32(bech32).unwrap();
             if let Address::Shelley(shelley) = &addr {
                 let payment = hex::encode(shelley.payment().as_hash().as_slice());
-                let delegation = shelley.delegation().as_hash().map(|h| hex::encode(h.as_slice())).unwrap_or_default();
+                let delegation = shelley
+                    .delegation()
+                    .as_hash()
+                    .map(|h| hex::encode(h.as_slice()))
+                    .unwrap_or_default();
                 eprintln!("{label}: payment={payment} staking={delegation}");
             }
         }

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -19,6 +19,22 @@ use crate::helpers::output::{add_assets_from_map, create_ada_output};
 type UtxoSelection<'a> = (Vec<&'a UtxoApi>, u64, HashMap<(String, String), u64>);
 use crate::intents::MintingPolicy;
 
+/// The change output a mint tx emits back to `deps.from_address`, surfaced so a
+/// caller can **chain** the next tx off it without a chain/indexer round-trip:
+/// `(tx_hash, output_index)` is a spendable input the moment this tx is built.
+///
+/// `output_index` is the index within the tx's output list. `has_assets` is true
+/// when the change carries native assets the inputs dragged through (then it's
+/// not a clean pure-ADA funding source — chainers should skip it). Absent
+/// entirely (`None` from the builder) when the change was dust folded into the
+/// fee, i.e. there is no change output to spend.
+#[derive(Debug, Clone, Copy)]
+pub struct ChangeOutput {
+    pub output_index: u32,
+    pub lovelace: u64,
+    pub has_assets: bool,
+}
+
 /// Build a CIP-25 mint transaction.
 ///
 /// Creates minted tokens with a native script policy and optional CIP-25 metadata.
@@ -265,6 +281,22 @@ pub fn build_cip25_mint_multi(
     inputs: Option<&[UtxoApi]>,
     extra_self_outputs: Option<&[u64]>,
 ) -> Result<UnsignedTx, TxBuildError> {
+    build_cip25_mint_multi_with_change(deps, policy, mints, metadata, inputs, extra_self_outputs)
+        .map(|(tx, _change)| tx)
+}
+
+/// Like [`build_cip25_mint_multi`] but also returns the tx's [`ChangeOutput`]
+/// (the pure-ADA remainder back to `deps.from_address`), so a caller can chain
+/// the next tx off it. `None` when the change was dust folded into the fee
+/// (no change output emitted). See [`ChangeOutput`].
+pub fn build_cip25_mint_multi_with_change(
+    deps: &TxDeps,
+    policy: &MintingPolicy,
+    mints: &[MintRecipientEntry],
+    metadata: Option<&serde_json::Value>,
+    inputs: Option<&[UtxoApi]>,
+    extra_self_outputs: Option<&[u64]>,
+) -> Result<(UnsignedTx, Option<ChangeOutput>), TxBuildError> {
     use pallas_primitives::Fragment;
 
     if mints.is_empty() {
@@ -455,7 +487,11 @@ pub fn build_cip25_mint_multi(
     }
 
     // Change. Inputs already cover `total_needed` (recipient outputs + extras + fee).
+    // The change output (when emitted) is appended after the recipient + extra
+    // outputs, so its index is `groups.len() + extras.len()`.
     let change_lovelace = total_input_lovelace - total_output_min_ada - total_extras_lovelace - fee;
+    let change_index = (groups.len() + extras.len()) as u32;
+    let change: Option<ChangeOutput>;
     if has_remaining_assets {
         // Must emit a change output to carry the inputs' native assets.
         if change_lovelace < min_pure_change {
@@ -471,19 +507,31 @@ pub fn build_cip25_mint_multi(
             .collect();
         change_output = add_assets_from_map(change_output, &asset_map)?;
         tx = tx.output(change_output);
+        change = Some(ChangeOutput {
+            output_index: change_index,
+            lovelace: change_lovelace,
+            has_assets: true,
+        });
     } else if change_lovelace >= min_pure_change {
         tx = tx.output(create_ada_output(
             deps.from_address.clone(),
             change_lovelace,
         ));
+        change = Some(ChangeOutput {
+            output_index: change_index,
+            lovelace: change_lovelace,
+            has_assets: false,
+        });
     } else {
         // Dust below a viable change output → fold into the fee to keep the tx balanced.
+        // No change output emitted, so nothing to chain off.
         fee += change_lovelace;
+        change = None;
     }
 
     tx = tx.fee(fee);
 
-    Ok(UnsignedTx { staging: tx, fee })
+    Ok((UnsignedTx { staging: tx, fee }, change))
 }
 
 // ============================================================================
@@ -974,6 +1022,52 @@ mod tests {
         );
         assert!(result.is_ok(), "multi-recipient mint failed: {result:?}");
         assert!(result.unwrap().fee > 0);
+    }
+
+    #[test]
+    fn test_build_cip25_mint_multi_surfaces_change() {
+        // 2 recipients, big pure-ADA input, no extras → a pure-ADA change output
+        // at index 2 (after the two recipient outputs), chainable.
+        let mints = vec![
+            MintRecipientEntry {
+                asset_name: "Foo001".to_string(),
+                quantity: 1,
+                recipient: test_recipient(1),
+            },
+            MintRecipientEntry {
+                asset_name: "Foo002".to_string(),
+                quantity: 1,
+                recipient: test_recipient(2),
+            },
+        ];
+        let (unsigned, change) = build_cip25_mint_multi_with_change(
+            &deps_with(50_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None,
+        )
+        .expect("build failed");
+        let change = change.expect("expected a change output");
+        assert_eq!(
+            change.output_index, 2,
+            "change follows the 2 recipient outputs"
+        );
+        assert!(!change.has_assets, "pure-ADA input → pure-ADA change");
+        assert!(change.lovelace > 0);
+        // The change index must point at a real output in the staging tx.
+        let n_outputs = unsigned
+            .staging
+            .outputs
+            .as_ref()
+            .map(|o| o.len())
+            .unwrap_or(0);
+        assert!(
+            (change.output_index as usize) < n_outputs,
+            "change index {} out of bounds ({n_outputs} outputs)",
+            change.output_index
+        );
     }
 
     #[test]

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -301,7 +301,11 @@ pub fn build_cip25_mint_multi(
         if let Some(g) = groups.iter_mut().find(|(k, _, _)| *k == key) {
             g.2.push((m.asset_name.clone(), m.quantity));
         } else {
-            groups.push((key, m.recipient.clone(), vec![(m.asset_name.clone(), m.quantity)]));
+            groups.push((
+                key,
+                m.recipient.clone(),
+                vec![(m.asset_name.clone(), m.quantity)],
+            ));
         }
     }
 
@@ -451,8 +455,7 @@ pub fn build_cip25_mint_multi(
     }
 
     // Change. Inputs already cover `total_needed` (recipient outputs + extras + fee).
-    let change_lovelace =
-        total_input_lovelace - total_output_min_ada - total_extras_lovelace - fee;
+    let change_lovelace = total_input_lovelace - total_output_min_ada - total_extras_lovelace - fee;
     if has_remaining_assets {
         // Must emit a change output to carry the inputs' native assets.
         if change_lovelace < min_pure_change {
@@ -469,7 +472,10 @@ pub fn build_cip25_mint_multi(
         change_output = add_assets_from_map(change_output, &asset_map)?;
         tx = tx.output(change_output);
     } else if change_lovelace >= min_pure_change {
-        tx = tx.output(create_ada_output(deps.from_address.clone(), change_lovelace));
+        tx = tx.output(create_ada_output(
+            deps.from_address.clone(),
+            change_lovelace,
+        ));
     } else {
         // Dust below a viable change output → fold into the fee to keep the tx balanced.
         fee += change_lovelace;
@@ -903,7 +909,10 @@ mod tests {
 
         let assets = vec![("TimeLockedNFT".to_string(), 1i64)];
         let result = build_cip25_mint(&deps, &policy, &assets, None, None);
-        assert!(result.is_ok(), "time-locked mint failed to build: {result:?}");
+        assert!(
+            result.is_ok(),
+            "time-locked mint failed to build: {result:?}"
+        );
 
         // Sanity: the policy reports the upper bound the builder must apply.
         assert_eq!(policy.validity_bounds(), (None, Some(90_000_000)));
@@ -955,7 +964,14 @@ mod tests {
                 recipient: test_recipient(2),
             },
         ];
-        let result = build_cip25_mint_multi(&deps_with(20_000_000), &test_policy(), &mints, None, None, None);
+        let result = build_cip25_mint_multi(
+            &deps_with(20_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None,
+        );
         assert!(result.is_ok(), "multi-recipient mint failed: {result:?}");
         assert!(result.unwrap().fee > 0);
     }
@@ -999,12 +1015,28 @@ mod tests {
             quantity: 0,
             recipient: test_recipient(1),
         }];
-        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &mints, None, None, None).is_err());
+        assert!(build_cip25_mint_multi(
+            &deps_with(10_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None
+        )
+        .is_err());
     }
 
     #[test]
     fn test_build_cip25_mint_multi_empty_errors() {
-        assert!(build_cip25_mint_multi(&deps_with(10_000_000), &test_policy(), &[], None, None, None).is_err());
+        assert!(build_cip25_mint_multi(
+            &deps_with(10_000_000),
+            &test_policy(),
+            &[],
+            None,
+            None,
+            None
+        )
+        .is_err());
     }
 
     /// `extra_self_outputs` adds pool-slot UTxOs back to `from_address` and the change

--- a/cardano-tx/src/builder/mod.rs
+++ b/cardano-tx/src/builder/mod.rs
@@ -52,6 +52,40 @@ impl std::fmt::Debug for UnsignedTx {
     }
 }
 
+/// A signed transaction ready for submission — hex tx hash + hex CBOR.
+/// Produced by [`UnsignedTx::build_and_sign`].
+pub struct SignedTx {
+    pub tx_hash: String,
+    pub tx_cbor_hex: String,
+}
+
+impl UnsignedTx {
+    /// Build the Conway-era tx + sign it with an Ed25519 key, returning
+    /// the hex tx hash and CBOR. The staging tx already carries `fee` +
+    /// `network_id` (set during construction), so this is just the
+    /// final assembly + signature — the server-side counterpart to
+    /// handing the CBOR to a CIP-30 wallet in the browser.
+    ///
+    /// Keeps the `pallas_txbuilder` build trait internal to this crate
+    /// so consumers (workers, CLIs) don't have to depend on it directly
+    /// just to turn an [`UnsignedTx`] into submittable bytes.
+    pub fn build_and_sign(
+        self,
+        secret_key: &pallas_crypto::key::ed25519::SecretKey,
+    ) -> Result<SignedTx, TxBuildError> {
+        use pallas_txbuilder::BuildConway;
+        let built = self
+            .staging
+            .build_conway_raw()
+            .map_err(|e| TxBuildError::BuildFailed(e.to_string()))?;
+        let signed = crate::sign::sign_transaction(built, secret_key)?;
+        Ok(SignedTx {
+            tx_hash: hex::encode(signed.tx_hash.0),
+            tx_cbor_hex: hex::encode(&signed.tx_bytes),
+        })
+    }
+}
+
 /// Two-round fee convergence.
 ///
 /// The Cardano fee depends on TX size, which depends on the fee field itself (circular).
@@ -82,7 +116,8 @@ pub fn converge_fee_with_witnesses(
 ) -> Result<UnsignedTx, TxBuildError> {
     // Round 1: build with rough estimate, calculate real fee
     let preliminary_tx = build_fn(initial_estimate)?;
-    let fee_round1 = crate::fee::calculate_fee_with_witnesses(&preliminary_tx, params, num_witnesses);
+    let fee_round1 =
+        crate::fee::calculate_fee_with_witnesses(&preliminary_tx, params, num_witnesses);
 
     // Round 2: rebuild with round-1 fee, recalculate
     let tx_round2 = build_fn(fee_round1)?;
@@ -111,7 +146,7 @@ mod tests {
             max_value_size: 5000,
             price_mem: None,
             price_step: None,
-                ..Default::default()
+            ..Default::default()
         };
 
         // Minimal TX that builds successfully

--- a/cardano-tx/src/builder/send.rs
+++ b/cardano-tx/src/builder/send.rs
@@ -3,7 +3,7 @@
 //! Pure functions for building send-lovelace, send-max, send-assets, and
 //! consolidation transactions. All operate on [`TxDeps`] and produce [`UnsignedTx`].
 
-use cardano_assets::{AssetId, UtxoApi};
+use cardano_assets::{AssetId, UtxoApi, UtxoTag};
 use pallas_addresses::Address;
 use pallas_txbuilder::StagingTransaction;
 use std::collections::HashSet;
@@ -351,6 +351,133 @@ pub fn build_consolidate(deps: &TxDeps, max_inputs: u32) -> Result<UnsignedTx, T
     )
 }
 
+/// Build a fan-out (refuel) transaction.
+///
+/// Sweeps the wallet's pure-ADA UTxOs (skipping anything carrying a
+/// script reference or native assets — those have their own purpose)
+/// and emits `slot_count` outputs of `slot_size` lovelace each back to
+/// `deps.from_address`, plus a single change output for the remainder.
+/// Result: a wallet primed with N parallel-spendable fuel UTxOs, ready
+/// for high-throughput minting before the first mint lands.
+///
+/// Multi-input by design — a self-spend can sweep an arbitrary mix of
+/// "bank" UTxOs (one big change UTxO, a few stragglers) into a clean
+/// pool shape. Inputs are taken largest-first so a healthy wallet
+/// usually only consumes one UTxO; smaller stragglers come along
+/// only when needed to cover the deficit.
+///
+/// # Errors
+///
+/// - `BuildFailed` — `slot_count == 0`, or all UTxOs were filtered
+///   out (every UTxO has assets or a script ref).
+/// - `InsufficientFunds` — the spendable UTxOs together can't cover
+///   `slot_size × slot_count + fee + min pure-change`.
+///
+/// Asset-bearing and `HasScriptRef` UTxOs are intentionally excluded
+/// from selection — they may hold the collection's mint policy script
+/// reference (CIP-68) or arbitrary native assets the operator put
+/// there; refuel must not consume either. The filter is conservative:
+/// it's better to fail loudly than to accidentally burn an asset.
+pub fn build_fan_out(
+    deps: &TxDeps,
+    slot_size: u64,
+    slot_count: u32,
+) -> Result<UnsignedTx, TxBuildError> {
+    if slot_count == 0 {
+        return Err(TxBuildError::BuildFailed(
+            "slot_count must be > 0 — caller should no-op when deficit is zero".to_string(),
+        ));
+    }
+
+    // Filter to pure-ADA UTxOs without script refs. Largest-first so
+    // healthy wallets sweep one UTxO; small stragglers join only when
+    // the deficit needs them.
+    let mut spendable: Vec<&UtxoApi> = deps
+        .utxos
+        .iter()
+        .filter(|u| u.assets.is_empty() && !u.has_tag(UtxoTag::HasScriptRef))
+        .collect();
+    spendable.sort_by_key(|u| std::cmp::Reverse(u.lovelace));
+    if spendable.is_empty() {
+        return Err(TxBuildError::BuildFailed(
+            "no spendable pure-ADA UTxOs (all entries carry native assets or a script ref)"
+                .to_string(),
+        ));
+    }
+
+    let total_outputs_lovelace = slot_size
+        .checked_mul(u64::from(slot_count))
+        .ok_or_else(|| {
+            TxBuildError::BuildFailed("slot_size * slot_count overflows u64".to_string())
+        })?;
+
+    // Min change cushion — the tx-builder will reject change outputs
+    // below the pure-ADA min UTxO threshold (~1.1 ADA at current params).
+    // Leave a 1.5 ADA buffer so converge_fee doesn't have to wrestle
+    // with edge-case sub-minimum change.
+    let min_change_cushion: u64 = 1_500_000;
+    // Multi-input fee estimate: base + per-input overhead.
+    let base_fee = selection::estimate_simple_fee(&deps.params);
+
+    let mut selected: Vec<&UtxoApi> = Vec::new();
+    let mut input_lovelace: u64 = 0;
+    for u in &spendable {
+        let projected_fee = base_fee + (selected.len() as u64 + 1) * 50_000;
+        let needed = total_outputs_lovelace
+            .saturating_add(projected_fee)
+            .saturating_add(min_change_cushion);
+        selected.push(u);
+        input_lovelace = input_lovelace.saturating_add(u.lovelace);
+        if input_lovelace >= needed {
+            break;
+        }
+    }
+    let final_fee_estimate = base_fee + (selected.len() as u64 * 50_000);
+    let needed_lovelace = total_outputs_lovelace
+        .saturating_add(final_fee_estimate)
+        .saturating_add(min_change_cushion);
+    if input_lovelace < needed_lovelace {
+        return Err(TxBuildError::InsufficientFunds {
+            needed: needed_lovelace,
+            available: input_lovelace,
+        });
+    }
+
+    let selected_cloned: Vec<UtxoApi> = selected.into_iter().cloned().collect();
+    let from_address = deps.from_address.clone();
+    let network_id = deps.network_id;
+    let rough_fee = final_fee_estimate;
+
+    converge_fee(
+        |fee| {
+            let refs: Vec<&UtxoApi> = selected_cloned.iter().collect();
+            let mut tx = add_utxo_inputs(StagingTransaction::new(), &refs)?;
+
+            // N equal fuel-slot outputs back to self.
+            for _ in 0..slot_count {
+                tx = tx.output(create_ada_output(from_address.clone(), slot_size));
+            }
+
+            // Change output for the remainder — fee converges around
+            // this. Must exceed min-pure-change or the ledger rejects.
+            let change = input_lovelace
+                .checked_sub(total_outputs_lovelace)
+                .and_then(|v| v.checked_sub(fee))
+                .ok_or(TxBuildError::InsufficientFunds {
+                    needed: total_outputs_lovelace + fee,
+                    available: input_lovelace,
+                })?;
+            if change > 0 {
+                tx = tx.output(create_ada_output(from_address.clone(), change));
+            }
+
+            Ok(tx.fee(fee).network_id(network_id))
+        },
+        rough_fee,
+        &deps.params,
+    )
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -621,5 +748,94 @@ mod tests {
 
         let result = find_utxos_for_assets(&[asset_id], &utxos);
         assert!(result.is_err());
+    }
+
+    fn make_script_ref_utxo(lovelace: u64) -> UtxoApi {
+        UtxoApi {
+            tx_hash: format!("{:064x}", lovelace + 9_000_000),
+            output_index: 0,
+            lovelace,
+            assets: vec![],
+            tags: vec![cardano_assets::UtxoTag::HasScriptRef],
+        }
+    }
+
+    #[test]
+    fn test_build_fan_out_splits_one_bank_utxo() {
+        // One 200 ADA "bank" UTxO → fan out into 5 × 10 ADA slots + change.
+        let deps = TxDeps {
+            utxos: vec![make_utxo(200_000_000)],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        let result = build_fan_out(&deps, 10_000_000, 5);
+        assert!(result.is_ok(), "build_fan_out failed: {result:?}");
+        let unsigned = result.unwrap();
+        assert!(unsigned.fee > 0);
+        // 5 fuel slots + 1 change output.
+        assert_eq!(unsigned.staging.outputs.as_ref().map(|o| o.len()), Some(6));
+    }
+
+    #[test]
+    fn test_build_fan_out_sweeps_multiple_inputs() {
+        // No single UTxO covers 5 × 10 ADA + fee + change; the sweep
+        // must pull in several stragglers.
+        let deps = TxDeps {
+            utxos: vec![
+                make_utxo(30_000_000),
+                make_utxo(25_000_000),
+                make_utxo(20_000_000),
+            ],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        let result = build_fan_out(&deps, 10_000_000, 5);
+        assert!(result.is_ok(), "multi-input fan_out failed: {result:?}");
+        let unsigned = result.unwrap();
+        assert!(
+            unsigned
+                .staging
+                .inputs
+                .as_ref()
+                .map(|i| i.len())
+                .unwrap_or(0)
+                >= 2
+        );
+    }
+
+    #[test]
+    fn test_build_fan_out_skips_script_ref_and_assets() {
+        // The script-ref UTxO + the asset-bearing UTxO must be left
+        // untouched; only the bare pure-ADA UTxO is spendable, and it
+        // can't cover the deficit → InsufficientFunds.
+        let policy = "a".repeat(56);
+        let deps = TxDeps {
+            utxos: vec![
+                make_script_ref_utxo(50_000_000),
+                make_utxo_with_asset(50_000_000, &policy, "4e4654", 1),
+                make_utxo(5_000_000),
+            ],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        let result = build_fan_out(&deps, 10_000_000, 5);
+        assert!(
+            matches!(result, Err(TxBuildError::InsufficientFunds { .. })),
+            "expected InsufficientFunds (script-ref + asset UTxOs excluded), got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_build_fan_out_zero_slots_errors() {
+        let deps = TxDeps {
+            utxos: vec![make_utxo(100_000_000)],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        assert!(build_fan_out(&deps, 10_000_000, 0).is_err());
     }
 }

--- a/cardano-tx/src/intents/native_scripts.rs
+++ b/cardano-tx/src/intents/native_scripts.rs
@@ -231,9 +231,7 @@ impl MintingPolicy {
                 ..
             } => (Some(*after_slot), Some(*before_slot)),
             Self::MultiSigTimeLocked { before_slot, .. } => (None, Some(*before_slot)),
-            Self::WalletDerived
-            | Self::SingleKey { .. }
-            | Self::MultiSig { .. } => (None, None),
+            Self::WalletDerived | Self::SingleKey { .. } | Self::MultiSig { .. } => (None, None),
         }
     }
 

--- a/cardano-tx/src/selection.rs
+++ b/cardano-tx/src/selection.rs
@@ -251,9 +251,7 @@ pub fn select_utxos_for_amount(
     sorted.sort_by(|a, b| {
         let a_pure = is_pure_ada_utxo(a);
         let b_pure = is_pure_ada_utxo(b);
-        b_pure
-            .cmp(&a_pure)
-            .then(b.lovelace.cmp(&a.lovelace))
+        b_pure.cmp(&a_pure).then(b.lovelace.cmp(&a.lovelace))
     });
 
     let mut selected = Vec::new();
@@ -519,9 +517,7 @@ mod tests {
         // single UTxO suffices, but combined the wallet has near-enough.
         let result = select_utxo_for_amount(&utxos, 4_000_000, 200_000, &config);
         match result {
-            Err(TxBuildError::NoSingleUtxoLargeEnough {
-                largest, total, ..
-            }) => {
+            Err(TxBuildError::NoSingleUtxoLargeEnough { largest, total, .. }) => {
                 assert_eq!(largest, 1_500_000);
                 assert_eq!(total, 4_800_000);
                 assert_ne!(largest, total, "fragmentation must be visible");

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -744,9 +744,7 @@ mod app {
                             ),
                             Story::GroupedSection => stories::grouped_section::show(ui),
                             Story::OfferTile => stories::offer_tile::show(ui),
-                            Story::TxCart => {
-                                stories::tx_cart::show(ui, &mut self.tx_cart_state)
-                            }
+                            Story::TxCart => stories::tx_cart::show(ui, &mut self.tx_cart_state),
                             Story::WalletIdentityHeader => stories::wallet_identity_header::show(
                                 ui,
                                 &mut self.wallet_identity_header_state,

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -7,6 +7,7 @@ use crate::{ACCENT, TEXT_MUTED};
 use egui_widgets::collection_list::{
     CollectionList, CollectionListAction, CollectionListLayout, CollectionRow,
 };
+use egui_widgets::wallet_list::{WalletPoolBadge, WalletPoolBadgeHealth};
 
 #[derive(Default)]
 pub struct CollectionListState {
@@ -18,6 +19,8 @@ pub struct CollectionListState {
     pub last_activity: Option<String>,
     /// Last open-wallet action observed.
     pub last_open_wallet: Option<u32>,
+    /// Last refuel action observed.
+    pub last_refuel: Option<u32>,
 }
 
 /// Construct a sample row. The widget does no truncation itself — the
@@ -47,7 +50,41 @@ fn row(
         test_mint_open: false,
         seed_stubs_open: false,
         activity_open: false,
+        wallet_address_short: None,
+        wallet_address_full: None,
+        pool: None,
     }
+}
+
+/// Construct a sample row pre-populated with a collection-wallet address
+/// and a pool badge — exercises the Refuel-on-card variant.
+#[allow(clippy::too_many_arguments)]
+fn row_with_wallet(
+    policy_id: &str,
+    wallet_account_index: u32,
+    title: &str,
+    status: &str,
+    standard: &str,
+    network: &str,
+    total_supply: u64,
+    minted_count: u64,
+    address: &str,
+    pool: WalletPoolBadge,
+) -> CollectionRow {
+    let mut r = row(
+        policy_id,
+        wallet_account_index,
+        title,
+        status,
+        standard,
+        network,
+        total_supply,
+        minted_count,
+    );
+    r.wallet_address_short = Some(truncate_middle(address, 14, 8));
+    r.wallet_address_full = Some(address.to_string());
+    r.pool = Some(pool);
+    r
 }
 
 fn truncate_middle(s: &str, prefix: usize, suffix: usize) -> String {
@@ -349,7 +386,90 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
     ui.separator();
     ui.add_space(16.0);
 
-    // ── Variant 6: list layout ─────────────────────────────────────────
+    // ── Variant 6: collection-centric — wallet + pool + Refuel ─────────
+    ui.label(
+        egui::RichText::new("Collection-centric — wallet sub-line + Refuel")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "The collection card is the primary surface for everything wallet-shaped \
+             that belongs to a collection. With `with_refuel(true)` plus a row that \
+             ships `wallet_address_*` and a `pool` badge, the card grows a wallet \
+             sub-line: clickable wallet # · address · 📋 · ● fuel/ADA · ⛽ Refuel. \
+             Refuel copies the address to the clipboard and emits an action so the \
+             host can flash a toast or open the testnet faucet.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let rows = vec![
+        row_with_wallet(
+            "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
+            4,
+            "Foobar",
+            "ready",
+            "cip25",
+            "cardano:preprod",
+            1000,
+            120,
+            "addr_test1vpqxc4dpv2lcw4w98v7y7r9p5m0z3qc9x8f6gj2v0nq4t9sucgmds",
+            WalletPoolBadge {
+                fuel_count: 22,
+                total_lovelace: 245_000_000,
+                health: WalletPoolBadgeHealth::Healthy,
+            },
+        ),
+        row_with_wallet(
+            "a8d4e1c7b2f5a9d3c6e0b4f7a1c8e2d5b9a6c3f0e7d4b1a8c5e2f9b6a3d0e7",
+            5,
+            "Black Flag (preprod)",
+            "live",
+            "cip25",
+            "cardano:preprod",
+            500,
+            340,
+            "addr_test1vrm9k2e5xz3l0c8q7t2p6r4n3a1y0w9v8u7s5h2g0f9d8b6jq2fxzc",
+            WalletPoolBadge {
+                fuel_count: 4,
+                total_lovelace: 38_000_000,
+                health: WalletPoolBadgeHealth::Low,
+            },
+        ),
+        row_with_wallet(
+            "5c3a8e4d2f1b7a9c6e0d3b5f8a2c4e7d1b9f6a3c0e5d8b2f7a4c1e6d3b9f0a8",
+            7,
+            "Empty Pool",
+            "ingesting",
+            "cip68",
+            "cardano:preprod",
+            333,
+            0,
+            "addr_test1vp7l0c8q7t2p6r4n3a1y0w9v8u7s5h2g0f9d8b6jq2fxzcrm9k2e5xz",
+            WalletPoolBadge {
+                fuel_count: 0,
+                total_lovelace: 0,
+                health: WalletPoolBadgeHealth::Empty,
+            },
+        ),
+    ];
+    let resp = CollectionList::new(&rows)
+        .with_test_mint(true)
+        .with_seed_stubs(true)
+        .with_activity(true)
+        .with_refuel(true)
+        .show(ui);
+    capture_actions(resp.actions, state);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
+    // ── Variant 7: list layout ─────────────────────────────────────────
     ui.label(
         egui::RichText::new("List layout — compact for dense surfaces")
             .color(ACCENT)
@@ -371,12 +491,14 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
         .with_layout(CollectionListLayout::List)
         .with_test_mint(true)
         .with_seed_stubs(true)
+        .with_refuel(true)
         .show(ui);
 
     // ── Action receipt ─────────────────────────────────────────────────
     if state.last_test_mint.is_some()
         || state.last_seed_stubs.is_some()
         || state.last_open_wallet.is_some()
+        || state.last_refuel.is_some()
     {
         ui.add_space(16.0);
         ui.separator();
@@ -405,6 +527,12 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
                 format!("✓ open-wallet requested for #{idx}"),
             );
         }
+        if let Some(idx) = state.last_refuel {
+            ui.colored_label(
+                egui::Color32::LIGHT_GREEN,
+                format!("✓ refuel requested for #{idx} (address copied)"),
+            );
+        }
     }
 }
 
@@ -422,6 +550,9 @@ fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionLis
             }
             CollectionListAction::OpenWallet { account_index } => {
                 state.last_open_wallet = Some(account_index);
+            }
+            CollectionListAction::Refuel { account_index } => {
+                state.last_refuel = Some(account_index);
             }
         }
     }

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -54,6 +54,7 @@ fn row(
         wallet_address_full: None,
         pool: None,
         refuel_in_flight: false,
+        archived_at: None,
     }
 }
 

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -19,8 +19,8 @@ pub struct CollectionListState {
     pub last_activity: Option<String>,
     /// Last open-wallet action observed.
     pub last_open_wallet: Option<u32>,
-    /// Last refuel action observed.
-    pub last_refuel: Option<u32>,
+    /// Last refuel action observed (policy_id).
+    pub last_refuel: Option<String>,
 }
 
 /// Construct a sample row. The widget does no truncation itself — the
@@ -53,6 +53,7 @@ fn row(
         wallet_address_short: None,
         wallet_address_full: None,
         pool: None,
+        refuel_in_flight: false,
     }
 }
 
@@ -399,19 +400,20 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
              that belongs to a collection. With `with_refuel(true)` plus a row that \
              ships `wallet_address_*` and a `pool` badge, the card grows a wallet \
              sub-line: clickable wallet # · address · 📋 · ● fuel/ADA · ⛽ Refuel. \
-             Refuel copies the address to the clipboard and emits an action so the \
-             host can flash a toast or open the testnet faucet.",
+             Refuel fires a server-side fan-out tx (sweeps pure-ADA UTxOs into \
+             10 ADA fuel slots). The widget self-disables when the pool is already \
+             Healthy or a refuel is in flight — the host doesn't have to check.",
         )
         .color(TEXT_MUTED)
         .small(),
     );
     ui.add_space(8.0);
 
-    let rows = vec![
+    let mut rows = vec![
         row_with_wallet(
             "7f2b6f15a4c91c2d8e6a3b9f5d2e8c1a4b7d6e9f2c3a5b8d7e0f1c9a8922e0",
             4,
-            "Foobar",
+            "Healthy pool — Refuel disabled",
             "ready",
             "cip25",
             "cardano:preprod",
@@ -427,7 +429,7 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
         row_with_wallet(
             "a8d4e1c7b2f5a9d3c6e0b4f7a1c8e2d5b9a6c3f0e7d4b1a8c5e2f9b6a3d0e7",
             5,
-            "Black Flag (preprod)",
+            "Low pool — Refuel enabled",
             "live",
             "cip25",
             "cardano:preprod",
@@ -443,7 +445,7 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
         row_with_wallet(
             "5c3a8e4d2f1b7a9c6e0d3b5f8a2c4e7d1b9f6a3c0e5d8b2f7a4c1e6d3b9f0a8",
             7,
-            "Empty Pool",
+            "Refuel in flight",
             "ingesting",
             "cip68",
             "cardano:preprod",
@@ -457,6 +459,9 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
             },
         ),
     ];
+    // Demo the in-flight state on the third row — host sets this
+    // between firing the action and receiving the ack.
+    rows[2].refuel_in_flight = true;
     let resp = CollectionList::new(&rows)
         .with_test_mint(true)
         .with_seed_stubs(true)
@@ -527,10 +532,10 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
                 format!("✓ open-wallet requested for #{idx}"),
             );
         }
-        if let Some(idx) = state.last_refuel {
+        if let Some(p) = &state.last_refuel {
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
-                format!("✓ refuel requested for #{idx} (address copied)"),
+                format!("✓ refuel requested for {}", truncate_middle(p, 8, 6)),
             );
         }
     }
@@ -551,8 +556,8 @@ fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionLis
             CollectionListAction::OpenWallet { account_index } => {
                 state.last_open_wallet = Some(account_index);
             }
-            CollectionListAction::Refuel { account_index } => {
-                state.last_refuel = Some(account_index);
+            CollectionListAction::Refuel { policy_id } => {
+                state.last_refuel = Some(policy_id);
             }
         }
     }

--- a/ui/_storybook-egui/src/stories/grouped_section.rs
+++ b/ui/_storybook-egui/src/stories/grouped_section.rs
@@ -115,11 +115,7 @@ pub fn show(ui: &mut egui::Ui) {
     ui.separator();
     ui.add_space(8.0);
 
-    ui.label(
-        egui::RichText::new("Test cases:")
-            .color(ACCENT)
-            .strong(),
-    );
+    ui.label(egui::RichText::new("Test cases:").color(ACCENT).strong());
     ui.label("\u{2022} Hero image renders at 32×32 with rounded corners");
     ui.label("\u{2022} Verified badge appears next to title when `verified(true)`");
     ui.label("\u{2022} Subtitle below title in muted text, optional");

--- a/ui/_storybook-egui/src/stories/offer_tile.rs
+++ b/ui/_storybook-egui/src/stories/offer_tile.rs
@@ -8,11 +8,7 @@ const PLACEHOLDER_IMAGE: egui::ImageSource<'_> =
     egui::include_image!("../../assets/placeholders/section_hero_64.png");
 
 pub fn show(ui: &mut egui::Ui) {
-    ui.label(
-        egui::RichText::new("Offer Tile")
-            .color(ACCENT)
-            .strong(),
-    );
+    ui.label(egui::RichText::new("Offer Tile").color(ACCENT).strong());
     ui.label(
         egui::RichText::new(
             "Picker tile with a state machine (Active / InCart / Spent), an image \
@@ -125,7 +121,9 @@ pub fn show(ui: &mut egui::Ui) {
         OfferTile::image("420.0 ADA", PLACEHOLDER_IMAGE.clone()).show(ui);
         OfferTile::image("150.0 ADA", PLACEHOLDER_IMAGE.clone()).show(ui);
         OfferTile::placeholder("7.0 ADA", "CO").badge("9×").show(ui);
-        OfferTile::placeholder("5.0 ADA", "CO").badge("12×").show(ui);
+        OfferTile::placeholder("5.0 ADA", "CO")
+            .badge("12×")
+            .show(ui);
         OfferTile::image("420.0 ADA", PLACEHOLDER_IMAGE.clone())
             .state(OfferTileState::Spent)
             .show(ui);
@@ -135,11 +133,7 @@ pub fn show(ui: &mut egui::Ui) {
     ui.separator();
     ui.add_space(8.0);
 
-    ui.label(
-        egui::RichText::new("Test cases:")
-            .color(ACCENT)
-            .strong(),
-    );
+    ui.label(egui::RichText::new("Test cases:").color(ACCENT).strong());
     ui.label("\u{2022} Active tile renders full-colour with hover cursor + click events");
     ui.label("\u{2022} InCart / Spent tiles dim the frame and tint the image; clicks are inert");
     ui.label("\u{2022} Tooltip is consumer-supplied; usually disambiguates dimmed states");

--- a/ui/_storybook-egui/src/stories/persona_strip.rs
+++ b/ui/_storybook-egui/src/stories/persona_strip.rs
@@ -31,12 +31,7 @@ pub fn show(ui: &mut egui::Ui) {
     );
     ui.add_space(4.0);
     PersonaStrip::new("ADA-leaning Large with blue-chip taste")
-        .tags(&[
-            "ada_maximalist",
-            "large",
-            "specialist",
-            "blue_chip_leaning",
-        ])
+        .tags(&["ada_maximalist", "large", "specialist", "blue_chip_leaning"])
         .show(ui);
     ui.add_space(16.0);
 
@@ -67,7 +62,5 @@ pub fn show(ui: &mut egui::Ui) {
             .strong(),
     );
     ui.add_space(4.0);
-    PersonaStrip::new("")
-        .tags(&["whale", "ada_maxi"])
-        .show(ui);
+    PersonaStrip::new("").tags(&["whale", "ada_maxi"]).show(ui);
 }

--- a/ui/_storybook-egui/src/stories/tx_cart.rs
+++ b/ui/_storybook-egui/src/stories/tx_cart.rs
@@ -57,11 +57,7 @@ impl Default for TxCartStoryState {
 }
 
 pub fn show(ui: &mut egui::Ui, state: &mut TxCartStoryState) {
-    ui.label(
-        egui::RichText::new("TxCart Widget")
-            .color(ACCENT)
-            .strong(),
-    );
+    ui.label(egui::RichText::new("TxCart Widget").color(ACCENT).strong());
     ui.label(
         egui::RichText::new(
             "Batched transaction cart with sequential signing. Groups actions by \

--- a/ui/_storybook-egui/src/stories/wallet_identity_header.rs
+++ b/ui/_storybook-egui/src/stories/wallet_identity_header.rs
@@ -36,10 +36,9 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletIdentityHeaderStoryState) {
             .strong(),
     );
     ui.add_space(4.0);
-    if let Some(WalletIdentityAction::CopyStake) =
-        WalletIdentityHeader::new(SAMPLE_STAKE)
-            .handle(Some("$djo"))
-            .show(ui)
+    if let Some(WalletIdentityAction::CopyStake) = WalletIdentityHeader::new(SAMPLE_STAKE)
+        .handle(Some("$djo"))
+        .show(ui)
     {
         state.last_action = Some("Copy stake address".to_string());
     }

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -244,6 +244,32 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
     ui.separator();
     ui.add_space(16.0);
 
+    // ── Variant 3b: hide archived behind a toggle ──────────────────────
+    ui.label(
+        egui::RichText::new("Archived hidden by default (.with_hide_archived)")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    ui.label(
+        egui::RichText::new(
+            "Same roster as above, but archived rows are dropped from their \
+             buckets until you click the \"Show N archived\" toggle below the \
+             list. The reveal flag is cosmetic — it lives in egui memory, so it \
+             doesn't round-trip through the host. JRYNers (#4) is the archived \
+             one; note it stays hidden until revealed.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+
+    let _ = WalletList::new(&rows).with_hide_archived(true).show(ui);
+
+    ui.add_space(24.0);
+    ui.separator();
+    ui.add_space(16.0);
+
     // ── Variant 4: mixed roles including Custom ────────────────────────
     ui.label(
         egui::RichText::new("Mixed — including a Custom wallet")

--- a/ui/_storybook-egui/src/stories/wallet_list.rs
+++ b/ui/_storybook-egui/src/stories/wallet_list.rs
@@ -197,11 +197,46 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
             false,
             false,
         ),
-        row(1, "Aliens", WalletListRole::Collection, "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22", true, false),
-        row(2, "Nikepig", WalletListRole::Collection, "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff", true, false),
-        row(3, "Toolheads", WalletListRole::Collection, "addr_test1vqahjlw2qspx9chgxctf48k0wq2g9j8a6fl74xg7q34fab10", true, false),
-        row(4, "JRYNers", WalletListRole::Collection, "addr_test1vrkxs3l5dt8jjlxhykqwa45dz8gj7nl2q6m3wt4kx07a8e02", true, true),
-        row(5, "IslaNOVA", WalletListRole::Collection, "addr_test1vp7ckag5jdtwfse5fy0adyfeesn5tep4qz0u9rmskg2bc491", true, false),
+        row(
+            1,
+            "Aliens",
+            WalletListRole::Collection,
+            "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22",
+            true,
+            false,
+        ),
+        row(
+            2,
+            "Nikepig",
+            WalletListRole::Collection,
+            "addr_test1vp9k8tcs0g7d7yze0v9rryf5p3afy3w4cy3lhsq6m8bc91ff",
+            true,
+            false,
+        ),
+        row(
+            3,
+            "Toolheads",
+            WalletListRole::Collection,
+            "addr_test1vqahjlw2qspx9chgxctf48k0wq2g9j8a6fl74xg7q34fab10",
+            true,
+            false,
+        ),
+        row(
+            4,
+            "JRYNers",
+            WalletListRole::Collection,
+            "addr_test1vrkxs3l5dt8jjlxhykqwa45dz8gj7nl2q6m3wt4kx07a8e02",
+            true,
+            true,
+        ),
+        row(
+            5,
+            "IslaNOVA",
+            WalletListRole::Collection,
+            "addr_test1vp7ckag5jdtwfse5fy0adyfeesn5tep4qz0u9rmskg2bc491",
+            true,
+            false,
+        ),
     ];
     let _ = WalletList::new(&rows).show(ui);
 
@@ -227,8 +262,22 @@ pub fn show(ui: &mut egui::Ui, state: &mut WalletListState) {
     ui.add_space(8.0);
 
     let rows = vec![
-        row(0, "Primary", WalletListRole::Primary, "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465", false, false),
-        row(1, "Aliens", WalletListRole::Collection, "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22", true, false),
+        row(
+            0,
+            "Primary",
+            WalletListRole::Primary,
+            "addr_test1vpedt5kty0v59fk2y4q44sxgs2my3aqlhxw7r5fzm9fc465",
+            false,
+            false,
+        ),
+        row(
+            1,
+            "Aliens",
+            WalletListRole::Collection,
+            "addr_test1vqnvts8en6q3qj9xkz2p3ahurv7lqkw0p3aexq8ad9a17e22",
+            true,
+            false,
+        ),
         row(
             7,
             "Cold storage",

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -60,6 +60,8 @@
 
 use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
 
+use crate::wallet_list::{WalletPoolBadge, WalletPoolBadgeHealth};
+
 // ─────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────
@@ -108,6 +110,23 @@ pub struct CollectionRow {
     /// `true` when the parent has the Activity panel open below this
     /// row. Same toggle treatment as the form-open flags.
     pub activity_open: bool,
+    /// Pre-truncated wallet address (e.g. middle-elided
+    /// `addr_test1vp…9fc465`) for inline display on the card's wallet
+    /// sub-line. `None` when the parent hasn't resolved an address yet
+    /// (rare — collection-wallet rows ship a derived address on the
+    /// first whoami). The widget hides the wallet sub-line entirely
+    /// when both `wallet_address_short` and `wallet_address_full` are
+    /// `None`, so the card degrades cleanly on older snapshots.
+    pub wallet_address_short: Option<String>,
+    /// Full, un-truncated address to write to the clipboard when the
+    /// user clicks either the row's wallet-address copy icon or the
+    /// "Refuel" button. `None` hides both affordances.
+    pub wallet_address_full: Option<String>,
+    /// Optional fuel-pool summary for the collection's mint wallet —
+    /// rendered as `● 20 fuel · 230 ADA` on the card's wallet sub-line.
+    /// `None` when the parent hasn't refreshed UTxOs for the wallet
+    /// yet (the host populates this from its cached UTxO snapshot).
+    pub pool: Option<WalletPoolBadge>,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -125,6 +144,13 @@ pub enum CollectionListAction {
     /// User clicked the `wallet #N` link in the footer. Parent opens
     /// that wallet's UTxO panel (or whatever it does for wallet focus).
     OpenWallet { account_index: u32 },
+    /// User clicked the per-card "Refuel" button. The widget has already
+    /// copied the wallet address to the clipboard (matches the in-widget
+    /// copy-icon convention); the action exists so the host can flash a
+    /// toast / emit telemetry / open a faucet tab if it wants to. Only
+    /// emitted when [`CollectionList::with_refuel`] is `true` and the
+    /// row supplies `wallet_address_full`.
+    Refuel { account_index: u32 },
 }
 
 /// Rendering style. Both styles share the same row VM and action emission —
@@ -148,6 +174,7 @@ pub struct CollectionList<'a> {
     show_test_mint: bool,
     show_seed_stubs: bool,
     show_activity: bool,
+    show_refuel: bool,
 }
 
 /// Response — drained actions for this frame.
@@ -194,6 +221,7 @@ impl<'a> CollectionList<'a> {
             show_test_mint: false,
             show_seed_stubs: false,
             show_activity: false,
+            show_refuel: false,
         }
     }
 
@@ -239,6 +267,23 @@ impl<'a> CollectionList<'a> {
         self
     }
 
+    /// Show the per-card "Refuel" button on the wallet sub-line. Off by
+    /// default. Click → widget copies `wallet_address_full` to the
+    /// clipboard *and* emits [`CollectionListAction::Refuel`] so the
+    /// host can flash a toast / log it / open a faucet. Hidden on rows
+    /// whose `wallet_address_full` is `None` (nothing to refuel).
+    ///
+    /// Why on the *collection* card rather than the wallet card: an
+    /// operator reasons "this collection needs fuel", not "wallet #4
+    /// is low" — the collection is the unit of work. Surfacing fuel
+    /// state + the address on the collection card lets a low-fuel
+    /// signal trigger the refuel directly, without a hop through the
+    /// Wallets section.
+    pub fn with_refuel(mut self, enabled: bool) -> Self {
+        self.show_refuel = enabled;
+        self
+    }
+
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
@@ -267,6 +312,7 @@ impl<'a> CollectionList<'a> {
                         self.show_test_mint,
                         self.show_seed_stubs,
                         self.show_activity,
+                        self.show_refuel,
                         &mut response,
                     );
                 }
@@ -280,6 +326,7 @@ impl<'a> CollectionList<'a> {
                             self.show_test_mint,
                             self.show_seed_stubs,
                             self.show_activity,
+                            self.show_refuel,
                             &mut response,
                         );
                     }
@@ -306,6 +353,7 @@ fn render_one(
     show_test_mint: bool,
     show_seed_stubs: bool,
     show_activity: bool,
+    show_refuel: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
@@ -315,6 +363,7 @@ fn render_one(
             show_test_mint,
             show_seed_stubs,
             show_activity,
+            show_refuel,
             response,
         ),
         CollectionListLayout::List => render_list_row(
@@ -323,17 +372,20 @@ fn render_one(
             show_test_mint,
             show_seed_stubs,
             show_activity,
+            show_refuel,
             response,
         ),
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_card(
     ui: &mut Ui,
     row: &CollectionRow,
     show_test_mint: bool,
     show_seed_stubs: bool,
     show_activity: bool,
+    show_refuel: bool,
     response: &mut CollectionListResponse,
 ) {
     Frame::new()
@@ -355,68 +407,65 @@ fn render_card(
                 standard_chip(ui, &row.standard);
                 network_chip(ui, &row.network);
 
-                ui.with_layout(
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        if show_test_mint {
-                            let label = if row.test_mint_open {
-                                "− Test mint"
-                            } else {
-                                "🧪 Test mint"
-                            };
-                            if ui
-                                .small_button(RichText::new(label).small())
-                                .on_hover_text(
-                                    "Open the test-mint form for this collection \
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if show_test_mint {
+                        let label = if row.test_mint_open {
+                            "− Test mint"
+                        } else {
+                            "🧪 Test mint"
+                        };
+                        if ui
+                            .small_button(RichText::new(label).small())
+                            .on_hover_text(
+                                "Open the test-mint form for this collection \
                                      (operator/super-admin only)",
-                                )
-                                .clicked()
-                            {
-                                response.actions.push(CollectionListAction::TestMint {
-                                    policy_id: row.policy_id.clone(),
-                                });
-                            }
+                            )
+                            .clicked()
+                        {
+                            response.actions.push(CollectionListAction::TestMint {
+                                policy_id: row.policy_id.clone(),
+                            });
                         }
-                        if show_seed_stubs {
-                            let label = if row.seed_stubs_open {
-                                "− Seed stubs"
-                            } else {
-                                "+ Seed stubs"
-                            };
-                            if ui
-                                .small_button(RichText::new(label).small())
-                                .on_hover_text(
-                                    "Seed placeholder mintable assets \
+                    }
+                    if show_seed_stubs {
+                        let label = if row.seed_stubs_open {
+                            "− Seed stubs"
+                        } else {
+                            "+ Seed stubs"
+                        };
+                        if ui
+                            .small_button(RichText::new(label).small())
+                            .on_hover_text(
+                                "Seed placeholder mintable assets \
                                      (testing-only — real ingest replaces this)",
-                                )
-                                .clicked()
-                            {
-                                response.actions.push(CollectionListAction::SeedStubs {
-                                    policy_id: row.policy_id.clone(),
-                                });
-                            }
+                            )
+                            .clicked()
+                        {
+                            response.actions.push(CollectionListAction::SeedStubs {
+                                policy_id: row.policy_id.clone(),
+                            });
                         }
-                        if show_activity {
-                            let label = if row.activity_open {
-                                "− Activity"
-                            } else {
-                                "📜 Activity"
-                            };
-                            if ui
-                                .small_button(RichText::new(label).small())
-                                .on_hover_text(
-                                    "Recent mint activity for this collection — \
+                    }
+                    if show_activity {
+                        let label = if row.activity_open {
+                            "− Activity"
+                        } else {
+                            "📜 Activity"
+                        };
+                        if ui
+                            .small_button(RichText::new(label).small())
+                            .on_hover_text(
+                                "Recent mint activity for this collection — \
                                      fetched from the engine's mint_log",
-                                )
-                                .clicked()
-                            {
-                                response.actions.push(CollectionListAction::Activity {
-                                    policy_id: row.policy_id.clone(),
-                                });
-                            }
+                            )
+                            .clicked()
+                        {
+                            response.actions.push(CollectionListAction::Activity {
+                                policy_id: row.policy_id.clone(),
+                            });
                         }
-                    },
-                );
+                    }
+                });
             });
 
             ui.add_space(8.0);
@@ -439,12 +488,9 @@ fn render_card(
                 } else {
                     format!("{:.0}%", pct * 100.0)
                 };
-                ui.with_layout(
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        ui.label(RichText::new(label).small().color(KEYHASH_GREY));
-                    },
-                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label(RichText::new(label).small().color(KEYHASH_GREY));
+                });
             });
 
             // Thin progress bar — caps at the surface width so it
@@ -464,11 +510,19 @@ fn render_card(
 
             ui.add_space(10.0);
 
-            // ── Footer: wallet ref + policy_id + copy ───────────────
+            // ── Wallet sub-line: address + copy + pool badge + Refuel ─
+            //
+            // The collection card is the primary surface for everything
+            // wallet-shaped that belongs to a collection — address, fuel
+            // level, refuel action. Collection wallets don't appear in
+            // the parent's "Wallets" section anymore, so this sub-line
+            // is the sole place where the operator interacts with the
+            // mint wallet for this collection.
+            //
+            // The `wallet #N` link is kept (left-most) so the
+            // collection-↔-wallet relationship is still visible, and
+            // clicking it still opens that wallet's UTxO panel.
             ui.horizontal(|ui| {
-                // wallet #N — clickable. The link surfaces the
-                // collection ↔ wallet relationship; clicking opens
-                // that wallet's UTxO panel (parent handles the wiring).
                 let wallet_text = format!("wallet #{}", row.wallet_account_index);
                 if ui
                     .small_button(RichText::new(wallet_text).small().color(META_GREY))
@@ -479,12 +533,74 @@ fn render_card(
                         account_index: row.wallet_account_index,
                     });
                 }
-                ui.label(
-                    RichText::new("·")
-                        .color(KEYHASH_GREY)
-                        .monospace()
-                        .small(),
-                );
+
+                // Inline address (truncated) + copy icon. The copy is
+                // done in-widget to match the policy_id pattern below
+                // (no host round-trip for a value the row already
+                // carries). Hidden when the row didn't supply one —
+                // older snapshots or wallets without a derived address.
+                if let Some(short) = &row.wallet_address_short {
+                    ui.label(RichText::new("·").color(KEYHASH_GREY).monospace().small());
+                    ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
+                    if let Some(full) = &row.wallet_address_full {
+                        if ui
+                            .small_button(RichText::new("📋").small())
+                            .on_hover_text("Copy wallet address to clipboard")
+                            .clicked()
+                        {
+                            ui.ctx().copy_text(full.clone());
+                        }
+                    }
+                }
+
+                // Pool badge — same shape as the wallet-list card's
+                // pool pill so the visual is consistent across surfaces.
+                if let Some(pool) = &row.pool {
+                    let fg = match pool.health {
+                        WalletPoolBadgeHealth::Empty => Color32::from_rgb(220, 130, 130),
+                        WalletPoolBadgeHealth::Low => Color32::from_rgb(220, 200, 130),
+                        WalletPoolBadgeHealth::Healthy => Color32::from_rgb(150, 210, 160),
+                    };
+                    ui.label(RichText::new("●").small().color(fg));
+                    let ada_whole = pool.total_lovelace / 1_000_000;
+                    ui.label(
+                        RichText::new(format!("{} fuel · {} ADA", pool.fuel_count, ada_whole))
+                            .small()
+                            .color(fg),
+                    );
+                }
+
+                // Refuel — copies the address (silent, matches the
+                // other copy icons) and emits an action so the host
+                // can flash a toast / open a faucet / log it. Hidden
+                // when the row has no `wallet_address_full` — nothing
+                // to copy.
+                if show_refuel {
+                    if let Some(full) = &row.wallet_address_full {
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            if ui
+                                .small_button(RichText::new("⛽ Refuel").small())
+                                .on_hover_text(
+                                    "Copy this wallet's address to the clipboard so \
+                                         you can paste it into the testnet faucet \
+                                         (or send ADA from another wallet).",
+                                )
+                                .clicked()
+                            {
+                                ui.ctx().copy_text(full.clone());
+                                response.actions.push(CollectionListAction::Refuel {
+                                    account_index: row.wallet_account_index,
+                                });
+                            }
+                        });
+                    }
+                }
+            });
+
+            ui.add_space(4.0);
+
+            // ── Footer: policy_id + copy ────────────────────────────
+            ui.horizontal(|ui| {
                 ui.label(
                     RichText::new(&row.policy_id_short)
                         .monospace()
@@ -502,12 +618,14 @@ fn render_card(
         });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_list_row(
     ui: &mut Ui,
     row: &CollectionRow,
     show_test_mint: bool,
     show_seed_stubs: bool,
     show_activity: bool,
+    show_refuel: bool,
     response: &mut CollectionListResponse,
 ) {
     Frame::new()
@@ -537,54 +655,68 @@ fn render_list_row(
                     .small(),
                 );
 
-                ui.with_layout(
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        if show_test_mint {
-                            let label = if row.test_mint_open {
-                                "− Test mint"
-                            } else {
-                                "🧪 Test mint"
-                            };
-                            if ui.small_button(RichText::new(label).small()).clicked() {
-                                response.actions.push(CollectionListAction::TestMint {
-                                    policy_id: row.policy_id.clone(),
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if show_test_mint {
+                        let label = if row.test_mint_open {
+                            "− Test mint"
+                        } else {
+                            "🧪 Test mint"
+                        };
+                        if ui.small_button(RichText::new(label).small()).clicked() {
+                            response.actions.push(CollectionListAction::TestMint {
+                                policy_id: row.policy_id.clone(),
+                            });
+                        }
+                    }
+                    if show_seed_stubs {
+                        let label = if row.seed_stubs_open {
+                            "− Seed stubs"
+                        } else {
+                            "+ Seed stubs"
+                        };
+                        if ui.small_button(RichText::new(label).small()).clicked() {
+                            response.actions.push(CollectionListAction::SeedStubs {
+                                policy_id: row.policy_id.clone(),
+                            });
+                        }
+                    }
+                    if show_activity {
+                        let label = if row.activity_open {
+                            "− Activity"
+                        } else {
+                            "📜 Activity"
+                        };
+                        if ui.small_button(RichText::new(label).small()).clicked() {
+                            response.actions.push(CollectionListAction::Activity {
+                                policy_id: row.policy_id.clone(),
+                            });
+                        }
+                    }
+                    if ui
+                        .small_button(RichText::new("📋").small())
+                        .on_hover_text("Copy policy_id to clipboard")
+                        .clicked()
+                    {
+                        ui.ctx().copy_text(row.policy_id.clone());
+                    }
+                    if show_refuel {
+                        if let Some(full) = &row.wallet_address_full {
+                            if ui
+                                .small_button(RichText::new("⛽").small())
+                                .on_hover_text(
+                                    "Copy this wallet's address to the clipboard \
+                                         (refuel via faucet or another wallet).",
+                                )
+                                .clicked()
+                            {
+                                ui.ctx().copy_text(full.clone());
+                                response.actions.push(CollectionListAction::Refuel {
+                                    account_index: row.wallet_account_index,
                                 });
                             }
                         }
-                        if show_seed_stubs {
-                            let label = if row.seed_stubs_open {
-                                "− Seed stubs"
-                            } else {
-                                "+ Seed stubs"
-                            };
-                            if ui.small_button(RichText::new(label).small()).clicked() {
-                                response.actions.push(CollectionListAction::SeedStubs {
-                                    policy_id: row.policy_id.clone(),
-                                });
-                            }
-                        }
-                        if show_activity {
-                            let label = if row.activity_open {
-                                "− Activity"
-                            } else {
-                                "📜 Activity"
-                            };
-                            if ui.small_button(RichText::new(label).small()).clicked() {
-                                response.actions.push(CollectionListAction::Activity {
-                                    policy_id: row.policy_id.clone(),
-                                });
-                            }
-                        }
-                        if ui
-                            .small_button(RichText::new("📋").small())
-                            .on_hover_text("Copy policy_id to clipboard")
-                            .clicked()
-                        {
-                            ui.ctx().copy_text(row.policy_id.clone());
-                        }
-                    },
-                );
+                    }
+                });
             });
         });
 }
@@ -602,7 +734,12 @@ fn standard_chip(ui: &mut Ui, standard: &str) {
         "cip68" => STD_CIP68_CHIP,
         _ => STD_UNKNOWN_CHIP,
     };
-    chip(ui, &standard.to_uppercase(), Color32::from_rgb(20, 20, 30), colour);
+    chip(
+        ui,
+        &standard.to_uppercase(),
+        Color32::from_rgb(20, 20, 30),
+        colour,
+    );
 }
 
 fn network_chip(ui: &mut Ui, network: &str) {
@@ -653,8 +790,10 @@ fn status_chip_colours(status: &str) -> (Color32, Color32) {
 /// Thin horizontal progress bar — 4 px tall, full surface width.
 fn draw_thin_bar(ui: &mut Ui, pct: f32, fill: Color32) {
     let height = 4.0;
-    let (rect, _) =
-        ui.allocate_exact_size(egui::vec2(ui.available_width(), height), egui::Sense::hover());
+    let (rect, _) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), height),
+        egui::Sense::hover(),
+    );
     let painter = ui.painter();
     let corner = CornerRadius::same(2);
     painter.rect_filled(rect, corner, BAR_TRACK);

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -132,6 +132,12 @@ pub struct CollectionRow {
     /// label so the operator can't double-fire. Host clears this when
     /// the action ack lands (success or failure).
     pub refuel_in_flight: bool,
+    /// Soft-archive timestamp (unix seconds), or `None` if active.
+    /// Archived rows render dimmed with an "archived" chip; the
+    /// Archive button flips to Restore. When
+    /// [`CollectionList::with_hide_archived`] is set they're hidden
+    /// behind a "show archived" toggle.
+    pub archived_at: Option<i64>,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -159,6 +165,13 @@ pub enum CollectionListAction {
     /// `pool.health != Healthy`. Widget self-enforces the no-op rule
     /// — host doesn't have to check.
     Refuel { policy_id: String },
+    /// User clicked Archive on an active card. Host soft-archives the
+    /// collection (halts its engine DO + hides it). Only emitted when
+    /// [`CollectionList::with_archive`] is `true`.
+    Archive { policy_id: String },
+    /// User clicked Restore on an archived card. Symmetric to
+    /// [`Archive`]; only emitted from archived rows.
+    Unarchive { policy_id: String },
 }
 
 /// Rendering style. Both styles share the same row VM and action emission —
@@ -183,6 +196,8 @@ pub struct CollectionList<'a> {
     show_seed_stubs: bool,
     show_activity: bool,
     show_refuel: bool,
+    show_archive: bool,
+    hide_archived: bool,
 }
 
 /// Response — drained actions for this frame.
@@ -198,6 +213,7 @@ pub struct CollectionListResponse {
 // ─────────────────────────────────────────────────────────────────────
 
 const ROW_BG: Color32 = Color32::from_rgb(22, 22, 32);
+const ROW_BG_ARCHIVED: Color32 = Color32::from_rgb(18, 18, 24);
 const ROW_STROKE: Color32 = Color32::from_rgb(40, 40, 56);
 const META_GREY: Color32 = Color32::from_gray(140);
 const KEYHASH_GREY: Color32 = Color32::from_gray(120);
@@ -230,7 +246,26 @@ impl<'a> CollectionList<'a> {
             show_seed_stubs: false,
             show_activity: false,
             show_refuel: false,
+            show_archive: false,
+            hide_archived: false,
         }
+    }
+
+    /// Show a per-card Archive button (Restore on archived cards). Off by
+    /// default. Click → [`CollectionListAction::Archive`] /
+    /// [`CollectionListAction::Unarchive`].
+    pub fn with_archive(mut self, enabled: bool) -> Self {
+        self.show_archive = enabled;
+        self
+    }
+
+    /// Hide archived collections by default behind a "Show N archived" toggle
+    /// rendered below the grid. Off by default (archived cards render inline,
+    /// dimmed). The reveal flag is cosmetic — it lives in egui memory, not the
+    /// host. Mirrors [`crate::wallet_list::WalletList::with_hide_archived`].
+    pub fn with_hide_archived(mut self, hide: bool) -> Self {
+        self.hide_archived = hide;
+        self
     }
 
     /// Switch the per-row presentation. See [`CollectionListLayout`].
@@ -295,53 +330,91 @@ impl<'a> CollectionList<'a> {
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
-        if self.rows.is_empty() {
-            return response;
-        }
-
-        // Per-grid clamp: a 1-row layout renders full-width even when
-        // 2+ columns are configured.
-        let effective_cols = self.columns.min(self.rows.len()).max(1);
-
-        let gap = match self.layout {
-            CollectionListLayout::Card => 8.0,
-            CollectionListLayout::List => 4.0,
+        // Archived collections are hidden by default when `hide_archived` is
+        // set — they're noise on the active dashboard. The reveal flag is
+        // cosmetic, so it lives in egui memory keyed by this Ui's id rather
+        // than round-tripping through the host. When hiding is off, archived
+        // cards render inline (dimmed).
+        let archived_total = self.rows.iter().filter(|r| r.archived_at.is_some()).count();
+        let toggle_id = ui.id().with("collection_list_show_archived");
+        let show_archived = if self.hide_archived {
+            ui.ctx()
+                .data_mut(|d| d.get_temp::<bool>(toggle_id))
+                .unwrap_or(false)
+        } else {
+            true
         };
+        let visible: Vec<&CollectionRow> = self
+            .rows
+            .iter()
+            .filter(|r| show_archived || r.archived_at.is_none())
+            .collect();
 
-        let chunks: Vec<&[CollectionRow]> = self.rows.chunks(effective_cols).collect();
-        let last_chunk = chunks.len().saturating_sub(1);
-        for (chunk_idx, chunk) in chunks.iter().enumerate() {
-            if effective_cols == 1 {
-                for r in chunk.iter() {
-                    render_one(
-                        ui,
-                        r,
-                        self.layout,
-                        self.show_test_mint,
-                        self.show_seed_stubs,
-                        self.show_activity,
-                        self.show_refuel,
-                        &mut response,
-                    );
-                }
-            } else {
-                ui.columns(effective_cols, |cols| {
-                    for (i, r) in chunk.iter().enumerate() {
+        if !visible.is_empty() {
+            // Per-grid clamp: a 1-row layout renders full-width even when
+            // 2+ columns are configured.
+            let effective_cols = self.columns.min(visible.len()).max(1);
+
+            let gap = match self.layout {
+                CollectionListLayout::Card => 8.0,
+                CollectionListLayout::List => 4.0,
+            };
+
+            let chunks: Vec<&[&CollectionRow]> = visible.chunks(effective_cols).collect();
+            let last_chunk = chunks.len().saturating_sub(1);
+            for (chunk_idx, chunk) in chunks.iter().enumerate() {
+                if effective_cols == 1 {
+                    for r in chunk.iter() {
                         render_one(
-                            &mut cols[i],
+                            ui,
                             r,
                             self.layout,
                             self.show_test_mint,
                             self.show_seed_stubs,
                             self.show_activity,
                             self.show_refuel,
+                            self.show_archive,
                             &mut response,
                         );
                     }
-                });
+                } else {
+                    ui.columns(effective_cols, |cols| {
+                        for (i, r) in chunk.iter().enumerate() {
+                            render_one(
+                                &mut cols[i],
+                                r,
+                                self.layout,
+                                self.show_test_mint,
+                                self.show_seed_stubs,
+                                self.show_activity,
+                                self.show_refuel,
+                                self.show_archive,
+                                &mut response,
+                            );
+                        }
+                    });
+                }
+                if chunk_idx < last_chunk {
+                    ui.add_space(gap);
+                }
             }
-            if chunk_idx < last_chunk {
-                ui.add_space(gap);
+        }
+
+        // Reveal toggle — only when hiding is enabled and there's something to
+        // reveal. Flips the cosmetic flag in egui memory.
+        if self.hide_archived && archived_total > 0 {
+            ui.add_space(6.0);
+            let label = if show_archived {
+                format!("Hide {archived_total} archived")
+            } else {
+                format!("Show {archived_total} archived")
+            };
+            if ui
+                .add(egui::Button::new(RichText::new(label).small().color(META_GREY)).small())
+                .clicked()
+            {
+                ui.ctx()
+                    .data_mut(|d| d.insert_temp(toggle_id, !show_archived));
             }
         }
 
@@ -362,6 +435,7 @@ fn render_one(
     show_seed_stubs: bool,
     show_activity: bool,
     show_refuel: bool,
+    show_archive: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
@@ -372,6 +446,7 @@ fn render_one(
             show_seed_stubs,
             show_activity,
             show_refuel,
+            show_archive,
             response,
         ),
         CollectionListLayout::List => render_list_row(
@@ -381,6 +456,7 @@ fn render_one(
             show_seed_stubs,
             show_activity,
             show_refuel,
+            show_archive,
             response,
         ),
     }
@@ -394,10 +470,13 @@ fn render_card(
     show_seed_stubs: bool,
     show_activity: bool,
     show_refuel: bool,
+    show_archive: bool,
     response: &mut CollectionListResponse,
 ) {
+    let archived = row.archived_at.is_some();
+    let fill = if archived { ROW_BG_ARCHIVED } else { ROW_BG };
     Frame::new()
-        .fill(ROW_BG)
+        .fill(fill)
         .stroke(Stroke::new(1.0, ROW_STROKE))
         .corner_radius(CornerRadius::same(8))
         .inner_margin(Margin::symmetric(14, 12))
@@ -406,7 +485,12 @@ fn render_card(
 
             // ── Title row: title + chips + (right) action buttons ──
             ui.horizontal(|ui| {
-                ui.label(RichText::new(&row.title).heading());
+                let title = RichText::new(&row.title).heading();
+                ui.label(if archived {
+                    title.color(META_GREY)
+                } else {
+                    title
+                });
 
                 // Status chip — filled tag using the status colour. The
                 // chip is the strongest secondary signal after the title,
@@ -414,8 +498,14 @@ fn render_card(
                 status_chip(ui, &row.status);
                 standard_chip(ui, &row.standard);
                 network_chip(ui, &row.network);
+                if archived {
+                    ui.colored_label(Color32::LIGHT_YELLOW, RichText::new("archived").small());
+                }
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if show_archive {
+                        archive_button(ui, row, archived, response);
+                    }
                     if show_test_mint {
                         let label = if row.test_mint_open {
                             "− Test mint"
@@ -628,17 +718,28 @@ fn render_list_row(
     show_seed_stubs: bool,
     show_activity: bool,
     show_refuel: bool,
+    show_archive: bool,
     response: &mut CollectionListResponse,
 ) {
+    let archived = row.archived_at.is_some();
+    let fill = if archived { ROW_BG_ARCHIVED } else { ROW_BG };
     Frame::new()
-        .fill(ROW_BG)
+        .fill(fill)
         .stroke(Stroke::new(1.0, ROW_STROKE))
         .corner_radius(CornerRadius::same(4))
         .inner_margin(Margin::symmetric(10, 7))
         .show(ui, |ui| {
             ui.horizontal(|ui| {
-                ui.label(RichText::new(&row.title).strong());
+                let title = RichText::new(&row.title).strong();
+                ui.label(if archived {
+                    title.color(META_GREY)
+                } else {
+                    title
+                });
                 status_chip(ui, &row.status);
+                if archived {
+                    ui.colored_label(Color32::LIGHT_YELLOW, RichText::new("archived").small());
+                }
                 ui.label(
                     RichText::new(format!("{}/{}", row.minted_count, row.total_supply))
                         .monospace()
@@ -658,6 +759,9 @@ fn render_list_row(
                 );
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if show_archive {
+                        archive_button(ui, row, archived, response);
+                    }
                     if show_test_mint {
                         let label = if row.test_mint_open {
                             "− Test mint"
@@ -754,6 +858,42 @@ fn refuel_button(
         .clicked()
     {
         response.actions.push(CollectionListAction::Refuel {
+            policy_id: row.policy_id.clone(),
+        });
+    }
+}
+
+/// Archive ↔ Restore button, shared by both layouts. Emits
+/// [`CollectionListAction::Unarchive`] on an archived card, else
+/// [`CollectionListAction::Archive`]. Archiving halts the collection's
+/// engine DO + hides the card; restoring re-enables it.
+fn archive_button(
+    ui: &mut Ui,
+    row: &CollectionRow,
+    archived: bool,
+    response: &mut CollectionListResponse,
+) {
+    if archived {
+        if ui
+            .small_button(RichText::new("Restore").small())
+            .on_hover_text(
+                "Bring this collection back — the engine resumes processing on the next signal.",
+            )
+            .clicked()
+        {
+            response.actions.push(CollectionListAction::Unarchive {
+                policy_id: row.policy_id.clone(),
+            });
+        }
+    } else if ui
+        .small_button(RichText::new("Archive").small())
+        .on_hover_text(
+            "Retire this collection: halts its mint engine + hides it from the \
+             dashboard. Reversible.",
+        )
+        .clicked()
+    {
+        response.actions.push(CollectionListAction::Archive {
             policy_id: row.policy_id.clone(),
         });
     }

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -127,6 +127,11 @@ pub struct CollectionRow {
     /// `None` when the parent hasn't refreshed UTxOs for the wallet
     /// yet (the host populates this from its cached UTxO snapshot).
     pub pool: Option<WalletPoolBadge>,
+    /// `true` while a refuel tx is in flight for this wallet. The
+    /// widget renders the Refuel button disabled with a spinner-style
+    /// label so the operator can't double-fire. Host clears this when
+    /// the action ack lands (success or failure).
+    pub refuel_in_flight: bool,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -144,13 +149,16 @@ pub enum CollectionListAction {
     /// User clicked the `wallet #N` link in the footer. Parent opens
     /// that wallet's UTxO panel (or whatever it does for wallet focus).
     OpenWallet { account_index: u32 },
-    /// User clicked the per-card "Refuel" button. The widget has already
-    /// copied the wallet address to the clipboard (matches the in-widget
-    /// copy-icon convention); the action exists so the host can flash a
-    /// toast / emit telemetry / open a faucet tab if it wants to. Only
-    /// emitted when [`CollectionList::with_refuel`] is `true` and the
-    /// row supplies `wallet_address_full`.
-    Refuel { account_index: u32 },
+    /// User clicked the per-card "Refuel" button. The host fires a
+    /// server-side fan-out tx (keyed by `policy_id` — the collection
+    /// owns the wallet) that sweeps the wallet's pure-ADA UTxOs into
+    /// N × 10 ADA fuel slots, so the wallet is mint-ready before the
+    /// first mint lands. Only emitted when [`CollectionList::with_refuel`]
+    /// is `true`, the row has a `pool` (so the widget can verify the
+    /// pool isn't already healthy), `refuel_in_flight` is `false`, and
+    /// `pool.health != Healthy`. Widget self-enforces the no-op rule
+    /// — host doesn't have to check.
+    Refuel { policy_id: String },
 }
 
 /// Rendering style. Both styles share the same row VM and action emission —
@@ -570,28 +578,22 @@ fn render_card(
                     );
                 }
 
-                // Refuel — copies the address (silent, matches the
-                // other copy icons) and emits an action so the host
-                // can flash a toast / open a faucet / log it. Hidden
-                // when the row has no `wallet_address_full` — nothing
-                // to copy.
+                // Refuel — fires a server-side fan-out tx that splits
+                // the wallet's pure-ADA balance into N × 10 ADA fuel
+                // slots, priming the wallet for parallel mints. The
+                // widget self-disables in three cases so the host
+                // doesn't have to:
+                //   - no pool snapshot yet — operator can't see fuel
+                //     state, button hidden
+                //   - pool already Healthy — refuel would be a no-op,
+                //     button shown but disabled with explanatory
+                //     hover text
+                //   - refuel already in flight — disabled, label is
+                //     "⛽ Refuelling…" until the host clears the flag
                 if show_refuel {
-                    if let Some(full) = &row.wallet_address_full {
+                    if let Some(pool) = &row.pool {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if ui
-                                .small_button(RichText::new("⛽ Refuel").small())
-                                .on_hover_text(
-                                    "Copy this wallet's address to the clipboard so \
-                                         you can paste it into the testnet faucet \
-                                         (or send ADA from another wallet).",
-                                )
-                                .clicked()
-                            {
-                                ui.ctx().copy_text(full.clone());
-                                response.actions.push(CollectionListAction::Refuel {
-                                    account_index: row.wallet_account_index,
-                                });
-                            }
+                            refuel_button(ui, row, pool, response);
                         });
                     }
                 }
@@ -700,25 +702,61 @@ fn render_list_row(
                         ui.ctx().copy_text(row.policy_id.clone());
                     }
                     if show_refuel {
-                        if let Some(full) = &row.wallet_address_full {
-                            if ui
-                                .small_button(RichText::new("⛽").small())
-                                .on_hover_text(
-                                    "Copy this wallet's address to the clipboard \
-                                         (refuel via faucet or another wallet).",
-                                )
-                                .clicked()
-                            {
-                                ui.ctx().copy_text(full.clone());
-                                response.actions.push(CollectionListAction::Refuel {
-                                    account_index: row.wallet_account_index,
-                                });
-                            }
+                        if let Some(pool) = &row.pool {
+                            refuel_button(ui, row, pool, response);
                         }
                     }
                 });
             });
         });
+}
+
+/// Shared Refuel button used by both card and list layouts. Owns the
+/// no-op-when-healthy + in-flight policies so neither call site (and
+/// no host) has to re-check the rules.
+///
+/// States, in priority order:
+///   - `refuel_in_flight` → disabled, label `⛽ Refuelling…`
+///   - `pool.health == Healthy` → disabled, label `⛽ Refuel`,
+///     explanatory hover ("pool is healthy")
+///   - otherwise → enabled, label `⛽ Refuel`, click emits the action
+fn refuel_button(
+    ui: &mut Ui,
+    row: &CollectionRow,
+    pool: &WalletPoolBadge,
+    response: &mut CollectionListResponse,
+) {
+    if row.refuel_in_flight {
+        ui.add_enabled(
+            false,
+            egui::Button::new(RichText::new("⛽ Refuelling…").small()),
+        )
+        .on_disabled_hover_text(
+            "A refuel tx is in flight — wait for it to confirm before submitting another.",
+        );
+        return;
+    }
+    let healthy = pool.health == WalletPoolBadgeHealth::Healthy;
+    if healthy {
+        ui.add_enabled(false, egui::Button::new(RichText::new("⛽ Refuel").small()))
+            .on_disabled_hover_text(
+                "Fuel pool is healthy — no refuel needed. \
+                 The pool tops up automatically during mints.",
+            );
+        return;
+    }
+    if ui
+        .small_button(RichText::new("⛽ Refuel").small())
+        .on_hover_text(
+            "Split this wallet's pure-ADA balance into 10 ADA fuel UTxOs \
+             so it's ready for parallel mints. Submits a self-spend tx.",
+        )
+        .clicked()
+    {
+        response.actions.push(CollectionListAction::Refuel {
+            policy_id: row.policy_id.clone(),
+        });
+    }
 }
 
 /// Filled chip with the status text in uppercase. Colour mirrors the

--- a/ui/egui-widgets/src/fungibles_row.rs
+++ b/ui/egui-widgets/src/fungibles_row.rs
@@ -126,11 +126,7 @@ impl<'a> FungiblesRow<'a> {
             }
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if let Some(v) = self.value_text {
-                    ui.label(
-                        RichText::new(v)
-                            .size(cfg.value_size)
-                            .color(cfg.value_color),
-                    );
+                    ui.label(RichText::new(v).size(cfg.value_size).color(cfg.value_color));
                     ui.add_space(6.0);
                 }
                 ui.label(
@@ -147,11 +143,9 @@ impl<'a> FungiblesRow<'a> {
 
 fn draw_chip(ui: &mut Ui, label: &str, cfg: &FungiblesRowConfig) {
     let font = FontId::proportional(cfg.ticker_size);
-    let galley = ui.painter().layout_no_wrap(
-        label.to_string(),
-        font,
-        cfg.ticker_text_color,
-    );
+    let galley = ui
+        .painter()
+        .layout_no_wrap(label.to_string(), font, cfg.ticker_text_color);
     let size = Vec2::new(
         galley.size().x + cfg.ticker_padding_x * 2.0,
         galley.size().y + cfg.ticker_padding_y * 2.0,
@@ -159,7 +153,11 @@ fn draw_chip(ui: &mut Ui, label: &str, cfg: &FungiblesRowConfig) {
     let (rect, _) = ui.allocate_exact_size(size, Sense::hover());
     if ui.is_rect_visible(rect) {
         let painter = ui.painter();
-        painter.rect_filled(rect, CornerRadius::same(cfg.ticker_corner_radius), cfg.ticker_bg);
+        painter.rect_filled(
+            rect,
+            CornerRadius::same(cfg.ticker_corner_radius),
+            cfg.ticker_bg,
+        );
         let pos = egui::pos2(
             rect.min.x + cfg.ticker_padding_x,
             rect.min.y + cfg.ticker_padding_y,

--- a/ui/egui-widgets/src/grouped_section.rs
+++ b/ui/egui-widgets/src/grouped_section.rs
@@ -188,9 +188,7 @@ impl<'a> GroupedSection<'a> {
                             .strong(),
                     );
                     if self.is_verified {
-                        ui.label(
-                            PhosphorIcon::CheckCircle.rich_text(12.0, cfg.badge_color),
-                        );
+                        ui.label(PhosphorIcon::CheckCircle.rich_text(12.0, cfg.badge_color));
                     }
                     if let Some((visible, label)) = &self.bulk_button {
                         if *visible {

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -12,12 +12,12 @@ pub mod flip_counter;
 pub mod fungibles_row;
 pub mod grouped_section;
 pub mod icons;
-pub mod offer_tile;
 pub mod image_loader;
 pub mod listing_grid;
 pub mod marquee;
 pub mod metric_card;
 pub mod mnemonic_display;
+pub mod offer_tile;
 pub mod persona_strip;
 pub mod pip_row;
 pub mod printing_timeline;
@@ -31,14 +31,14 @@ pub mod swap_modal;
 pub mod theme;
 pub mod trait_filter;
 pub mod utils;
-pub mod wallet_identity_header;
-pub mod wallet_list;
 #[cfg(all(target_arch = "wasm32", feature = "cardano"))]
 pub mod wallet;
 #[cfg(all(target_arch = "wasm32", feature = "cardano"))]
 pub mod wallet_button;
 #[cfg(feature = "cardano")]
 pub mod wallet_editor;
+pub mod wallet_identity_header;
+pub mod wallet_list;
 
 // Image text editor (feature-gated)
 #[cfg(feature = "image-editor")]
@@ -86,12 +86,17 @@ pub use buttons::UiButtonExt;
 pub use card_browser::{
     CardBrowserConfig, CardBrowserResponse, CardBrowserState, CardRenderContext,
 };
+pub use collection_list::{
+    CollectionList, CollectionListAction, CollectionListLayout, CollectionListResponse,
+    CollectionRow,
+};
 pub use donut_chart::{
     format_value as format_chart_value, legend_row, DistBand, DistributionChart,
 };
 #[cfg(target_arch = "wasm32")]
 pub use file_upload::{FileUploadButton, UploadedFile};
 pub use flip_counter::FlipCounter;
+pub use fungibles_row::{FungiblesRow, FungiblesRowConfig};
 pub use icons::{install_phosphor_font, PhosphorIcon};
 pub use image_loader::{iiif_asset_url, AssetImageSize};
 #[cfg(feature = "image-editor")]
@@ -100,20 +105,8 @@ pub use image_text_editor::{
 };
 pub use listing_grid::{ListingCard, ListingGrid, ListingGridConfig};
 pub use marquee::{Marquee, MarqueeConfig, MarqueeItem};
-pub use fungibles_row::{FungiblesRow, FungiblesRowConfig};
 pub use metric_card::{MetricCard, Trend};
 pub use persona_strip::{PersonaStrip, PersonaStripConfig};
-pub use wallet_identity_header::{
-    truncate_stake, WalletIdentityAction, WalletIdentityConfig, WalletIdentityHeader,
-};
-pub use collection_list::{
-    CollectionList, CollectionListAction, CollectionListLayout, CollectionListResponse,
-    CollectionRow,
-};
-pub use wallet_list::{
-    WalletList, WalletListAction, WalletListLayout, WalletListResponse, WalletListRole,
-    WalletListRow, WalletPoolBadge, WalletPoolBadgeHealth,
-};
 pub use pip_row::{
     HoverInfo, HoveredBin, HoveredPip, Pip, PipRowConfig, PipRowData, PipRowResponse,
 };
@@ -139,6 +132,13 @@ pub use wallet_button::{WalletAction, WalletButton, WalletButtonTheme};
 pub use wallet_editor::{
     WalletEditorAction, WalletEditorConfig, WalletEditorEntry, WalletEditorResponse,
     WalletEditorState, WalletEntryStatus,
+};
+pub use wallet_identity_header::{
+    truncate_stake, WalletIdentityAction, WalletIdentityConfig, WalletIdentityHeader,
+};
+pub use wallet_list::{
+    WalletList, WalletListAction, WalletListLayout, WalletListResponse, WalletListRole,
+    WalletListRow, WalletPoolBadge, WalletPoolBadgeHealth,
 };
 
 // DEX split swap re-exports

--- a/ui/egui-widgets/src/mnemonic_display.rs
+++ b/ui/egui-widgets/src/mnemonic_display.rs
@@ -162,8 +162,7 @@ impl<'a> MnemonicDisplay<'a> {
             ui.add_space(8.0);
             ui.checkbox(
                 confirmed,
-                RichText::new("I have securely recorded this recovery phrase")
-                    .strong(),
+                RichText::new("I have securely recorded this recovery phrase").strong(),
             );
             output.confirmed = *confirmed;
         }

--- a/ui/egui-widgets/src/offer_tile.rs
+++ b/ui/egui-widgets/src/offer_tile.rs
@@ -214,10 +214,7 @@ impl<'a> OfferTile<'a> {
 
         // Outer container — fixed size so wrapping rows align.
         // Height = tile + price label + a hair of spacing.
-        let outer_size = Vec2::new(
-            cfg.tile_size + 8.0,
-            cfg.tile_size + cfg.price_size + 12.0,
-        );
+        let outer_size = Vec2::new(cfg.tile_size + 8.0, cfg.tile_size + cfg.price_size + 12.0);
 
         let inner = ui.allocate_ui_with_layout(
             outer_size,
@@ -236,9 +233,8 @@ impl<'a> OfferTile<'a> {
                                         cfg.image_corner_radius,
                                     ));
                                 if dimmed {
-                                    img = img.tint(Color32::from_white_alpha(
-                                        cfg.dimmed_image_alpha,
-                                    ));
+                                    img =
+                                        img.tint(Color32::from_white_alpha(cfg.dimmed_image_alpha));
                                 }
                                 ui.add(img).rect
                             }

--- a/ui/egui-widgets/src/persona_strip.rs
+++ b/ui/egui-widgets/src/persona_strip.rs
@@ -105,11 +105,9 @@ impl<'a> PersonaStrip<'a> {
 
 fn draw_chip(ui: &mut Ui, label: &str, cfg: &PersonaStripConfig) {
     let font = FontId::proportional(cfg.chip_text_size);
-    let galley = ui.painter().layout_no_wrap(
-        label.to_string(),
-        font.clone(),
-        cfg.chip_text_color,
-    );
+    let galley = ui
+        .painter()
+        .layout_no_wrap(label.to_string(), font.clone(), cfg.chip_text_color);
     let size = Vec2::new(
         galley.size().x + cfg.chip_padding_x * 2.0,
         galley.size().y + cfg.chip_padding_y * 2.0,
@@ -117,7 +115,11 @@ fn draw_chip(ui: &mut Ui, label: &str, cfg: &PersonaStripConfig) {
     let (rect, _resp) = ui.allocate_exact_size(size, Sense::hover());
     if ui.is_rect_visible(rect) {
         let painter = ui.painter();
-        painter.rect_filled(rect, CornerRadius::same(cfg.chip_corner_radius), cfg.chip_bg);
+        painter.rect_filled(
+            rect,
+            CornerRadius::same(cfg.chip_corner_radius),
+            cfg.chip_bg,
+        );
         let text_pos = egui::pos2(
             rect.min.x + cfg.chip_padding_x,
             rect.min.y + cfg.chip_padding_y,

--- a/ui/egui-widgets/src/tx_cart.rs
+++ b/ui/egui-widgets/src/tx_cart.rs
@@ -200,11 +200,7 @@ pub enum TxCartAction {
 /// panel — call [`show_items`] inside a `ScrollArea` and
 /// [`show_footer`] inside a `TopBottomPanel::bottom`. Both halves
 /// can return actions, so the caller has to merge them.
-pub fn show(
-    ui: &mut Ui,
-    state: &mut TxCartState,
-    config: &TxCartConfig,
-) -> Option<TxCartAction> {
+pub fn show(ui: &mut Ui, state: &mut TxCartState, config: &TxCartConfig) -> Option<TxCartAction> {
     let mut action = show_items(ui, state, config);
     if let Some(a) = show_footer(ui, state) {
         action = Some(a);
@@ -251,7 +247,10 @@ pub fn show_items(
     // Group items by action_label for section display
     let mut groups: Vec<(String, Vec<&TxCartItem>)> = Vec::new();
     for item in &state.items {
-        if let Some(group) = groups.iter_mut().find(|(label, _)| *label == item.action_label) {
+        if let Some(group) = groups
+            .iter_mut()
+            .find(|(label, _)| *label == item.action_label)
+        {
             group.1.push(item);
         } else {
             groups.push((item.action_label.clone(), vec![item]));
@@ -279,16 +278,14 @@ pub fn show_items(
                     && ui
                         .add(
                             egui::Button::new(
-                                RichText::new("Clear")
-                                    .color(theme::TEXT_MUTED)
-                                    .size(10.0),
+                                RichText::new("Clear").color(theme::TEXT_MUTED).size(10.0),
                             )
                             .frame(false),
                         )
                         .clicked()
-                    {
-                        action = Some(TxCartAction::Clear);
-                    }
+                {
+                    action = Some(TxCartAction::Clear);
+                }
                 ui.label(
                     RichText::new(format!("{:.0} ADA", group_total))
                         .color(theme::ACCENT_RED)
@@ -362,53 +359,47 @@ pub fn show_items(
                             }
                             other => {
                                 ui.label(
-                                    RichText::new(other.label())
-                                        .color(other.color())
-                                        .size(9.0),
+                                    RichText::new(other.label()).color(other.color()).size(9.0),
                                 );
                             }
                         }
                     });
 
                     // Right side: quantity x price + remove
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            // Remove button
-                            if matches!(item.status, TxCartItemStatus::Pending)
-                                && matches!(state.phase, TxCartPhase::Editing)
-                            {
-                                if ui
-                                    .add(
-                                        egui::Button::new(
-                                            PhosphorIcon::Trash
-                                                .rich_text(14.0, theme::TEXT_MUTED),
-                                        )
-                                        .frame(false),
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        // Remove button
+                        if matches!(item.status, TxCartItemStatus::Pending)
+                            && matches!(state.phase, TxCartPhase::Editing)
+                        {
+                            if ui
+                                .add(
+                                    egui::Button::new(
+                                        PhosphorIcon::Trash.rich_text(14.0, theme::TEXT_MUTED),
                                     )
-                                    .clicked()
-                                {
-                                    remove_id = Some(item.id.clone());
-                                }
-                                ui.add_space(4.0);
+                                    .frame(false),
+                                )
+                                .clicked()
+                            {
+                                remove_id = Some(item.id.clone());
                             }
+                            ui.add_space(4.0);
+                        }
 
-                            // Price
-                            let total = item.ada_per_item * item.quantity as f64;
+                        // Price
+                        let total = item.ada_per_item * item.quantity as f64;
+                        ui.label(
+                            RichText::new(format!("{:.0} ADA", total))
+                                .color(theme::TEXT_PRIMARY)
+                                .size(11.0),
+                        );
+                        if item.quantity > 1 {
                             ui.label(
-                                RichText::new(format!("{:.0} ADA", total))
-                                    .color(theme::TEXT_PRIMARY)
-                                    .size(11.0),
+                                RichText::new(format!("{}x", item.quantity))
+                                    .color(theme::TEXT_MUTED)
+                                    .size(10.0),
                             );
-                            if item.quantity > 1 {
-                                ui.label(
-                                    RichText::new(format!("{}x", item.quantity))
-                                        .color(theme::TEXT_MUTED)
-                                        .size(10.0),
-                                );
-                            }
-                        },
-                    );
+                        }
+                    });
                 })
                 .response
                 .rect;
@@ -429,11 +420,7 @@ pub fn show_items(
                 } else {
                     short.to_string()
                 };
-                ui.label(
-                    RichText::new(short)
-                        .color(theme::ACCENT_RED)
-                        .size(9.0),
-                );
+                ui.label(RichText::new(short).color(theme::ACCENT_RED).size(9.0));
             }
 
             ui.add_space(4.0);
@@ -484,27 +471,24 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                             .size(11.0),
                     );
 
-                    ui.with_layout(
-                        egui::Layout::right_to_left(egui::Align::Center),
-                        |ui| {
-                            if ui
-                                .add(
-                                    egui::Button::new(
-                                        RichText::new("Prepare")
-                                            .color(theme::BG_PRIMARY)
-                                            .size(13.0)
-                                            .strong(),
-                                    )
-                                    .fill(theme::ACCENT_GREEN)
-                                    .corner_radius(egui::CornerRadius::same(6))
-                                    .min_size(egui::vec2(100.0, 32.0)),
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    RichText::new("Prepare")
+                                        .color(theme::BG_PRIMARY)
+                                        .size(13.0)
+                                        .strong(),
                                 )
-                                .clicked()
-                            {
-                                action = Some(TxCartAction::Execute);
-                            }
-                        },
-                    );
+                                .fill(theme::ACCENT_GREEN)
+                                .corner_radius(egui::CornerRadius::same(6))
+                                .min_size(egui::vec2(100.0, 32.0)),
+                            )
+                            .clicked()
+                        {
+                            action = Some(TxCartAction::Execute);
+                        }
+                    });
                 });
             }
         }
@@ -564,9 +548,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                 if ui
                     .add(
                         egui::Button::new(
-                            RichText::new("< Edit")
-                                .color(theme::TEXT_MUTED)
-                                .size(11.0),
+                            RichText::new("< Edit").color(theme::TEXT_MUTED).size(11.0),
                         )
                         .frame(false),
                     )
@@ -609,11 +591,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                 } else {
                     format!("Submitting {completed}/{total}...")
                 };
-                ui.label(
-                    RichText::new(label)
-                        .color(theme::ACCENT_CYAN)
-                        .size(12.0),
-                );
+                ui.label(RichText::new(label).color(theme::ACCENT_CYAN).size(12.0));
             });
         }
 
@@ -621,9 +599,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
             ui.separator();
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                ui.label(
-                    PhosphorIcon::CheckCircle.rich_text(16.0, theme::ACCENT_GREEN),
-                );
+                ui.label(PhosphorIcon::CheckCircle.rich_text(16.0, theme::ACCENT_GREEN));
                 ui.label(
                     RichText::new("All transactions submitted")
                         .color(theme::ACCENT_GREEN)
@@ -634,9 +610,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                     if ui
                         .add(
                             egui::Button::new(
-                                RichText::new("Clear")
-                                    .color(theme::TEXT_PRIMARY)
-                                    .size(12.0),
+                                RichText::new("Clear").color(theme::TEXT_PRIMARY).size(12.0),
                             )
                             .fill(theme::BG_SECONDARY)
                             .corner_radius(egui::CornerRadius::same(6))
@@ -667,9 +641,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                 if ui
                     .add(
                         egui::Button::new(
-                            RichText::new("Retry")
-                                .color(theme::TEXT_PRIMARY)
-                                .size(12.0),
+                            RichText::new("Retry").color(theme::TEXT_PRIMARY).size(12.0),
                         )
                         .fill(theme::BG_SECONDARY)
                         .corner_radius(egui::CornerRadius::same(6))
@@ -683,9 +655,7 @@ pub fn show_footer(ui: &mut Ui, state: &mut TxCartState) -> Option<TxCartAction>
                 if ui
                     .add(
                         egui::Button::new(
-                            RichText::new("Clear")
-                                .color(theme::TEXT_MUTED)
-                                .size(12.0),
+                            RichText::new("Clear").color(theme::TEXT_MUTED).size(12.0),
                         )
                         .frame(false),
                     )

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -270,8 +270,9 @@ impl<'a> WalletList<'a> {
         collections.sort_by_key(|r| r.account_index);
         custom.sort_by_key(|r| r.account_index);
 
-        let populated_buckets =
-            usize::from(!primary.is_empty()) + usize::from(!collections.is_empty()) + usize::from(!custom.is_empty());
+        let populated_buckets = usize::from(!primary.is_empty())
+            + usize::from(!collections.is_empty())
+            + usize::from(!custom.is_empty());
         let show_headers = self.show_section_headers_for_single || populated_buckets > 1;
 
         render_bucket(
@@ -286,9 +287,7 @@ impl<'a> WalletList<'a> {
             &mut response,
         );
 
-        if !primary.is_empty()
-            && (!collections.is_empty() || !custom.is_empty())
-        {
+        if !primary.is_empty() && (!collections.is_empty() || !custom.is_empty()) {
             ui.add_space(8.0);
         }
 
@@ -348,12 +347,7 @@ fn render_bucket(
     if show_header {
         ui.add_space(2.0);
         ui.horizontal(|ui| {
-            ui.label(
-                RichText::new(title)
-                    .color(SECTION_HEADER)
-                    .small()
-                    .strong(),
-            );
+            ui.label(RichText::new(title).color(SECTION_HEADER).small().strong());
             ui.label(
                 RichText::new(format!("({})", rows.len()))
                     .color(META_GREY)
@@ -393,7 +387,14 @@ fn render_bucket(
             // grid alignment with cells above).
             ui.columns(effective_cols, |cols| {
                 for (i, r) in chunk.iter().enumerate() {
-                    render_one(&mut cols[i], r, layout, allow_archive, view_button, response);
+                    render_one(
+                        &mut cols[i],
+                        r,
+                        layout,
+                        allow_archive,
+                        view_button,
+                        response,
+                    );
                 }
             });
         }
@@ -442,7 +443,11 @@ fn render_row(
                 ui.label(
                     RichText::new(format!("#{}", row.account_index))
                         .monospace()
-                        .color(if archived { META_GREY } else { Color32::from_gray(200) }),
+                        .color(if archived {
+                            META_GREY
+                        } else {
+                            Color32::from_gray(200)
+                        }),
                 );
 
                 // ── Label ───────────────────────────────────────────
@@ -469,89 +474,82 @@ fn render_row(
                 }
 
                 if archived {
-                    ui.colored_label(
-                        Color32::LIGHT_YELLOW,
-                        RichText::new("archived").small(),
-                    );
+                    ui.colored_label(Color32::LIGHT_YELLOW, RichText::new("archived").small());
                 }
 
                 // ── Address (right-aligned with copy + archive) ─────
-                ui.with_layout(
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        // Archive ↔ Restore — placed first because of
-                        // the right-to-left layout (ends up rightmost).
-                        // Archive hidden for Primary (unless explicitly
-                        // enabled). Restore appears only on archived
-                        // rows; clicking flips the wallet back to active.
-                        if archived {
-                            if ui
-                                .small_button(RichText::new("Restore").small())
-                                .on_hover_text(
-                                    "Bring this wallet back from archived. \
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    // Archive ↔ Restore — placed first because of
+                    // the right-to-left layout (ends up rightmost).
+                    // Archive hidden for Primary (unless explicitly
+                    // enabled). Restore appears only on archived
+                    // rows; clicking flips the wallet back to active.
+                    if archived {
+                        if ui
+                            .small_button(RichText::new("Restore").small())
+                            .on_hover_text(
+                                "Bring this wallet back from archived. \
                                      Clears `archived_at`; no key material touched.",
+                            )
+                            .clicked()
+                        {
+                            response.actions.push(WalletListAction::Unarchive {
+                                account_index: row.account_index,
+                            });
+                        }
+                    } else {
+                        let can_archive = row.role != WalletListRole::Primary || allow_archive;
+                        if can_archive
+                            && ui
+                                .small_button(RichText::new("Archive").small())
+                                .on_hover_text(
+                                    "Soft-delete this wallet (reversible — historical \
+                                         collections still resolve their key_hash)",
                                 )
                                 .clicked()
-                            {
-                                response.actions.push(WalletListAction::Unarchive {
-                                    account_index: row.account_index,
-                                });
-                            }
-                        } else {
-                            let can_archive =
-                                row.role != WalletListRole::Primary || allow_archive;
-                            if can_archive
-                                && ui
-                                    .small_button(RichText::new("Archive").small())
-                                    .on_hover_text(
-                                        "Soft-delete this wallet (reversible — historical \
-                                         collections still resolve their key_hash)",
-                                    )
-                                    .clicked()
-                            {
-                                response.actions.push(WalletListAction::Archive {
-                                    account_index: row.account_index,
-                                });
-                            }
+                        {
+                            response.actions.push(WalletListAction::Archive {
+                                account_index: row.account_index,
+                            });
                         }
+                    }
 
-                        // View-UTxOs button. Opt-in via
-                        // `with_view_button(true)` since not every
-                        // host has a panel to render them into.
-                        if view_button {
-                            let clicked = ui
-                                .small_button(RichText::new("UTxOs").small())
-                                .on_hover_text("View on-chain UTxOs for this wallet")
-                                .clicked();
-                            if clicked {
-                                response.actions.push(WalletListAction::ViewUtxos {
-                                    account_index: row.account_index,
-                                });
-                            }
+                    // View-UTxOs button. Opt-in via
+                    // `with_view_button(true)` since not every
+                    // host has a panel to render them into.
+                    if view_button {
+                        let clicked = ui
+                            .small_button(RichText::new("UTxOs").small())
+                            .on_hover_text("View on-chain UTxOs for this wallet")
+                            .clicked();
+                        if clicked {
+                            response.actions.push(WalletListAction::ViewUtxos {
+                                account_index: row.account_index,
+                            });
                         }
+                    }
 
-                        // Copy-to-clipboard icon button — copies the full
-                        // address (not the truncation) so the value is
-                        // usable. egui has a built-in clipboard helper;
-                        // we don't need to round-trip through a parent
-                        // action. Hidden when no `address_full` is set.
-                        if let Some(full) = &row.address_full {
-                            let copy = ui
-                                .small_button(RichText::new("📋").small())
-                                .on_hover_text("Copy address to clipboard");
-                            if copy.clicked() {
-                                ui.ctx().copy_text(full.clone());
-                            }
+                    // Copy-to-clipboard icon button — copies the full
+                    // address (not the truncation) so the value is
+                    // usable. egui has a built-in clipboard helper;
+                    // we don't need to round-trip through a parent
+                    // action. Hidden when no `address_full` is set.
+                    if let Some(full) = &row.address_full {
+                        let copy = ui
+                            .small_button(RichText::new("📋").small())
+                            .on_hover_text("Copy address to clipboard");
+                        if copy.clicked() {
+                            ui.ctx().copy_text(full.clone());
                         }
+                    }
 
-                        ui.label(
-                            RichText::new(&row.address_short)
-                                .color(KEYHASH_GREY)
-                                .monospace()
-                                .small(),
-                        );
-                    },
-                );
+                    ui.label(
+                        RichText::new(&row.address_short)
+                            .color(KEYHASH_GREY)
+                            .monospace()
+                            .small(),
+                    );
+                });
             });
         });
 }
@@ -594,7 +592,11 @@ fn render_card(
             // qualifying it. Archive lives at the far right.
             ui.horizontal(|ui| {
                 let title = RichText::new(&row.label).heading();
-                let title = if archived { title.color(META_GREY) } else { title };
+                let title = if archived {
+                    title.color(META_GREY)
+                } else {
+                    title
+                };
                 ui.label(title);
                 ui.label(
                     RichText::new(format!("#{}", row.account_index))
@@ -622,57 +624,50 @@ fn render_card(
                     ui.colored_label(META_GREY, RichText::new("auto").small());
                 }
                 if archived {
-                    ui.colored_label(
-                        Color32::LIGHT_YELLOW,
-                        RichText::new("archived").small(),
-                    );
+                    ui.colored_label(Color32::LIGHT_YELLOW, RichText::new("archived").small());
                 }
 
-                ui.with_layout(
-                    egui::Layout::right_to_left(egui::Align::Center),
-                    |ui| {
-                        if archived {
-                            if ui
-                                .small_button(RichText::new("Restore").small())
-                                .on_hover_text(
-                                    "Bring this wallet back from archived. \
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if archived {
+                        if ui
+                            .small_button(RichText::new("Restore").small())
+                            .on_hover_text(
+                                "Bring this wallet back from archived. \
                                      Clears `archived_at`; no key material touched.",
-                                )
-                                .clicked()
-                            {
-                                response.actions.push(WalletListAction::Unarchive {
-                                    account_index: row.account_index,
-                                });
-                            }
-                        } else {
-                            let can_archive =
-                                row.role != WalletListRole::Primary || allow_archive;
-                            if can_archive
-                                && ui
-                                    .small_button(RichText::new("Archive").small())
-                                    .on_hover_text(
-                                        "Soft-delete this wallet (reversible — historical \
-                                         collections still resolve their key_hash)",
-                                    )
-                                    .clicked()
-                            {
-                                response.actions.push(WalletListAction::Archive {
-                                    account_index: row.account_index,
-                                });
-                            }
-                        }
-                        if view_button
-                            && ui
-                                .small_button(RichText::new("UTxOs").small())
-                                .on_hover_text("View on-chain UTxOs for this wallet")
-                                .clicked()
+                            )
+                            .clicked()
                         {
-                            response.actions.push(WalletListAction::ViewUtxos {
+                            response.actions.push(WalletListAction::Unarchive {
                                 account_index: row.account_index,
                             });
                         }
-                    },
-                );
+                    } else {
+                        let can_archive = row.role != WalletListRole::Primary || allow_archive;
+                        if can_archive
+                            && ui
+                                .small_button(RichText::new("Archive").small())
+                                .on_hover_text(
+                                    "Soft-delete this wallet (reversible — historical \
+                                         collections still resolve their key_hash)",
+                                )
+                                .clicked()
+                        {
+                            response.actions.push(WalletListAction::Archive {
+                                account_index: row.account_index,
+                            });
+                        }
+                    }
+                    if view_button
+                        && ui
+                            .small_button(RichText::new("UTxOs").small())
+                            .on_hover_text("View on-chain UTxOs for this wallet")
+                            .clicked()
+                    {
+                        response.actions.push(WalletListAction::ViewUtxos {
+                            account_index: row.account_index,
+                        });
+                    }
+                });
             });
 
             ui.add_space(8.0);

--- a/ui/egui-widgets/src/wallet_list.rs
+++ b/ui/egui-widgets/src/wallet_list.rs
@@ -170,6 +170,7 @@ pub struct WalletList<'a> {
     can_archive_primary: bool,
     show_section_headers_for_single: bool,
     view_button: bool,
+    hide_archived: bool,
 }
 
 /// Response — drained actions for this frame.
@@ -205,7 +206,18 @@ impl<'a> WalletList<'a> {
             can_archive_primary: false,
             show_section_headers_for_single: false,
             view_button: false,
+            hide_archived: false,
         }
+    }
+
+    /// Hide archived rows by default behind a "Show N archived" toggle. Off by
+    /// default (archived rows render inline, dimmed). When enabled, archived
+    /// rows are dropped from every bucket until the operator clicks the reveal
+    /// toggle rendered below the list — the reveal flag is purely cosmetic and
+    /// lives in egui memory, so it doesn't round-trip through the host.
+    pub fn with_hide_archived(mut self, hide: bool) -> Self {
+        self.hide_archived = hide;
+        self
     }
 
     /// Show a per-row "UTxOs" button alongside Archive. Off by
@@ -255,20 +267,39 @@ impl<'a> WalletList<'a> {
     pub fn show(self, ui: &mut Ui) -> WalletListResponse {
         let mut response = WalletListResponse::default();
 
-        // Bucket the rows in a stable order: Primary → Collections (by
-        // account_index ASC) → Custom (by account_index ASC).
+        // Archived rows are hidden by default when `hide_archived` is set —
+        // they're noise on the active roster. The reveal flag is cosmetic, so
+        // it lives in egui memory keyed by this Ui's id rather than
+        // round-tripping through the host. When hiding is off, archived rows
+        // always render inline (the original behaviour).
+        let archived_total = self.rows.iter().filter(|r| r.archived_at.is_some()).count();
+        let toggle_id = ui.id().with("wallet_list_show_archived");
+        let show_archived = if self.hide_archived {
+            ui.ctx()
+                .data_mut(|d| d.get_temp::<bool>(toggle_id))
+                .unwrap_or(false)
+        } else {
+            true
+        };
+
+        // Bucket the rows in a stable order: Primary → Collections → Custom,
+        // active before archived within each bucket (by account_index ASC).
+        // Archived rows are dropped entirely while the reveal toggle is off.
         let mut primary: Vec<&WalletListRow> = Vec::new();
         let mut collections: Vec<&WalletListRow> = Vec::new();
         let mut custom: Vec<&WalletListRow> = Vec::new();
         for r in self.rows {
+            if r.archived_at.is_some() && !show_archived {
+                continue;
+            }
             match r.role {
                 WalletListRole::Primary => primary.push(r),
                 WalletListRole::Collection => collections.push(r),
                 WalletListRole::Custom => custom.push(r),
             }
         }
-        collections.sort_by_key(|r| r.account_index);
-        custom.sort_by_key(|r| r.account_index);
+        collections.sort_by_key(|r| (r.archived_at.is_some(), r.account_index));
+        custom.sort_by_key(|r| (r.archived_at.is_some(), r.account_index));
 
         let populated_buckets = usize::from(!primary.is_empty())
             + usize::from(!collections.is_empty())
@@ -318,6 +349,24 @@ impl<'a> WalletList<'a> {
             self.view_button,
             &mut response,
         );
+
+        // Reveal toggle — only when hiding is enabled and there's something to
+        // reveal. Flips the cosmetic flag stored in egui memory above.
+        if self.hide_archived && archived_total > 0 {
+            ui.add_space(6.0);
+            let label = if show_archived {
+                format!("Hide {archived_total} archived")
+            } else {
+                format!("Show {archived_total} archived")
+            };
+            if ui
+                .add(egui::Button::new(RichText::new(label).small().color(META_GREY)).small())
+                .clicked()
+            {
+                ui.ctx()
+                    .data_mut(|d| d.insert_temp(toggle_id, !show_archived));
+            }
+        }
 
         response
     }


### PR DESCRIPTION
Two related streams that the minting work depends on:

1. **cardano-tx** — the transaction-building primitives for high-throughput,
   server-signed batch minting (tx-chaining, fan-out/refuel, build-and-sign) +
   multi-recipient mint and time-lock validity handling.
2. **egui-widgets + storybook** — the collection/wallet roster widgets the admin
   portal renders, including collection-centric cards and soft-archive UX.

Both are consumed downstream by `cnft.dev-workers` via git-rev bump; see
**Downstream impact** below.

## cardano-tx

- **Chainable change** — `build_cip25_mint_multi_with_change` + the new
  `ChangeOutput { output_index, lovelace, has_assets }`. Surfaces the pure-ADA
  remainder a mint tx returns to `from_address` so a caller can spend it as the
  next tx's input without a chain/indexer round-trip — the basis for chaining
  many mint txs within one execution window. `build_cip25_mint_multi` is kept
  (delegates, drops the change), so existing callers are unaffected.
- **Server-side build + sign** — `UnsignedTx::build_and_sign(secret_key) ->
  SignedTx { tx_hash, tx_cbor_hex }`. Keeps `pallas_txbuilder`'s build trait
  internal to the crate so workers/CLIs don't depend on it just to produce
  submittable bytes.
- **Fan-out (refuel)** — `builder::send::build_fan_out`: sweeps a wallet's
  pure-ADA UTxOs into N parallel-spendable fuel slots (multi-input, largest-first),
  conservatively excluding asset-bearing and script-ref UTxOs so it can't burn a
  CIP-68 reference script or stray native asset. Fails loudly on shortfall.
- Multi-recipient batch mint + time-lock validity bounds threaded through the
  mint build path; supporting tweaks in `selection.rs` and
  `builder/collection_offer.rs`.
- New unit tests (incl. change-output index/shape) + an fmt sweep.

## egui-widgets + storybook

- **`CollectionList`** — collection-centric card buildout: wallet sub-line
  (address + copy + fuel-pool badge + Refuel), Test-mint / Seed-stubs / Activity
  toggles, supply progress bar, copyable `policy_id`; plus **soft-archive**:
  Archive/Restore button (`with_archive`), dimmed archived cards with an
  "archived" chip, and a "Show N archived" reveal toggle (`with_hide_archived`,
  state in egui memory — no host plumbing).
- **`WalletList`** — card layout, fuel-pool-health badge, Restore on archived
  rows, and the same **"Show N archived"** toggle (`with_hide_archived`).
- Minor polish across `tx_cart`, `fungibles_row`, `persona_strip`, `offer_tile`,
  `grouped_section`, `mnemonic_display`.
- Storybook stories updated to match, including new archived-toggle variants for
  the wallet + collection lists.

## Downstream impact (rev-bump consumers)

- **cardano-tx changes are additive** — new functions/structs; existing
  signatures preserved. Consumers compile unchanged and opt into the new
  capabilities.
- **`CollectionRow` gained a required `archived_at: Option<i64>` field** and
  `CollectionListAction` gained `Archive` / `Unarchive` variants — struct
  literals + exhaustive matches in consumers must be updated on rev bump (the
  cnft.dev-workers portal changes that do this land alongside the bump).

## Testing

- `egui-widgets` and `storybook-egui` build clean under
  `cargo clippy -- -D warnings`.
- cardano-tx carries new unit tests for the change-surfacing path; run
  `cargo test -p cardano-tx` before merge if not already green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)