### PR TITLE
feature: additional widgets and tx behaviours to support the minting flows

### DIFF
--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -289,6 +289,10 @@ pub fn build_cip25_mint_multi(
 /// (the pure-ADA remainder back to `deps.from_address`), so a caller can chain
 /// the next tx off it. `None` when the change was dust folded into the fee
 /// (no change output emitted). See [`ChangeOutput`].
+///
+/// Thin shim over [`build_cip25_mint_multi_with_change_and_refunds`] —
+/// passes an empty refund list, preserving the legacy signature for
+/// callers that don't issue inline refunds.
 pub fn build_cip25_mint_multi_with_change(
     deps: &TxDeps,
     policy: &MintingPolicy,
@@ -296,6 +300,43 @@ pub fn build_cip25_mint_multi_with_change(
     metadata: Option<&serde_json::Value>,
     inputs: Option<&[UtxoApi]>,
     extra_self_outputs: Option<&[u64]>,
+) -> Result<(UnsignedTx, Option<ChangeOutput>), TxBuildError> {
+    build_cip25_mint_multi_with_change_and_refunds(
+        deps,
+        policy,
+        mints,
+        metadata,
+        inputs,
+        extra_self_outputs,
+        &[],
+    )
+}
+
+/// Superset of [`build_cip25_mint_multi_with_change`] that accepts
+/// `refund_outputs` — additional pure-ADA outputs paid to arbitrary
+/// (non-self) bech32 addresses, in lovelace. The intended use is
+/// **Mode A inline refunds** (`MINT_REFUNDS.md`): when an order's
+/// inventory came up short, the executor folds the refund-to-payer
+/// into the same mint tx instead of waiting for a separate worker tx.
+///
+/// Each refund output must be ≥ the pure-ADA min UTxO (the builder
+/// rejects undersized entries before signing). Callers should use
+/// `minting_core::REFUND_OUTPUT_MIN_LOVELACE` as the policy floor;
+/// the ledger min is lower but our platform-wide rule treats
+/// sub-`REFUND_OUTPUT_MIN_LOVELACE` amounts as `dust_forfeit` rather
+/// than emitting an output at all.
+///
+/// **Output ordering**: recipient mints → extra-self → refunds →
+/// change. The `ChangeOutput.output_index` is `groups.len() +
+/// extras.len() + refund_outputs.len()`.
+pub fn build_cip25_mint_multi_with_change_and_refunds(
+    deps: &TxDeps,
+    policy: &MintingPolicy,
+    mints: &[MintRecipientEntry],
+    metadata: Option<&serde_json::Value>,
+    inputs: Option<&[UtxoApi]>,
+    extra_self_outputs: Option<&[u64]>,
+    refund_outputs: &[(Address, u64)],
 ) -> Result<(UnsignedTx, Option<ChangeOutput>), TxBuildError> {
     use pallas_primitives::Fragment;
 
@@ -380,8 +421,12 @@ pub fn build_cip25_mint_multi_with_change(
     let extras: &[u64] = extra_self_outputs.unwrap_or(&[]);
     let total_extras_lovelace: u64 = extras.iter().sum();
 
-    // Pure-ADA min UTxO under current params. Sanity-check each extra rather than letting
-    // the ledger reject after a fee has been paid.
+    // Refund outputs: pure-ADA outputs to arbitrary (non-self)
+    // bech32 addresses. Mode A inline refunds (`MINT_REFUNDS.md`).
+    let total_refund_lovelace: u64 = refund_outputs.iter().map(|(_, l)| *l).sum();
+
+    // Pure-ADA min UTxO under current params. Sanity-check each extra + refund rather
+    // than letting the ledger reject after a fee has been paid.
     let min_pure_change = 228 * deps.params.coins_per_utxo_byte;
     for (i, &amount) in extras.iter().enumerate() {
         if amount < min_pure_change {
@@ -390,15 +435,25 @@ pub fn build_cip25_mint_multi_with_change(
             )));
         }
     }
+    for (i, (_addr, amount)) in refund_outputs.iter().enumerate() {
+        if *amount < min_pure_change {
+            return Err(TxBuildError::BuildFailed(format!(
+                "refund_outputs[{i}] = {amount} lovelace < min_pure_utxo {min_pure_change} \
+                 (use minting_core::REFUND_OUTPUT_MIN_LOVELACE + classify_refund to filter \
+                 sub-floor amounts before they reach the builder)"
+            )));
+        }
+    }
 
     // Fee from real sizes: base + script + aux + per-output + per-mint + extra outputs +
-    // change output.
+    // refund outputs + change output.
     let estimated_tx_size = 300usize
         + script_bytes.len()
         + metadata_bytes.as_ref().map_or(0, |b| b.len())
         + groups.len() * 70
         + mints.len() * 50
         + extras.len() * 70
+        + refund_outputs.len() * 70
         + 70;
     let base_fee =
         deps.params.min_fee_coefficient * estimated_tx_size as u64 + deps.params.min_fee_constant;
@@ -422,7 +477,7 @@ pub fn build_cip25_mint_multi_with_change(
     };
 
     let total_input_lovelace: u64 = chosen.iter().map(|u| u.lovelace).sum();
-    let total_needed = total_output_min_ada + total_extras_lovelace + fee;
+    let total_needed = total_output_min_ada + total_extras_lovelace + total_refund_lovelace + fee;
     if total_input_lovelace < total_needed {
         return Err(TxBuildError::InsufficientFunds {
             needed: total_needed,
@@ -481,22 +536,37 @@ pub fn build_cip25_mint_multi_with_change(
         tx = tx.output(create_ada_output(deps.from_address.clone(), amount));
     }
 
+    // Refund outputs — pure-ADA UTxOs to the payer's address. Mode A
+    // inline refunds (`MINT_REFUNDS.md`). Same sized + sanity-checked
+    // shape as extras, just targeting a non-self address.
+    for (addr, amount) in refund_outputs {
+        tx = tx.output(create_ada_output(addr.clone(), *amount));
+    }
+
     // Metadata.
     if let Some(aux) = metadata_bytes {
         tx = tx.add_auxiliary_data(aux);
     }
 
-    // Change. Inputs already cover `total_needed` (recipient outputs + extras + fee).
-    // The change output (when emitted) is appended after the recipient + extra
-    // outputs, so its index is `groups.len() + extras.len()`.
-    let change_lovelace = total_input_lovelace - total_output_min_ada - total_extras_lovelace - fee;
-    let change_index = (groups.len() + extras.len()) as u32;
+    // Change. Inputs already cover `total_needed` (recipient outputs + extras + refunds + fee).
+    // The change output (when emitted) is appended after the recipient + extra +
+    // refund outputs, so its index is `groups.len() + extras.len() + refund_outputs.len()`.
+    let change_lovelace = total_input_lovelace
+        - total_output_min_ada
+        - total_extras_lovelace
+        - total_refund_lovelace
+        - fee;
+    let change_index = (groups.len() + extras.len() + refund_outputs.len()) as u32;
     let change: Option<ChangeOutput>;
     if has_remaining_assets {
         // Must emit a change output to carry the inputs' native assets.
         if change_lovelace < min_pure_change {
             return Err(TxBuildError::InsufficientFunds {
-                needed: total_output_min_ada + total_extras_lovelace + fee + min_pure_change,
+                needed: total_output_min_ada
+                    + total_extras_lovelace
+                    + total_refund_lovelace
+                    + fee
+                    + min_pure_change,
                 available: total_input_lovelace,
             });
         }

--- a/cardano-tx/src/metadata/cip25.rs
+++ b/cardano-tx/src/metadata/cip25.rs
@@ -70,6 +70,18 @@ pub fn build_cip25_auxiliary_data(
     let mut metadata = Metadata::new();
     metadata.insert(721, cip25_metadata);
 
+    // CIP-674 ("msg" label) — additive: if the input JSON carries a
+    // `"674"` key alongside the `"721"` CIP-25 blob, emit it verbatim
+    // at metadata label 674. Used by the minting-engine to tag
+    // inline refund outputs with `refund:<order_id>` for explorer
+    // visibility + worker idempotency. See `MINT_REFUNDS.md` →
+    // "Refund-output metadata tag". No impact on callers that don't
+    // populate the `"674"` key.
+    if let Some(cip674) = metadata_json.get("674") {
+        let cip674_metadatum = json_to_metadatum(cip674)?;
+        metadata.insert(674, cip674_metadatum);
+    }
+
     // Use Alonzo PostAlonzo format with Tag 259 (matches working mainnet transactions)
     let auxiliary_data = AuxiliaryData::PostAlonzo(PostAlonzoAuxiliaryData {
         metadata: Some(metadata),

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -460,17 +460,27 @@ struct DatumsByHashesResponse {
     data: std::collections::HashMap<String, DatumData>,
 }
 
+/// Minimal view of `GET /transactions/{tx_hash}`. Only the fields any
+/// caller in the workspace actually reads — keeping the struct narrow
+/// shields us from upstream additions (Maestro adds fields freely; serde
+/// silently ignores unknown ones with default config). The richer
+/// inputs/outputs/redeemers/etc. shape lives on
+/// [`CompleteTransactionDetails`] for callers that need it.
+///
+/// **Field-name notes**: Maestro's current API exposes the absolute
+/// slot as `block_absolute_slot` and the block timestamp as a unix-epoch
+/// `block_timestamp` int64 — older revisions called them `slot` and
+/// `timestamp: <ISO-8601>`, which is what this struct used to mirror.
+/// If you see "missing field `slot`" deserialization errors, the
+/// struct has drifted from the API again — fact-check against
+/// <https://docs.gomaestro.org/cardano/blockchain-indexer-api/transactions/transaction-details>.
 #[derive(Deserialize, Debug)]
 pub struct TransactionDetails {
     pub tx_hash: String,
     pub block_height: u64,
-    pub slot: u64,
-    #[serde(with = "maestro_date_format")]
-    pub timestamp: chrono::DateTime<Utc>,
+    pub block_absolute_slot: u64,
+    pub block_timestamp: u64,
     pub fee: u64,
-    pub size: u32,
-    pub metadata: Option<serde_json::Value>,
-    pub scripts: Vec<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -841,6 +851,13 @@ pub struct CompleteTransactionOutput {
 #[derive(Deserialize, Debug)]
 pub struct TransactionAsset {
     pub unit: String,
+    // Maestro's OpenAPI says `NumOrString` here — native-token amounts
+    // commonly come as JSON strings (they can overflow JSON's safe int
+    // range). A plain `u64` field fails the whole response when ANY
+    // string-encoded asset is present. Mirrors [`AssetAmount`] (which
+    // has been battle-tested on `get_address_utxos` since day one).
+    #[serde(with = "wasm_safe_serde::u64_required")]
+    #[serde(alias = "quantity")]
     pub amount: u64,
 }
 

--- a/pipeline/tx-classifier/src/indexers/maestro.rs
+++ b/pipeline/tx-classifier/src/indexers/maestro.rs
@@ -3,134 +3,30 @@ pub use maestro::MaestroApi;
 use tracing::{debug, warn};
 use transactions::{MintOperation, RawTxData, TxDatum, TxInput, TxOutput};
 
-/// Fetch transaction from Maestro
+/// Fetch a transaction from Maestro and translate to [`RawTxData`].
+///
+/// Backed by `get_complete_transaction`, which returns the full tx
+/// (inputs, outputs, mints, metadata) in one call. The legacy
+/// fallback that tried `get_transaction` + `get_transaction_utxos`
+/// was removed — Maestro retired the `/utxos` sub-endpoint (now
+/// 404), and the basic `/transactions/{hash}` shape dropped several
+/// fields the fallback referenced (`metadata`, `timestamp`, `size`,
+/// `scripts`). The minimal `TransactionDetails` shape that remains
+/// is now used only for thin metadata fetches that don't need
+/// inputs/outputs.
 pub async fn get_tx_from_maestro(
     maestro: &MaestroApi,
     tx_hash: &str,
 ) -> Result<RawTxData, TxClassifierError> {
     debug!("Fetching from Maestro: {}", tx_hash);
-
-    // Use the complete transaction endpoint if available (transactions feature)
-    #[cfg(feature = "indexers")]
-    {
-        match maestro.get_complete_transaction(tx_hash).await {
-            Ok(complete_tx) => {
-                debug!(
-                    "✅ Successfully fetched complete transaction data for {}",
-                    tx_hash
-                );
-                let mut raw_tx = convert_complete_transaction_to_raw_data(&complete_tx)?;
-                enrich_missing_datum_content(maestro, &mut raw_tx).await;
-                return Ok(raw_tx);
-            }
-            Err(e) => {
-                warn!("⚠️ Complete transaction endpoint failed for {}: {:?}, falling back to basic endpoints", tx_hash, e);
-            }
-        }
-    }
-
-    // Fallback to basic transaction details and UTXOs
-    let tx_details = maestro.get_transaction(tx_hash).await?;
-
-    // Try to fetch UTXOs, but don't fail if not available
-    let tx_utxos = match maestro.get_transaction_utxos(tx_hash).await {
-        Ok(utxos) => {
-            debug!("✅ Successfully fetched UTXOs for transaction {}", tx_hash);
-            utxos
-        }
-        Err(e) => {
-            warn!(
-                "⚠️ UTXOs endpoint failed for {}: {:?}, using transaction details only",
-                tx_hash, e
-            );
-            // Create minimal UTXO structure from transaction details if possible
-            return Ok(RawTxData {
-                tx_hash: tx_details.tx_hash,
-                inputs: vec![],  // No input data available without UTXOs endpoint
-                outputs: vec![], // No output data available without UTXOs endpoint
-                collateral_inputs: vec![], // No collateral data available without complete endpoint
-                collateral_outputs: vec![], // No collateral data available without complete endpoint
-                reference_inputs: vec![], // No reference input data available without complete endpoint
-                mint: vec![],             // No mint data available without complete endpoint
-                metadata: tx_details.metadata,
-                fee: Some(tx_details.fee),
-                block_height: Some(tx_details.block_height),
-                timestamp: Some(tx_details.timestamp.timestamp() as u64),
-                size: Some(tx_details.size),
-                scripts: tx_details.scripts,
-                redeemers: None,
-            });
-        }
-    };
-
-    // Convert Maestro data to our RawTxData format
-    let inputs = tx_utxos
-        .inputs
-        .into_iter()
-        .map(|input| {
-            let mut assets = std::collections::HashMap::new();
-            for asset in &input.assets {
-                assets.insert(asset.unit.clone(), asset.amount);
-            }
-
-            TxInput {
-                address: input.address.clone(),
-                tx_hash: input.tx_hash.clone(),
-                output_index: input.output_index,
-                amount_lovelace: input.amount,
-                assets,
-                datum: None, // Basic UTXOs endpoint doesn't provide datum data for inputs
-            }
-        })
-        .collect();
-
-    let outputs = tx_utxos
-        .outputs
-        .into_iter()
-        .map(|output| {
-            let mut assets = std::collections::HashMap::new();
-            for asset in &output.assets {
-                assets.insert(asset.unit.clone(), asset.amount);
-            }
-
-            TxOutput {
-                address: output.address.clone(),
-                amount_lovelace: output.amount,
-                assets,
-                datum: if output.datum_hash.is_some() || output.inline_datum.is_some() {
-                    Some(match (&output.datum_hash, &output.inline_datum) {
-                        (Some(hash), None) => TxDatum::Hash { hash: hash.clone() },
-                        (hash_opt, Some(json)) => TxDatum::Json {
-                            hash: hash_opt.clone().unwrap_or_default(),
-                            json: json.clone(),
-                            bytes: None, // Basic UTXOs endpoint doesn't provide bytes
-                        },
-                        _ => unreachable!(), // We check above that at least one is Some
-                    })
-                } else {
-                    None
-                },
-                script_ref: output.script_ref,
-            }
-        })
-        .collect();
-
-    Ok(RawTxData {
-        tx_hash: tx_details.tx_hash,
-        inputs,
-        outputs,
-        collateral_inputs: vec![], // Basic UTXOs endpoint doesn't provide collateral data
-        collateral_outputs: vec![], // Basic UTXOs endpoint doesn't provide collateral data
-        reference_inputs: vec![],  // Basic UTXOs endpoint doesn't provide reference input data
-        mint: vec![],              // Basic UTXOs endpoint doesn't provide mint data
-        metadata: tx_details.metadata,
-        fee: Some(tx_details.fee),
-        block_height: Some(tx_details.block_height),
-        timestamp: Some(tx_details.timestamp.timestamp() as u64),
-        size: Some(tx_details.size),
-        scripts: tx_details.scripts,
-        redeemers: None,
-    })
+    let complete_tx = maestro.get_complete_transaction(tx_hash).await?;
+    debug!(
+        "✅ Successfully fetched complete transaction data for {}",
+        tx_hash
+    );
+    let mut raw_tx = convert_complete_transaction_to_raw_data(&complete_tx)?;
+    enrich_missing_datum_content(maestro, &mut raw_tx).await;
+    Ok(raw_tx)
 }
 
 /// Parse mint operations from Maestro's mint JSON format

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -77,15 +77,28 @@ mod app {
         MnemonicDisplay,
         WalletList,
         CollectionList,
+        // Mint configuration
+        Chip,
+        PropertyList,
+        IdPill,
+        PhaseCard,
+        ButtonGroup,
     }
 
     impl Story {
         fn all() -> &'static [Self] {
             &[
+                // Primitives — foundational composables. Add new
+                // foundation widgets (Chip / IdPill / PropertyList shape)
+                // to this group, not at the end of the list.
                 Self::Formatting,
                 Self::Distribution,
                 Self::Marquee,
                 Self::Buttons,
+                Self::Chip,
+                Self::IdPill,
+                Self::PropertyList,
+                Self::ButtonGroup,
                 Self::ProgressBar,
                 Self::Sparkline,
                 Self::MetricCard,
@@ -141,6 +154,8 @@ mod app {
                 Self::MnemonicDisplay,
                 Self::WalletList,
                 Self::CollectionList,
+                // Mint configuration
+                Self::PhaseCard,
             ]
         }
 
@@ -198,14 +213,24 @@ mod app {
                 Self::MnemonicDisplay => "Mnemonic Display",
                 Self::WalletList => "Wallet List",
                 Self::CollectionList => "Collection List",
+                Self::Chip => "Chip",
+                Self::PropertyList => "Property List",
+                Self::IdPill => "ID Pill",
+                Self::PhaseCard => "Phase Card",
+                Self::ButtonGroup => "Button Group",
             }
         }
 
         fn category(&self) -> &'static str {
             match self {
-                Self::Formatting | Self::Distribution | Self::Marquee | Self::Buttons => {
-                    "Primitives"
-                }
+                Self::Formatting
+                | Self::Distribution
+                | Self::Marquee
+                | Self::Buttons
+                | Self::Chip
+                | Self::IdPill
+                | Self::PropertyList
+                | Self::ButtonGroup => "Primitives",
                 Self::ProgressBar
                 | Self::Sparkline
                 | Self::MetricCard
@@ -249,6 +274,7 @@ mod app {
                 Self::TxCart => "TX Cart",
                 Self::GroupedSection | Self::OfferTile => "Layout",
                 Self::MnemonicDisplay | Self::WalletList | Self::CollectionList => "Auth / Admin",
+                Self::PhaseCard => "Mint Configuration",
             }
         }
 
@@ -390,6 +416,21 @@ mod app {
                 Self::CollectionList => {
                     "Per-client collections list — title, status/standard/network chips, supply progress, policy_id copy, Test mint / Seed stubs actions"
                 }
+                Self::Chip => {
+                    "Small filled-tag label with semantic variants (Success / Warning / Danger / Tag / Info / Muted) + optional × remove affordance"
+                }
+                Self::PropertyList => {
+                    "Compact label/value grid for read-only key data — phase summaries, wallet readouts, payment audit"
+                }
+                Self::IdPill => {
+                    "Truncated identifier with copy button — policy_id, wallet addresses, deposit addresses, tx hashes"
+                }
+                Self::PhaseCard => {
+                    "Read-only mint phase card — header (name + status + priority + Edit/Delete), Price/Window/Per-wallet properties, gate chips with × remove + Add gate"
+                }
+                Self::ButtonGroup => {
+                    "Row of related action buttons — text + optional Phosphor icons + tooltips + disabled state, with horizontal_wrapped layout"
+                }
             }
         }
     }
@@ -470,6 +511,8 @@ mod app {
         mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState,
         wallet_list_state: stories::wallet_list::WalletListState,
         collection_list_state: stories::collection_list::CollectionListState,
+        // Primitives
+        button_group_state: stories::button_group::ButtonGroupState,
     }
 
     impl StorybookApp {
@@ -550,6 +593,7 @@ mod app {
                 mnemonic_display_state: stories::mnemonic_display::MnemonicDisplayState::default(),
                 wallet_list_state: stories::wallet_list::WalletListState::default(),
                 collection_list_state: stories::collection_list::CollectionListState::default(),
+                button_group_state: stories::button_group::ButtonGroupState::default(),
             }
         }
 
@@ -760,6 +804,13 @@ mod app {
                             }
                             Story::CollectionList => {
                                 stories::collection_list::show(ui, &mut self.collection_list_state)
+                            }
+                            Story::Chip => stories::chip::show(ui),
+                            Story::PropertyList => stories::property_list::show(ui),
+                            Story::IdPill => stories::id_pill::show(ui),
+                            Story::PhaseCard => stories::phase_card::show(ui),
+                            Story::ButtonGroup => {
+                                stories::button_group::show(ui, &mut self.button_group_state)
                             }
                         }
                     });

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -83,6 +83,7 @@ mod app {
         IdPill,
         PhaseCard,
         ButtonGroup,
+        Toast,
     }
 
     impl Story {
@@ -99,6 +100,7 @@ mod app {
                 Self::IdPill,
                 Self::PropertyList,
                 Self::ButtonGroup,
+                Self::Toast,
                 Self::ProgressBar,
                 Self::Sparkline,
                 Self::MetricCard,
@@ -218,6 +220,7 @@ mod app {
                 Self::IdPill => "ID Pill",
                 Self::PhaseCard => "Phase Card",
                 Self::ButtonGroup => "Button Group",
+                Self::Toast => "Toast",
             }
         }
 
@@ -230,7 +233,8 @@ mod app {
                 | Self::Chip
                 | Self::IdPill
                 | Self::PropertyList
-                | Self::ButtonGroup => "Primitives",
+                | Self::ButtonGroup
+                | Self::Toast => "Primitives",
                 Self::ProgressBar
                 | Self::Sparkline
                 | Self::MetricCard
@@ -431,6 +435,9 @@ mod app {
                 Self::ButtonGroup => {
                     "Row of related action buttons — text + optional Phosphor icons + tooltips + disabled state, with horizontal_wrapped layout"
                 }
+                Self::Toast => {
+                    "Transient overlay messages with frame-countdown auto-dismiss — Success/Error/Warning/Info, host-owned ToastQueue, bottom-right stack"
+                }
             }
         }
     }
@@ -513,6 +520,7 @@ mod app {
         collection_list_state: stories::collection_list::CollectionListState,
         // Primitives
         button_group_state: stories::button_group::ButtonGroupState,
+        toast_state: stories::toast::ToastState,
     }
 
     impl StorybookApp {
@@ -594,6 +602,7 @@ mod app {
                 wallet_list_state: stories::wallet_list::WalletListState::default(),
                 collection_list_state: stories::collection_list::CollectionListState::default(),
                 button_group_state: stories::button_group::ButtonGroupState::default(),
+                toast_state: stories::toast::ToastState::default(),
             }
         }
 
@@ -812,6 +821,7 @@ mod app {
                             Story::ButtonGroup => {
                                 stories::button_group::show(ui, &mut self.button_group_state)
                             }
+                            Story::Toast => stories::toast::show(ui, &mut self.toast_state),
                         }
                     });
                 });

--- a/ui/_storybook-egui/src/stories/button_group.rs
+++ b/ui/_storybook-egui/src/stories/button_group.rs
@@ -1,0 +1,150 @@
+//! `ButtonGroup` storybook story — text-only, with-icons, disabled,
+//! single-row (no wrap), and a realistic collection-card action bar.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::{ButtonGroup, ButtonGroupButton, PhosphorIcon};
+
+#[derive(Default)]
+pub struct ButtonGroupState {
+    pub last_clicked: Option<u64>,
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut ButtonGroupState) {
+    ui.label(egui::RichText::new("ButtonGroup").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Row of related action buttons with shared layout. Each button \
+             gets a caller-supplied `id`; the group's response carries the \
+             clicked id so the host dispatches on a single matched value. \
+             Default layout is horizontal_wrapped — narrow surfaces spill \
+             onto a second line instead of overlapping siblings.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── 1. Text-only action group ──────────────────────────────────────
+    section(ui, "Plain text labels");
+    let resp = ButtonGroup::new()
+        .add(ButtonGroupButton::new(11, "Save"))
+        .add(ButtonGroupButton::new(12, "Cancel"))
+        .add(ButtonGroupButton::new(13, "Reset"))
+        .show(ui);
+    capture(state, resp.clicked);
+
+    ui.add_space(12.0);
+
+    // ── 2. With icons + tooltips ──────────────────────────────────────
+    section(ui, "Icon + label + tooltip (per-button)");
+    let resp = ButtonGroup::new()
+        .add(
+            ButtonGroupButton::new(21, "Configure")
+                .icon(PhosphorIcon::Gear)
+                .hover_text("Edit phases, gates, and allowlist"),
+        )
+        .add(
+            ButtonGroupButton::new(22, "Scan")
+                .icon(PhosphorIcon::MagnifyingGlass)
+                .hover_text("Walk the deposit address for unspent payments"),
+        )
+        .add(ButtonGroupButton::new(23, "Copy policy_id").icon(PhosphorIcon::Copy))
+        .show(ui);
+    capture(state, resp.clicked);
+
+    ui.add_space(12.0);
+
+    // ── 3. Disabled state ─────────────────────────────────────────────
+    section(ui, "Disabled (e.g. action in flight)");
+    ui.label(
+        egui::RichText::new(
+            "Disabled buttons render greyed-out and unclickable. Their \
+             `hover_text` becomes the disabled-hover hint so the operator \
+             sees the reason a button is unavailable.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    let resp = ButtonGroup::new()
+        .add(
+            ButtonGroupButton::new(31, "Refuelling…")
+                .enabled(false)
+                .hover_text("Refuel tx in flight — wait for the ack"),
+        )
+        .add(ButtonGroupButton::new(32, "Activity"))
+        .add(
+            ButtonGroupButton::new(33, "Scanning…")
+                .icon(PhosphorIcon::MagnifyingGlass)
+                .enabled(false)
+                .hover_text("A scan is in flight"),
+        )
+        .show(ui);
+    capture(state, resp.clicked);
+
+    ui.add_space(12.0);
+
+    // ── 4. Single-row (no wrap) — toolbar use case ────────────────────
+    section(ui, "Single row (no wrap) — toolbar");
+    let resp = ButtonGroup::new()
+        .wrap(false)
+        .spacing(8.0)
+        .add(ButtonGroupButton::new(41, "New").icon(PhosphorIcon::Plus))
+        .add(ButtonGroupButton::new(42, "Open").icon(PhosphorIcon::Eye))
+        .add(
+            ButtonGroupButton::new(43, "Delete")
+                .icon(PhosphorIcon::Trash)
+                .hover_text("Permanent — no undo"),
+        )
+        .show(ui);
+    capture(state, resp.clicked);
+
+    ui.add_space(12.0);
+
+    // ── 5. Realistic collection-card action bar ───────────────────────
+    section(ui, "Collection-card action bar (real use case)");
+    ui.label(
+        egui::RichText::new(
+            "The action bar from the portal's collection card: Test mint, \
+             Activity, Configure, Scan, + Ingest, + Seed stubs. This is the \
+             pattern `collection_list.rs` will use after the refactor.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    let resp = ButtonGroup::new()
+        .add(ButtonGroupButton::new(51, "Test mint"))
+        .add(ButtonGroupButton::new(52, "Activity"))
+        .add(
+            ButtonGroupButton::new(53, "Configure")
+                .icon(PhosphorIcon::Gear)
+                .hover_text("Edit phases / gates / allowlist"),
+        )
+        .add(
+            ButtonGroupButton::new(54, "Scan")
+                .icon(PhosphorIcon::MagnifyingGlass)
+                .hover_text("Walk deposit address for unspent payments"),
+        )
+        .add(ButtonGroupButton::new(55, "+ Ingest"))
+        .add(ButtonGroupButton::new(56, "+ Seed stubs"))
+        .show(ui);
+    capture(state, resp.clicked);
+
+    // ── Action receipt ────────────────────────────────────────────────
+    if let Some(id) = state.last_clicked {
+        ui.add_space(12.0);
+        ui.colored_label(egui::Color32::LIGHT_GREEN, format!("last clicked: id {id}"));
+    }
+}
+
+fn section(ui: &mut egui::Ui, label: &str) {
+    ui.label(egui::RichText::new(label).color(ACCENT).strong());
+    ui.add_space(4.0);
+}
+
+fn capture(state: &mut ButtonGroupState, clicked: Option<u64>) {
+    if let Some(id) = clicked {
+        state.last_clicked = Some(id);
+    }
+}

--- a/ui/_storybook-egui/src/stories/chip.rs
+++ b/ui/_storybook-egui/src/stories/chip.rs
@@ -1,0 +1,99 @@
+//! `Chip` storybook story — every variant + the removable affordance.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::{Chip, ChipVariant};
+
+pub fn show(ui: &mut egui::Ui) {
+    ui.label(egui::RichText::new("Chip").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Small filled-tag label with optional × remove. Semantic variants pick a palette \
+             so the call site says what the chip means rather than which colour to use.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── Every variant in one row ───────────────────────────────────────
+    ui.label(egui::RichText::new("Variants").color(ACCENT).strong());
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        Chip::new("active").variant(ChipVariant::Success).show(ui);
+        Chip::new("paused").variant(ChipVariant::Muted).show(ui);
+        Chip::new("archived").variant(ChipVariant::Warning).show(ui);
+        Chip::new("failed").variant(ChipVariant::Danger).show(ui);
+        Chip::new("public").variant(ChipVariant::Tag).show(ui);
+        Chip::new("preprod").variant(ChipVariant::Info).show(ui);
+    });
+
+    ui.add_space(16.0);
+
+    // ── Removable (gate chip use case) ─────────────────────────────────
+    ui.label(
+        egui::RichText::new("Removable (gate chips)")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Removable chips emit `removed = true` on the × click. \
+             The host drops the row from its model.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        Chip::new("public")
+            .variant(ChipVariant::Tag)
+            .removable(true)
+            .show(ui);
+        Chip::new("allowlist")
+            .variant(ChipVariant::Tag)
+            .removable(true)
+            .show(ui);
+        Chip::new("token_held(8532f316…, min 3)")
+            .variant(ChipVariant::Tag)
+            .removable(true)
+            .show(ui);
+    });
+
+    ui.add_space(16.0);
+
+    // ── Tooltip + upper-case ───────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Tooltip + upper-case")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "`upper_case(true)` matches the old `status_chip` rendering. \
+             `on_hover_text` attaches a tooltip — hover the chip below.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        Chip::new("draft")
+            .variant(ChipVariant::Muted)
+            .upper_case(true)
+            .on_hover_text("Status: draft — not minting yet")
+            .show(ui);
+        Chip::new("live")
+            .variant(ChipVariant::Success)
+            .upper_case(true)
+            .on_hover_text("Status: live — actively minting")
+            .show(ui);
+        Chip::new("sold_out")
+            .variant(ChipVariant::Info)
+            .upper_case(true)
+            .on_hover_text("Status: sold out — inventory exhausted")
+            .show(ui);
+    });
+}

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -55,6 +55,8 @@ fn row(
         pool: None,
         refuel_in_flight: false,
         archived_at: None,
+        deposit_address: None,
+        deposit_address_short: None,
     }
 }
 

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -21,6 +21,11 @@ pub struct CollectionListState {
     pub last_open_wallet: Option<u32>,
     /// Last refuel action observed (policy_id).
     pub last_refuel: Option<String>,
+    /// Catch-all slot for the portal-only actions
+    /// (Archive / Unarchive / IngestPayment / ScanPayments / Configure).
+    /// The story doesn't model those flows; the field lets the match arm
+    /// stay exhaustive without adding five UI slots.
+    pub last_other: Option<String>,
 }
 
 /// Construct a sample row. The widget does no truncation itself — the
@@ -57,6 +62,8 @@ fn row(
         archived_at: None,
         deposit_address: None,
         deposit_address_short: None,
+        ingest_payment_open: false,
+        scan_payments_in_flight: false,
     }
 }
 
@@ -520,25 +527,25 @@ pub fn show(ui: &mut egui::Ui, state: &mut CollectionListState) {
         if let Some(p) = &state.last_test_mint {
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
-                format!("✓ test-mint requested for {}", truncate_middle(p, 8, 6)),
+                format!("test-mint requested for {}", truncate_middle(p, 8, 6)),
             );
         }
         if let Some(p) = &state.last_seed_stubs {
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
-                format!("✓ seed-stubs requested for {}", truncate_middle(p, 8, 6)),
+                format!("seed-stubs requested for {}", truncate_middle(p, 8, 6)),
             );
         }
         if let Some(idx) = state.last_open_wallet {
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
-                format!("✓ open-wallet requested for #{idx}"),
+                format!("open-wallet requested for #{idx}"),
             );
         }
         if let Some(p) = &state.last_refuel {
             ui.colored_label(
                 egui::Color32::LIGHT_GREEN,
-                format!("✓ refuel requested for {}", truncate_middle(p, 8, 6)),
+                format!("refuel requested for {}", truncate_middle(p, 8, 6)),
             );
         }
     }
@@ -561,6 +568,17 @@ fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionLis
             }
             CollectionListAction::Refuel { policy_id } => {
                 state.last_refuel = Some(policy_id);
+            }
+            // Post-V1 actions added by the cnft.dev portal — captured into
+            // a single `last_other` slot since the story doesn't model
+            // archive / payment / configure flows yet. The widget host
+            // (the real portal) dispatches these directly.
+            CollectionListAction::Archive { policy_id }
+            | CollectionListAction::Unarchive { policy_id }
+            | CollectionListAction::IngestPayment { policy_id }
+            | CollectionListAction::ScanPayments { policy_id }
+            | CollectionListAction::Configure { policy_id } => {
+                state.last_other = Some(policy_id);
             }
         }
     }

--- a/ui/_storybook-egui/src/stories/id_pill.rs
+++ b/ui/_storybook-egui/src/stories/id_pill.rs
@@ -1,7 +1,7 @@
 //! `IdPill` storybook story.
 
 use crate::{ACCENT, TEXT_MUTED};
-use egui_widgets::IdPill;
+use egui_widgets::{id_pill_stacked_width_for, IdPill, IdPillLayout};
 
 pub fn show(ui: &mut egui::Ui) {
     ui.label(egui::RichText::new("IdPill").color(ACCENT).strong());
@@ -17,21 +17,101 @@ pub fn show(ui: &mut egui::Ui) {
     );
     ui.add_space(12.0);
 
-    // ── Typical use cases ──────────────────────────────────────────────
-    ui.label(egui::RichText::new("Common uses").color(ACCENT).strong());
-    ui.add_space(4.0);
+    // ── Stacked (default) ──────────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Stacked — default")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Three-row framed pill: small muted label header, monospace value body, \
+             right-aligned copy footer. Shows the FULL value when it fits the parent's \
+             available width; falls back to middle-elision only when constrained. \
+             Best for standalone display stacks (the typical policy / wallet / \
+             stake / tx group on a dashboard).",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
     let policy = "8532f316dd0973a8e2c5b7d0fa194deebd4451aabdfe3a8c2bd45d87a1b";
     let stake = "stake1u9k5j8d4xv5c98xy7d3jhgf2pvqd0u4ldyk2pz0t3w8nye6jyq25fr";
     let addr = "addr_test1qpx5d3p6vhwl8sqkek74p2lz5w2sse5e0wpzm2ynj3aqlk4qfn7lm";
     let tx = "fa9bfb46c8d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8fe407d";
 
-    IdPill::new("policy", policy).show(ui);
+    // Normalize frame width across the stack — measure each value's
+    // natural Stacked width and take the max so every pill's right
+    // border lines up regardless of value length.
+    let stack_w = [policy, addr, stake, tx]
+        .iter()
+        .map(|v| id_pill_stacked_width_for(ui, v, true))
+        .fold(0.0_f32, f32::max);
+    IdPill::new("policy", policy).min_width(stack_w).show(ui);
+    ui.add_space(4.0);
+    IdPill::new("wallet", addr).min_width(stack_w).show(ui);
+    ui.add_space(4.0);
+    IdPill::new("stake", stake).min_width(stack_w).show(ui);
+    ui.add_space(4.0);
+    IdPill::new("tx", tx).min_width(stack_w).show(ui);
+
+    ui.add_space(16.0);
+
+    // ── Stacked, constrained ───────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Stacked — constrained width")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Wrap the pill in a narrow container and it auto-elides without any \
+             extra config. The width budget is what the parent hands the frame.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+    ui.allocate_ui(egui::vec2(220.0, 0.0), |ui| {
+        IdPill::new("policy", policy).show(ui);
+    });
+
+    ui.add_space(16.0);
+
+    // ── Inline ─────────────────────────────────────────────────────────
+    ui.label(egui::RichText::new("Inline").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Single-row compact shape: `label  value [Copy]`, no frame. \
+             Always truncates per `with_widths`. Use this inside header bars \
+             where vertical budget is tight (e.g. the portal's Configure window \
+             header). `label_min_width` reserves a column so a vertical stack of \
+             Inline pills aligns its values.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(8.0);
+    const LABEL_W: f32 = 48.0;
+    IdPill::new("policy", policy)
+        .layout(IdPillLayout::Inline)
+        .label_min_width(LABEL_W)
+        .show(ui);
     ui.add_space(3.0);
-    IdPill::new("wallet", addr).with_widths(14, 8).show(ui);
+    IdPill::new("wallet", addr)
+        .layout(IdPillLayout::Inline)
+        .label_min_width(LABEL_W)
+        .show(ui);
     ui.add_space(3.0);
-    IdPill::new("stake", stake).with_widths(14, 8).show(ui);
+    IdPill::new("stake", stake)
+        .layout(IdPillLayout::Inline)
+        .label_min_width(LABEL_W)
+        .show(ui);
     ui.add_space(3.0);
-    IdPill::new("tx", tx).with_widths(12, 6).show(ui);
+    IdPill::new("tx", tx)
+        .layout(IdPillLayout::Inline)
+        .label_min_width(LABEL_W)
+        .show(ui);
 
     ui.add_space(16.0);
 
@@ -43,16 +123,16 @@ pub fn show(ui: &mut egui::Ui) {
     );
     ui.label(
         egui::RichText::new(
-            "Pass `\"\"` for the label to drop it. Short values render verbatim \
-             (no truncation needed). `copyable(false)` suppresses the copy button \
-             for read-only contexts.",
+            "Pass `\"\"` for the label to drop the header row. Short values render \
+             verbatim (no truncation needed). `copyable(false)` suppresses the copy \
+             button for read-only contexts.",
         )
         .color(TEXT_MUTED)
         .small(),
     );
-    ui.add_space(4.0);
+    ui.add_space(8.0);
     IdPill::new("", "abc123").show(ui);
-    ui.add_space(3.0);
+    ui.add_space(4.0);
     IdPill::new("ref", policy).copyable(false).show(ui);
 
     ui.add_space(16.0);
@@ -72,7 +152,7 @@ pub fn show(ui: &mut egui::Ui) {
         .color(TEXT_MUTED)
         .small(),
     );
-    ui.add_space(4.0);
+    ui.add_space(8.0);
     IdPill::new("policy", policy)
         .with_short("8532…d87a1b")
         .show(ui);

--- a/ui/_storybook-egui/src/stories/id_pill.rs
+++ b/ui/_storybook-egui/src/stories/id_pill.rs
@@ -1,0 +1,79 @@
+//! `IdPill` storybook story.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::IdPill;
+
+pub fn show(ui: &mut egui::Ui) {
+    ui.label(egui::RichText::new("IdPill").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Truncated identifier + copy button. The recurring \
+             `policy 8532f316dd09…45d87a1b 📋` pattern used for policy_id, \
+             wallet addresses, deposit addresses, tx hashes. Hover the value \
+             to see the full string in a tooltip.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── Typical use cases ──────────────────────────────────────────────
+    ui.label(egui::RichText::new("Common uses").color(ACCENT).strong());
+    ui.add_space(4.0);
+    let policy = "8532f316dd0973a8e2c5b7d0fa194deebd4451aabdfe3a8c2bd45d87a1b";
+    let stake = "stake1u9k5j8d4xv5c98xy7d3jhgf2pvqd0u4ldyk2pz0t3w8nye6jyq25fr";
+    let addr = "addr_test1qpx5d3p6vhwl8sqkek74p2lz5w2sse5e0wpzm2ynj3aqlk4qfn7lm";
+    let tx = "fa9bfb46c8d3f4e5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8fe407d";
+
+    IdPill::new("policy", policy).show(ui);
+    ui.add_space(3.0);
+    IdPill::new("wallet", addr).with_widths(14, 8).show(ui);
+    ui.add_space(3.0);
+    IdPill::new("stake", stake).with_widths(14, 8).show(ui);
+    ui.add_space(3.0);
+    IdPill::new("tx", tx).with_widths(12, 6).show(ui);
+
+    ui.add_space(16.0);
+
+    // ── No label / short value ─────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("No label, short value, no copy")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Pass `\"\"` for the label to drop it. Short values render verbatim \
+             (no truncation needed). `copyable(false)` suppresses the copy button \
+             for read-only contexts.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    IdPill::new("", "abc123").show(ui);
+    ui.add_space(3.0);
+    IdPill::new("ref", policy).copyable(false).show(ui);
+
+    ui.add_space(16.0);
+
+    // ── Pre-truncated value (host-provided) ────────────────────────────
+    ui.label(
+        egui::RichText::new("Host-provided truncation")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Hosts that already have a pre-formatted display string (e.g. from \
+             a row VM) pass it via `with_short`. The full value still goes to \
+             the clipboard on copy.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    IdPill::new("policy", policy)
+        .with_short("8532…d87a1b")
+        .show(ui);
+}

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -64,6 +64,7 @@ pub mod button_group;
 pub mod chip;
 pub mod id_pill;
 pub mod property_list;
+pub mod toast;
 
 // Layout
 pub mod grouped_section;

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -57,9 +57,20 @@ pub mod wallet_asset_picker;
 // TX cart
 pub mod tx_cart;
 
-// Layout primitives
+// Primitives — foundational composables (semantic chips, ID displays,
+// label/value grids, button groups). Add new foundation widgets to this
+// group rather than tacking on a new category at the end of the file.
+pub mod button_group;
+pub mod chip;
+pub mod id_pill;
+pub mod property_list;
+
+// Layout
 pub mod grouped_section;
 pub mod offer_tile;
+
+// Mint configuration
+pub mod phase_card;
 
 // Wallet
 pub mod fungibles_row;

--- a/ui/_storybook-egui/src/stories/phase_card.rs
+++ b/ui/_storybook-egui/src/stories/phase_card.rs
@@ -1,0 +1,147 @@
+//! `PhaseCard` storybook story — every common state of a phase row.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::{GateChip, PhaseCard, PhaseCardAction, PhaseCardRow};
+
+pub fn show(ui: &mut egui::Ui) {
+    ui.label(egui::RichText::new("PhaseCard").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Read-only display of one mint phase row — header (name + status + \
+             priority + Edit/Delete), properties (price / window / per-wallet), \
+             gates strip with × remove + Add gate. The edit form lives in the \
+             host beside its form state; the card emits Edit/Delete/AddGate/RemoveGate \
+             actions for the host to dispatch.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── 1. Public phase, FREE, unbounded, one public gate ──────────────
+    section(ui, "Active public phase (default seed)");
+    let row = PhaseCardRow {
+        phase_key: "public".into(),
+        name: "Public".into(),
+        price_display: "FREE".into(),
+        window_display: "unbounded to unbounded".into(),
+        per_wallet_display: "unlimited".into(),
+        active: true,
+        priority: 0,
+    };
+    let gates = vec![GateChip {
+        gate_id: 1,
+        label: "public".into(),
+    }];
+    let resp = PhaseCard::new(&row, &gates).show(ui);
+    surface_actions(ui, &resp.actions);
+
+    ui.add_space(12.0);
+
+    // ── 2. Allowlist phase with multiple gates ─────────────────────────
+    section(ui, "Allowlist phase, 50 ADA, time-bounded, two gates");
+    let row = PhaseCardRow {
+        phase_key: "allowlist".into(),
+        name: "Allowlist".into(),
+        price_display: "50 ADA".into(),
+        window_display: "2026-06-01T09:00:00 to 2026-06-01T18:00:00".into(),
+        per_wallet_display: "3".into(),
+        active: true,
+        priority: 20,
+    };
+    let gates = vec![
+        GateChip {
+            gate_id: 12,
+            label: "allowlist".into(),
+        },
+        GateChip {
+            gate_id: 13,
+            label: "token_held(8532f316…, min 3)".into(),
+        },
+    ];
+    let resp = PhaseCard::new(&row, &gates).show(ui);
+    surface_actions(ui, &resp.actions);
+
+    ui.add_space(12.0);
+
+    // ── 3. Paused (active=false) — operator's emergency stop ───────────
+    section(ui, "Paused — operator-flipped `active = false`");
+    let row = PhaseCardRow {
+        phase_key: "og".into(),
+        name: "OG".into(),
+        price_display: "30 ADA".into(),
+        window_display: "2026-06-01T08:00:00 to 2026-06-01T09:00:00".into(),
+        per_wallet_display: "5".into(),
+        active: false,
+        priority: 30,
+    };
+    let gates = vec![GateChip {
+        gate_id: 5,
+        label: "token_held(b3dab69f…, min 1)".into(),
+    }];
+    let resp = PhaseCard::new(&row, &gates).show(ui);
+    surface_actions(ui, &resp.actions);
+
+    ui.add_space(12.0);
+
+    // ── 4. Phase with zero gates — fail-safe warning ───────────────────
+    section(ui, "Phase with zero gates (fail-safe: nobody eligible)");
+    let row = PhaseCardRow {
+        phase_key: "draft".into(),
+        name: "Stealth drop".into(),
+        price_display: "25 ADA".into(),
+        window_display: "unbounded to 2026-12-31T23:59:59".into(),
+        per_wallet_display: "1".into(),
+        active: true,
+        priority: 10,
+    };
+    let resp = PhaseCard::new(&row, &[]).show(ui);
+    surface_actions(ui, &resp.actions);
+
+    ui.add_space(12.0);
+
+    // ── 5. Read-only audit (no Edit/Delete/Add) ────────────────────────
+    section(ui, "Audit mode — Edit/Delete/AddGate suppressed");
+    let row = PhaseCardRow {
+        phase_key: "archived".into(),
+        name: "Public (archived)".into(),
+        price_display: "FREE".into(),
+        window_display: "2025-12-01T00:00:00 to 2025-12-31T23:59:59".into(),
+        per_wallet_display: "unlimited".into(),
+        active: false,
+        priority: 0,
+    };
+    let gates = vec![GateChip {
+        gate_id: 99,
+        label: "public".into(),
+    }];
+    let _ = PhaseCard::new(&row, &gates)
+        .with_edit(false)
+        .with_delete(false)
+        .with_add_gate(false)
+        .with_gate_remove(false)
+        .show(ui);
+}
+
+fn section(ui: &mut egui::Ui, label: &str) {
+    ui.label(egui::RichText::new(label).color(ACCENT).strong());
+    ui.add_space(4.0);
+}
+
+fn surface_actions(ui: &mut egui::Ui, actions: &[PhaseCardAction]) {
+    for action in actions {
+        let msg = match action {
+            PhaseCardAction::Edit => "Edit clicked".to_string(),
+            PhaseCardAction::Delete => "Delete confirmed".to_string(),
+            PhaseCardAction::AddGate => "+ Add gate clicked".to_string(),
+            PhaseCardAction::RemoveGate { gate_id } => {
+                format!("Remove gate {gate_id}")
+            }
+        };
+        ui.label(
+            egui::RichText::new(msg)
+                .small()
+                .color(egui::Color32::LIGHT_GREEN),
+        );
+    }
+}

--- a/ui/_storybook-egui/src/stories/property_list.rs
+++ b/ui/_storybook-egui/src/stories/property_list.rs
@@ -1,0 +1,78 @@
+//! `PropertyList` storybook story.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::{PropertyLabelAlign, PropertyList};
+
+pub fn show(ui: &mut egui::Ui) {
+    ui.label(egui::RichText::new("PropertyList").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Label/value grid for read-only key data. Two columns, stable widths, \
+             muted label colour, default text colour for the value. Used wherever \
+             you'd otherwise hand-build an egui::Grid for descriptive metadata.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── Phase-card use case ────────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Phase summary (default)")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    PropertyList::new()
+        .id("story_phase_props")
+        .add("Price", "FREE")
+        .add("Window", "2026-06-01T09:00:00 → unbounded")
+        .add("Per wallet", "3")
+        .show(ui);
+
+    ui.add_space(16.0);
+
+    // ── add_optional + right-aligned labels ────────────────────────────
+    ui.label(
+        egui::RichText::new("Right-aligned labels + optional rows")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Right alignment suits dense layouts where the value column is the \
+             scanning axis. `add_optional` keeps optional rows out of the layout \
+             without a noisy match at the call site.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(4.0);
+    let refund: Option<&str> = Some("0.50 ADA");
+    let mint_tx: Option<&str> = None;
+    PropertyList::new()
+        .id("story_props_right")
+        .label_align(PropertyLabelAlign::Right)
+        .add("Status", "refund_queued")
+        .add("Paid", "1.50 ADA")
+        .add_optional("Refund", refund)
+        .add_optional("Mint tx", mint_tx)
+        .show(ui);
+
+    ui.add_space(16.0);
+
+    // ── Wallet card use case ───────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Wallet card readout")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.add_space(4.0);
+    PropertyList::new()
+        .id("story_props_wallet")
+        .add("Account index", "0")
+        .add("Role", "ClientMaster")
+        .add("Fuel UTxOs", "20")
+        .add("Total balance", "230 ADA")
+        .show(ui);
+}

--- a/ui/_storybook-egui/src/stories/toast.rs
+++ b/ui/_storybook-egui/src/stories/toast.rs
@@ -1,0 +1,152 @@
+//! `Toast` / `ToastQueue` storybook story.
+
+use crate::{ACCENT, TEXT_MUTED};
+use egui_widgets::{show_toasts, IdPill, PhosphorIcon, Toast, ToastKind, ToastQueue};
+
+/// Per-story state — owns the queue so toasts persist across paint
+/// frames and self-dismiss on the countdown.
+pub struct ToastState {
+    pub queue: ToastQueue,
+    /// Backing string for the IdPill demo so we have something to copy.
+    pub demo_policy: String,
+}
+
+impl Default for ToastState {
+    fn default() -> Self {
+        Self {
+            queue: ToastQueue::new(),
+            demo_policy: "8532f316dd0973a8e2c5b7d0fa194deebd4451aabdfe3a8c2bd45d87a1b".to_string(),
+        }
+    }
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut ToastState) {
+    ui.label(egui::RichText::new("Toast").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Transient overlay messages with frame-countdown auto-dismiss. \
+             Host owns the queue; push from action handlers and call \
+             `show_toasts(ctx, &mut queue)` once per paint to render the \
+             bottom-right stack. Lifetime is frame-based (no `js_sys` \
+             dependency) so it works the same in native and wasm.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(12.0);
+
+    // ── Kinds ──────────────────────────────────────────────────────────
+    ui.label(egui::RichText::new("Kinds").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Four severities drive the palette and (where available) the \
+             default Phosphor glyph: Success/CheckCircle (green), \
+             Error/X (red), Warning/Warning (amber), Info (blue, no icon).",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        if ui.button("Success").clicked() {
+            state.queue.success("Saved successfully");
+        }
+        if ui.button("Error").clicked() {
+            state.queue.error("Save failed: network unreachable");
+        }
+        if ui.button("Warning").clicked() {
+            state.queue.warning("Wallet balance is low");
+        }
+        if ui.button("Info").clicked() {
+            state.queue.info("3 new orders since last refresh");
+        }
+    });
+
+    ui.add_space(16.0);
+
+    // ── Copy-to-clipboard pattern ──────────────────────────────────────
+    ui.label(
+        egui::RichText::new("IdPill — clipboard acknowledgement")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Common case: confirm a copy from an `IdPill`. The widget \
+             returns `response.copied`; the host pushes an info toast. \
+             No coupling between primitive and controller.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(6.0);
+    if IdPill::new("policy", &state.demo_policy).show(ui).copied {
+        state
+            .queue
+            .push(Toast::new("policy copied to clipboard", ToastKind::Info).icon(PhosphorIcon::Copy));
+    }
+
+    ui.add_space(16.0);
+
+    // ── Builders ───────────────────────────────────────────────────────
+    ui.label(
+        egui::RichText::new("Custom icon + lifetime")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Build a `Toast` directly to override the icon (e.g. `Copy` for \
+             a clipboard ack instead of the default `CheckCircle`) or to \
+             extend the auto-dismiss duration for messages that need to \
+             linger.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        if ui.button("Long-lived").clicked() {
+            state.queue.push(
+                Toast::new("This one stays for 10 seconds", ToastKind::Info)
+                    .duration_frames(600),
+            );
+        }
+        if ui.button("Custom icon").clicked() {
+            state.queue.push(
+                Toast::new("Shipping", ToastKind::Success).icon(PhosphorIcon::Lightning),
+            );
+        }
+        if ui.button("Icon-suppressed").clicked() {
+            state
+                .queue
+                .push(Toast::new("Plain text only", ToastKind::Success).no_icon());
+        }
+    });
+
+    ui.add_space(16.0);
+
+    // ── Queue state ────────────────────────────────────────────────────
+    ui.label(egui::RichText::new("Queue state").color(ACCENT).strong());
+    ui.label(
+        egui::RichText::new(
+            "Live count + a clear-all (e.g. on a route change). Default \
+             cap is 5 simultaneously-visible toasts; older entries drop \
+             off the front of the queue as new ones land.",
+        )
+        .color(TEXT_MUTED)
+        .small(),
+    );
+    ui.add_space(6.0);
+    ui.horizontal(|ui| {
+        ui.label(format!("Active toasts: {}", state.queue.len()));
+        if ui.button("Clear all").clicked() {
+            state.queue.clear();
+        }
+    });
+
+    // The overlay itself is detached — it goes through `ctx` and floats
+    // above the storybook scroll. Calling it from inside the story
+    // routes it through the same code path a host app would use.
+    show_toasts(ui.ctx(), &mut state.queue);
+}

--- a/ui/egui-widgets/CLAUDE.md
+++ b/ui/egui-widgets/CLAUDE.md
@@ -2,6 +2,19 @@
 
 Reusable egui widget library for defrag frontends.
 
+## 📖 Before building UI here, read [`WIDGETS.md`](./WIDGETS.md)
+
+The crate has 50+ widgets organised into Primitives / Cards & Rows /
+Lists & Tables / Charts / Inputs / Wallet / Section / Domain-specific.
+**Before hand-building anything that looks widget-shaped — a chip, an
+ID display, a label-value grid, a card, a chart — scan WIDGETS.md
+first.** Most things you'd want already exist as a composable widget
+with a Storybook story showing the variants.
+
+If you do extract a new widget, the maintenance section at the bottom
+of WIDGETS.md is the three-step checklist (lib.rs registration,
+storybook story, catalog entry).
+
 ## Icons & Special Characters
 
 **NEVER use raw Unicode symbols** (e.g. `●` `○` `✓` `✕` `→` `★`) — they will render as broken boxes in the browser. The default egui font and the Phosphor font do not include geometric/symbol Unicode blocks.

--- a/ui/egui-widgets/WIDGETS.md
+++ b/ui/egui-widgets/WIDGETS.md
@@ -1,0 +1,222 @@
+# egui-widgets — Catalog
+
+One-line index of every widget in the crate, grouped by use case. Before
+building anything UI-shaped from scratch, scan this list first. Every
+entry follows the same shape:
+
+> `module` → `MainType` — what it renders — **when to reach for it**
+
+For full API: `cargo doc --open -p egui-widgets`. For visual examples:
+run the storybook (`shared-crates/ui/_storybook-egui`) and navigate to
+the matching story.
+
+---
+
+## Primitives
+
+Small composables — labels, chips, pills, counters. Cheap, no
+domain assumptions. Stack these into larger displays.
+
+- **`chip`** → `Chip` — Small filled-tag label with semantic variants
+  (`Success` / `Warning` / `Danger` / `Tag` / `Info` / `Muted`) +
+  optional `×` remove. **When you need a status / category / role
+  indicator that says what it means, not what colour it is.**
+- **`id_pill`** → `IdPill` — `label policy_id_truncated [Copy]` — owns
+  middle-elision + clipboard. **When you'd otherwise hand-build the
+  recurring "label + ellipsed hex + copy" pattern (policy_id, addresses,
+  tx hashes).**
+- **`property_list`** → `PropertyList` — Label/value grid via `.add(k,v)` /
+  `.add_optional(k, opt)`. **When you'd otherwise hand-build an
+  `egui::Grid` of "field: value" descriptive rows.**
+- **`animated_counter`** → `AnimatedCounter` — Smoothly interpolates a
+  numeric value between data snapshots. **When the value updates on a
+  poll cadence and you want it to feel alive (vs jumping).**
+- **`flip_counter`** → `FlipCounter` — Split-flap digit counter with
+  perspective. **When the kinetic vibe matters — leaderboards, scoreboards.**
+- **`seven_segment`** → `SevenSegmentDisplay` — Painter-drawn LED-style
+  digits. **When you want a scoreboard/clock aesthetic for time or
+  integers.**
+- **`progress_bar`** → `ProgressBar` — Themed determinate bar with
+  optional countdown / label modes. **Any determinate progress display
+  — supply minted, sync ratio, time remaining.**
+- **`marquee`** → `Marquee` — Continuously scrolling ticker of coloured
+  items. **Live feeds, announcements, anything ambient horizontal.**
+- **`button_group`** → `ButtonGroup` — Row of related action buttons
+  (`add(ButtonGroupButton::new(id, "label")…)`) with optional Phosphor
+  icons + tooltips + disabled state, `horizontal_wrapped` by default.
+  Returns the clicked button's caller-supplied `id`. **Any time you'd
+  otherwise stack 3+ small_button calls into an inline action bar.**
+
+## Cards & rows
+
+Composed display blocks for a single domain entity. One card = one
+row of data. These compose primitives internally.
+
+- **`metric_card`** → `MetricCard` — Label + large value + optional trend
+  + optional sparkline. **Dashboard KPIs.**
+- **`phase_card`** → `PhaseCard` — Read-only mint phase: header (name +
+  status + priority + Edit/Delete), Price/Window/Per-wallet via
+  `PropertyList`, gate chips with × remove. **Mint configuration UI.**
+- **`asset_card`** → `CardEffect` (+ projection / geometry / mesh /
+  overlay) — 3D-projected NFT card with tilt + holo + rarity border.
+  **Hero asset display where presentation matters.**
+- **`offer_tile`** → `OfferTile` — Fixed-size picker tile with
+  Active/InCart/Spent state + quantity badge. **Cart-driven asset
+  selection.**
+- **`offer_slot`** → `OfferSlotData` — Square card with IIIF thumbnail
+  + name overlay on hover. **Trade-table asset slots.**
+- **`fungibles_row`** → `FungiblesRow` — Compact "icon | name | ticker
+  chip | qty (ADA value)" row. **CNT holdings list (no thumbnails).**
+- **`pip_row`** → `PipRow` — Label + horizontal bar of coloured pips OR
+  density heatmap. **Distributions, market depth, listing spreads.**
+
+## Lists & tables
+
+Collections with a row-VM input + drained-action-list output. Same
+shape: builder → `.show(ui) -> Response { actions: Vec<…> }`.
+
+- **`collection_list`** → `CollectionList` — Per-client collections
+  roster (Card / List layouts). **Mint dashboard, collection management.**
+- **`wallet_list`** → `WalletList` — Per-client wallets grouped by role
+  (Primary / Collection / Custom). **Wallet management.**
+- **`data_table`** → `DataTable` — Dense column-headed table with row
+  selection + expandable detail. **Numeric dashboards (loans, audit).**
+- **`listing_grid`** → `ListingGrid` — Marketplace card grid with
+  thumbnails, prices, hover details. **Listing browsers.**
+- **`card_browser`** → `CardBrowserConfig` — Master-detail card grid
+  with right detail slider. **Browse + drill-in flows.**
+- **`trade_table`** → trade-offer display (split top/bottom) — Two-party
+  trade workspace with NFT slots + ADA sweetener + lock mechanics.
+  **Trade-desk concurrent dual-side offers.**
+- **`asset_strip`** → `AssetStripItem` row — Horizontal overlapping
+  thumbnails that lift on hover. **Compact related-assets row.**
+
+## Charts & visualisations
+
+- **`donut_chart`** → `DistributionChart` — Concentric orbital rings
+  with arc-layout toggle. **Proportional distribution in compact form.**
+- **`radar_chart`** → `RadarChartConfig` + `RadarPoint` — N-axis spider
+  chart. **Multi-axis profiles (trait coverage, wallet metrics).**
+- **`sparkline`** → `Sparkline` — Inline mini line chart with optional
+  fill + reference + endpoint highlight. **Embed in metric cards.**
+- **`range_bar`** → `RangePoint` + `RangeBarConfig` — Gradient bar with
+  ticks + coloured dots + auto-staggered labels. **Price/value points
+  along a continuous axis.**
+- **`exposure_bar`** → `ExposureSegment` — Stacked bar by collateral
+  token, coloured by LTV risk. **Loan-dashboard ADA exposure.**
+- **`coverage_delta_bar`** → `CoverageDeltaConfig` — Before/after
+  progress with gain/loss regions. **Trait-coverage trade impact.**
+- **`split_allocation_bar`** → `AllocationSegment` — Stacked bar
+  segmented by DEX with % labels. **Split-routing allocation display.**
+- **`price_impact_curve`** → `ImpactCurvePool` — AMM impact curves per
+  pool with optimizer allocation overlay. **Split-routing optimisation
+  rationale.**
+- **`pool_liquidity_indicator`** → `PoolInfo` — Per-pool depth + health
+  with relative depth bar + TVL + impact tint. **DEX pool comparison.**
+- **`utxo_map`** → `UtxoCell` Voronoi terrain — Force-directed UTxO
+  visualisation with policy territories + water/land. **Wallet
+  composition as an organic map.**
+- **`utxo_shelf`** → `ShelfTier` — UTxO health classification into
+  shelves (collateral/liquid/clean/bloated/dust). **Fragmentation
+  diagnosis.**
+
+## Inputs & form controls
+
+- **`amount_input`** → `AmountInputState` — Text input with "ADA" suffix
+  + MAX button + preset chips + validation. **ADA amount entry with
+  wallet-balance awareness.**
+- **`slippage_selector`** → `SlippageSelectorState` — Preset chips
+  (0.5%, 1%, 3%) + custom + warning bands. **DEX slippage tolerance.**
+- **`trait_filter`** → `FilterEntry` + `TraitFilterConfig` — Prefix-trie
+  search over `category:value` with removable tag chips. **Hierarchical
+  trait filtering.**
+- **`file_upload`** → `FileUploadButton` *(wasm32 only)* — Browser file
+  picker via async inbox. **Web-only file uploads.**
+- **`image_text_editor`** → `ImageTextEditor` *(feature-gated)* — Place,
+  style, drag text overlays on an image; flatten to RGBA. **Composite
+  image+text authoring.**
+- **`wallet_asset_picker`** → `PickerAsset` + `PickerPolicyGroup` —
+  Modal browser grouped by policy with multi-select summary bar.
+  **Pick NFTs from wallet inventory.**
+
+## Wallet / identity
+
+- **`wallet`** → `WalletConnector` — Framework-agnostic CIP-30 wallet
+  state (connection, addresses, balance, API). **State container for
+  any wallet-aware UI.**
+- **`wallet_button`** → `WalletAction` + `WalletConnector` display —
+  Compact status bar with picker popup. **Connect/disconnect entry
+  point.**
+- **`wallet_editor`** → `WalletEditorEntry` + `WalletEditorAction` —
+  List editor for stake addresses / handles with resolving / loading /
+  ready / failed states. **Wallet bundle management flows.**
+- **`wallet_identity_header`** → `WalletIdentityAction` — Hero strip:
+  handle (or short address) + full address + copy. **"Whose profile?"
+  page header.**
+- **`persona_strip`** → `PersonaStrip` — Italic one-liner tagline with
+  optional chip row. **Wallet / collection persona summary.**
+- **`mnemonic_display`** → `MnemonicDisplay` — BIP-39 phrase on dark
+  card with warning + copy + confirmation gate. **Show-mnemonic-once
+  flows (provisioning, Art. 20 export).**
+- **`signing_status`** → `SigningPhase` — Two-row signing checklist
+  with Sign + submission state. **Multi-party signing progress.**
+
+## Section / layout
+
+- **`grouped_section`** → `GroupedSection` + `GroupedSectionAction` —
+  Hero icon + title + verified badge + subtitle + bulk-action button +
+  caller-rendered body. **Grouping items under a parent entity with a
+  bulk action.**
+
+## Domain-specific
+
+Specialised — only reach for these in the matching domain. Don't try to
+generalise them into other contexts.
+
+- **`fee_report`** → `FeeReportData` + `SideFeeData` — Two-party trade
+  fee breakdown (platform + network + min UTxO + net ADA per side).
+- **`route_summary`** → `RouteSummaryData` + `RouteLeg` — Split-routing
+  per-leg display with improvement-vs-best-single-pool.
+- **`swap_modal`** → `SwapModalAction` — Self-contained DEX swap UI
+  (amount + slippage + preview + confirm + processing + success).
+- **`tx_cart`** → `TxCartItem` — Pending chain action list with
+  per-item counts + providers + batch execute.
+- **`tx_estimate`** → `TxEstimateData` — Per-wallet ADA cost breakdown
+  during trade negotiation.
+- **`trait_delta`** → `TraitItem` — Gains (+green) / losses (-red)
+  trait chips for trade swaps.
+- **`printing_timeline`** → `PrintingTimelineConfig` — Horizontal
+  timeline of card/asset printings (MtG / TCG context).
+
+## Infrastructure (not widgets)
+
+- **`buttons`** → `UiButtonExt` — extension trait adding pointer-cursor
+  hover. Use on any `egui::Button`.
+- **`icons`** → `PhosphorIcon` + `install_phosphor_font` — phosphor
+  glyph helper. Call `install_phosphor_font(ctx)` once, then
+  `PhosphorIcon::Gear.rich_text(size, colour)`.
+- **`theme`** — shared dark-mode colour palette.
+- **`utils`** — `truncate_middle`, etc. *(Consider `IdPill` before
+  hand-truncating.)*
+- **`screenshot`**, **`image_loader`** — runtime infrastructure.
+
+---
+
+## Maintenance
+
+When adding a new widget:
+
+1. Add it to the lib.rs `pub mod` block + `pub use` re-export.
+2. Add a Storybook story under
+   `shared-crates/ui/_storybook-egui/src/stories/` with the same name +
+   register it in `lib.rs::Story` enum (label, category, description,
+   dispatch arm).
+3. **Add a one-line entry to this file** in the bucket that best fits.
+
+If an existing widget is being *generalised* (e.g. `Chip` came from the
+old `status_chip` helpers), note the old call sites in the doc-comment
+so future readers find the bridge.
+
+If you find yourself building something inline that looks like it
+should be a widget — check this file first, then either reach for what
+exists or extract a new one with a story.

--- a/ui/egui-widgets/WIDGETS.md
+++ b/ui/egui-widgets/WIDGETS.md
@@ -46,6 +46,11 @@ domain assumptions. Stack these into larger displays.
   icons + tooltips + disabled state, `horizontal_wrapped` by default.
   Returns the clicked button's caller-supplied `id`. **Any time you'd
   otherwise stack 3+ small_button calls into an inline action bar.**
+- **`toast`** → `ToastQueue` + `show_toasts` — Transient overlay
+  messages with frame-countdown auto-dismiss; Success / Error / Warning
+  / Info kinds, host-owned queue, bottom-right stack. **Acknowledging
+  an action without committing to a status bar — "Copied to clipboard",
+  "Save failed", "Refuel submitted".**
 
 ## Cards & rows
 

--- a/ui/egui-widgets/src/button_group.rs
+++ b/ui/egui-widgets/src/button_group.rs
@@ -1,0 +1,240 @@
+//! `ButtonGroup` — a row of related action buttons with shared layout.
+//!
+//! Generalises the action-bar pattern used on the collection card, the
+//! wallet card, the orders viewer toolbar, etc. — anywhere a small set
+//! of related buttons needs to live on one row with consistent spacing,
+//! optional Phosphor icons, optional disabled state, optional click
+//! tooltips, and a single drained "which one was clicked?" response.
+//!
+//! ## Why not just `ui.horizontal_wrapped` with raw buttons?
+//!
+//! Inline button bars routinely accumulate:
+//! - inconsistent spacing across pages
+//! - mixed icon/text patterns (some use Phosphor, some use raw Unicode
+//!   that breaks per CLAUDE.md)
+//! - one-off disabled/in-flight handling
+//! - per-card glue code to dispatch which button was clicked
+//!
+//! `ButtonGroup` collapses this into one builder. Each button gets a
+//! caller-supplied `id` (any `u64` — the host typically casts an enum
+//! discriminant); on click, the response carries `Some(id)`.
+//!
+//! ## Layout
+//!
+//! - Default: `horizontal_wrapped` — a narrow surface spills onto the
+//!   next row rather than overlapping siblings. Switch to `wrapped(false)`
+//!   for fixed-width contexts.
+//! - Item spacing default = 4px; override with `spacing(f32)`.
+//! - Icons render via `phosphor_with_text` (LayoutJob mixing Phosphor +
+//!   proportional fonts) so a button label stays crisp even when the
+//!   icon family isn't pre-installed on the parent Ui — the widget
+//!   installs the font itself.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use egui_widgets::{ButtonGroup, ButtonGroupButton, PhosphorIcon};
+//!
+//! let resp = ButtonGroup::new()
+//!     .add(ButtonGroupButton::new(1, "Test mint"))
+//!     .add(ButtonGroupButton::new(2, "Activity"))
+//!     .add(
+//!         ButtonGroupButton::new(3, "Configure")
+//!             .icon(PhosphorIcon::Gear)
+//!             .hover_text("Edit phases, gates, and allowlist"),
+//!     )
+//!     .add(
+//!         ButtonGroupButton::new(4, "Refuelling…")
+//!             .enabled(false)
+//!             .hover_text("Refuel tx in flight — wait for the ack"),
+//!     )
+//!     .show(ui);
+//! match resp.clicked {
+//!     Some(1) => dispatch_test_mint(),
+//!     Some(2) => dispatch_activity(),
+//!     Some(3) => dispatch_configure(),
+//!     _ => {}
+//! }
+//! ```
+
+use egui::{Color32, FontFamily, RichText, TextStyle, Ui, WidgetText};
+
+use crate::icons::{install_phosphor_font, phosphor_family, PhosphorIcon};
+
+/// Builder.
+pub struct ButtonGroup<'a> {
+    buttons: Vec<ButtonGroupButton<'a>>,
+    wrap: bool,
+    spacing: f32,
+}
+
+/// Outcome of one `ButtonGroup::show()` call.
+#[derive(Default, Debug)]
+pub struct ButtonGroupResponse {
+    /// The `id` of the button the user clicked this frame, if any. The
+    /// host typically matches on this against its own enum discriminants.
+    pub clicked: Option<u64>,
+}
+
+/// One button in the group.
+pub struct ButtonGroupButton<'a> {
+    id: u64,
+    label: &'a str,
+    icon: Option<PhosphorIcon>,
+    enabled: bool,
+    hover_text: Option<&'a str>,
+}
+
+impl<'a> ButtonGroupButton<'a> {
+    /// Construct a default-enabled, text-only button with the given
+    /// caller-supplied click `id` and visible `label`.
+    pub fn new(id: u64, label: &'a str) -> Self {
+        Self {
+            id,
+            label,
+            icon: None,
+            enabled: true,
+            hover_text: None,
+        }
+    }
+
+    /// Add a leading Phosphor glyph rendered before the label.
+    pub fn icon(mut self, icon: PhosphorIcon) -> Self {
+        self.icon = Some(icon);
+        self
+    }
+
+    /// Disable the button. Renders greyed-out and unclickable; the
+    /// `hover_text` (if any) becomes a `on_disabled_hover_text`.
+    pub fn enabled(mut self, b: bool) -> Self {
+        self.enabled = b;
+        self
+    }
+
+    /// Tooltip shown on hover. On disabled buttons this becomes the
+    /// disabled-hover hint instead.
+    pub fn hover_text(mut self, s: &'a str) -> Self {
+        self.hover_text = Some(s);
+        self
+    }
+}
+
+impl<'a> Default for ButtonGroup<'a> {
+    fn default() -> Self {
+        Self {
+            buttons: Vec::new(),
+            wrap: true,
+            spacing: 4.0,
+        }
+    }
+}
+
+impl<'a> ButtonGroup<'a> {
+    /// New empty group. Default layout: horizontal-wrapped, 4px spacing.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one button. Chain `.add(…).add(…)` to build the row.
+    #[allow(clippy::should_implement_trait)] // builder verb, not arithmetic
+    pub fn add(mut self, button: ButtonGroupButton<'a>) -> Self {
+        self.buttons.push(button);
+        self
+    }
+
+    /// Switch to a single horizontal row that doesn't wrap (the row may
+    /// overflow on narrow surfaces). Default `true` (wrapped).
+    pub fn wrap(mut self, b: bool) -> Self {
+        self.wrap = b;
+        self
+    }
+
+    /// Set item spacing in pixels. Default `4.0`.
+    pub fn spacing(mut self, px: f32) -> Self {
+        self.spacing = px;
+        self
+    }
+
+    /// Render the group.
+    pub fn show(self, ui: &mut Ui) -> ButtonGroupResponse {
+        // Any button might carry a Phosphor icon. Idempotent.
+        if self.buttons.iter().any(|b| b.icon.is_some()) {
+            install_phosphor_font(ui.ctx());
+        }
+        let mut response = ButtonGroupResponse::default();
+        let render_row = |ui: &mut Ui| {
+            ui.spacing_mut().item_spacing.x = self.spacing;
+            for button in &self.buttons {
+                if let Some(id) = render_one(ui, button) {
+                    response.clicked = Some(id);
+                }
+            }
+        };
+        if self.wrap {
+            ui.horizontal_wrapped(render_row);
+        } else {
+            ui.horizontal(render_row);
+        }
+        response
+    }
+}
+
+/// Render one button. Returns `Some(id)` if it was clicked this frame.
+fn render_one(ui: &mut Ui, button: &ButtonGroupButton) -> Option<u64> {
+    let widget_text: WidgetText = match button.icon {
+        None => RichText::new(button.label).small().into(),
+        Some(icon) => phosphor_text(ui, icon, button.label),
+    };
+    let resp = ui.add_enabled(button.enabled, egui::Button::new(widget_text).small());
+    let resp = match (button.hover_text, button.enabled) {
+        (Some(t), true) => resp.on_hover_text(t),
+        (Some(t), false) => resp.on_disabled_hover_text(t),
+        _ => resp,
+    };
+    if resp.clicked() {
+        Some(button.id)
+    } else {
+        None
+    }
+}
+
+/// Build a `LayoutJob`-backed `WidgetText` that mixes a Phosphor glyph
+/// with proportional label text.
+///
+/// **Both runs use the size of egui's `TextStyle::Small`** so an
+/// icon+label button visually matches a text-only button in the same
+/// group. (Earlier shape hard-coded 12pt while text-only paths used
+/// `.small()` which resolves to ~10.5pt — leaving icon buttons visibly
+/// larger than their siblings inside a group. Resolving from
+/// `ui.style()` keeps the icon size in lock-step with whatever the
+/// active theme calls "small".)
+///
+/// Colour stays `PLACEHOLDER` so the button's enabled / hovered visual
+/// state carries through automatically.
+fn phosphor_text(ui: &Ui, icon: PhosphorIcon, label: &str) -> WidgetText {
+    use egui::text::LayoutJob;
+    use egui::{FontId, TextFormat};
+    let small = TextStyle::Small.resolve(ui.style());
+    let icon_font = FontId::new(small.size, phosphor_family());
+    let text_font = FontId::new(small.size, FontFamily::Proportional);
+    let mut job = LayoutJob::default();
+    job.append(
+        &icon.as_str(),
+        0.0,
+        TextFormat {
+            font_id: icon_font,
+            color: Color32::PLACEHOLDER,
+            ..Default::default()
+        },
+    );
+    job.append(
+        &format!(" {label}"),
+        0.0,
+        TextFormat {
+            font_id: text_font,
+            color: Color32::PLACEHOLDER,
+            ..Default::default()
+        },
+    );
+    job.into()
+}

--- a/ui/egui-widgets/src/chip.rs
+++ b/ui/egui-widgets/src/chip.rs
@@ -1,0 +1,187 @@
+//! `Chip` — small filled-tag label with optional remove (`×`) affordance.
+//!
+//! Generalises the half-dozen one-off `*_chip` helpers scattered through
+//! `wallet_list`, `collection_list`, and the portal frontend (status,
+//! standard, network, role, gate, archived). Variants pick a palette so
+//! the surrounding code says **what the chip means** rather than which
+//! colour to use.
+//!
+//! ## Variants
+//!
+//! - [`ChipVariant::Success`] — green. Active phases, healthy state, OK.
+//! - [`ChipVariant::Warning`] — yellow. Archived / paused / mind-the-gap.
+//! - [`ChipVariant::Danger`]  — red. Failures, ineligible, removed.
+//! - [`ChipVariant::Tag`]     — soft blue. Generic enumerated tag (e.g.
+//!   gate types: `public`, `allowlist`, `token_held`).
+//! - [`ChipVariant::Info`]    — soft teal. Informational secondary signal.
+//! - [`ChipVariant::Muted`]   — neutral grey. Background / deferred.
+//!
+//! ## Removable chips
+//!
+//! Setting [`Chip::removable`] adds a small `×` to the right of the
+//! label. Click on `×` returns [`ChipResponse::removed = true`] so the
+//! host can drop the row. The chip body is still hoverable for the
+//! tooltip; the `×` has its own hover hint.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use egui_widgets::{Chip, ChipVariant};
+//!
+//! Chip::new("active").variant(ChipVariant::Success).show(ui);
+//! let resp = Chip::new("public").variant(ChipVariant::Tag).removable(true).show(ui);
+//! if resp.removed { dispatch(RemoveGate { id }); }
+//! ```
+
+use egui::{Color32, CornerRadius, Frame, Margin, RichText, Sense, Stroke, Ui};
+
+use crate::icons::{install_phosphor_font, PhosphorIcon};
+
+/// Semantic palette pick — `Chip::variant(…)` consumes one of these.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChipVariant {
+    /// Green. Use for active / healthy / OK states.
+    Success,
+    /// Yellow. Use for paused / archived / "needs attention".
+    Warning,
+    /// Red. Use for failures / ineligible / removed.
+    Danger,
+    /// Soft blue. Generic enumerated tag (gate types, role tags, etc.).
+    Tag,
+    /// Soft teal. Informational secondary signal.
+    Info,
+    /// Neutral grey. Background / deferred / placeholder.
+    Muted,
+}
+
+impl ChipVariant {
+    /// Return the (foreground, background, optional border) triple. The
+    /// border is only set on `Tag` / `Info` variants — the filled
+    /// success/warning/danger chips don't need extra structure.
+    pub fn palette(self) -> (Color32, Color32, Option<Color32>) {
+        match self {
+            Self::Success => (Color32::from_rgb(18, 28, 18), Color32::LIGHT_GREEN, None),
+            Self::Warning => (Color32::from_rgb(40, 30, 10), Color32::LIGHT_YELLOW, None),
+            Self::Danger => (Color32::WHITE, Color32::from_rgb(180, 80, 80), None),
+            Self::Tag => (
+                Color32::from_gray(220),
+                Color32::from_rgb(30, 40, 60),
+                Some(Color32::from_rgb(60, 80, 110)),
+            ),
+            Self::Info => (
+                Color32::from_gray(220),
+                Color32::from_rgb(26, 44, 44),
+                Some(Color32::from_rgb(60, 100, 100)),
+            ),
+            Self::Muted => (Color32::WHITE, Color32::from_gray(140), None),
+        }
+    }
+}
+
+/// Builder.
+pub struct Chip<'a> {
+    text: &'a str,
+    variant: ChipVariant,
+    removable: bool,
+    hover_text: Option<&'a str>,
+    upper: bool,
+}
+
+/// Outcome of one `Chip::show()` call.
+#[derive(Default, Debug)]
+pub struct ChipResponse {
+    /// `true` when the user clicked the `×` (only emitted for chips built
+    /// with [`Chip::removable(true)`]).
+    pub removed: bool,
+    /// `true` when the chip body itself was clicked. Hosts can use this
+    /// for "click chip to filter" patterns; for static chips, ignore.
+    pub clicked: bool,
+}
+
+impl<'a> Chip<'a> {
+    /// Construct a `Chip` displaying `text`. Defaults: `ChipVariant::Muted`,
+    /// not removable, no tooltip, label rendered verbatim (no upper-casing).
+    pub fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            variant: ChipVariant::Muted,
+            removable: false,
+            hover_text: None,
+            upper: false,
+        }
+    }
+
+    /// Set the semantic variant. See [`ChipVariant`] for the palette
+    /// guide.
+    pub fn variant(mut self, v: ChipVariant) -> Self {
+        self.variant = v;
+        self
+    }
+
+    /// Add a `×` affordance to the right of the label. Click → returns
+    /// `ChipResponse { removed: true, .. }`.
+    pub fn removable(mut self, b: bool) -> Self {
+        self.removable = b;
+        self
+    }
+
+    /// Attach a tooltip shown on hover.
+    pub fn on_hover_text(mut self, s: &'a str) -> Self {
+        self.hover_text = Some(s);
+        self
+    }
+
+    /// Upper-case the label at render time (matches the old `status_chip`
+    /// behaviour). Off by default — passing pre-cased text is cleaner.
+    pub fn upper_case(mut self, b: bool) -> Self {
+        self.upper = b;
+        self
+    }
+
+    /// Render the chip inline at the current `Ui` cursor. The chip
+    /// allocates a small filled frame; the caller does spacing.
+    pub fn show(self, ui: &mut Ui) -> ChipResponse {
+        let (fg, bg, border) = self.variant.palette();
+        let mut response = ChipResponse::default();
+        let label_text = if self.upper {
+            self.text.to_ascii_uppercase()
+        } else {
+            self.text.to_string()
+        };
+
+        let mut frame = Frame::new()
+            .fill(bg)
+            .corner_radius(CornerRadius::same(3))
+            .inner_margin(Margin::symmetric(5, 1));
+        if let Some(b) = border {
+            frame = frame.stroke(Stroke::new(1.0, b));
+        }
+        let inner = frame.show(ui, |ui| {
+            ui.horizontal(|ui| {
+                let body = ui.label(RichText::new(&label_text).small().color(fg));
+                if let Some(hover) = self.hover_text {
+                    body.clone().on_hover_text(hover);
+                }
+                if self.removable {
+                    // Phosphor `X` glyph for the remove affordance per the
+                    // crate's no-raw-Unicode rule (see CLAUDE.md). Rendered
+                    // as a click-sensed `egui::Label` rather than a
+                    // `small_button` because the button has too much padding
+                    // for a chip's footprint.
+                    install_phosphor_font(ui.ctx());
+                    let x = ui.add(
+                        egui::Label::new(PhosphorIcon::X.rich_text(10.0, fg)).sense(Sense::click()),
+                    );
+                    if x.on_hover_text("Remove").clicked() {
+                        response.removed = true;
+                    }
+                }
+            });
+        });
+
+        if inner.response.clicked() {
+            response.clicked = true;
+        }
+        response
+    }
+}

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -138,6 +138,15 @@ pub struct CollectionRow {
     /// [`CollectionList::with_hide_archived`] is set they're hidden
     /// behind a "show archived" toggle.
     pub archived_at: Option<i64>,
+    /// The collection's bech32 deposit (payment-receiving) address — buyers
+    /// send ADA here; the host's payment monitor turns each inbound tx into a
+    /// `crypto` mint order. Full value goes to the clipboard on copy.
+    /// `None` hides the row (legacy collections allocated before the deposit
+    /// derivation was wired).
+    pub deposit_address: Option<String>,
+    /// Pre-truncated `deposit_address` for inline display (caller picks the
+    /// prefix/suffix widths). `None` hides the row.
+    pub deposit_address_short: Option<String>,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -707,6 +716,27 @@ fn render_card(
                     ui.ctx().copy_text(row.policy_id.clone());
                 }
             });
+
+            // ── Deposit address (where buyers send ADA) — only when
+            //    allocated (legacy rows hide it cleanly). Same shape as
+            //    the policy_id footer: prefix "deposit · " so it's
+            //    self-labelling at a glance, then the short bech32 + copy.
+            if let (Some(short), Some(full)) = (&row.deposit_address_short, &row.deposit_address) {
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new("deposit · ").small().color(META_GREY));
+                    ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
+                    if ui
+                        .small_button(RichText::new("📋").small())
+                        .on_hover_text(
+                            "Copy this collection's deposit address — \
+                             buyers send ADA here to mint",
+                        )
+                        .clicked()
+                    {
+                        ui.ctx().copy_text(full.clone());
+                    }
+                });
+            }
         });
 }
 

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -60,7 +60,10 @@
 
 use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
 
+use crate::button_group::{ButtonGroup, ButtonGroupButton};
+use crate::icons::install_phosphor_font;
 use crate::wallet_list::{WalletPoolBadge, WalletPoolBadgeHealth};
+use crate::PhosphorIcon;
 
 // ─────────────────────────────────────────────────────────────────────
 // Types
@@ -147,6 +150,14 @@ pub struct CollectionRow {
     /// Pre-truncated `deposit_address` for inline display (caller picks the
     /// prefix/suffix widths). `None` hides the row.
     pub deposit_address_short: Option<String>,
+    /// `true` when the parent has the Ingest-payment form open below this
+    /// row. Same toggle treatment as `test_mint_open` — `+ Ingest` flips to
+    /// `− Ingest`.
+    pub ingest_payment_open: bool,
+    /// `true` while a `ScanPayments` action is in flight for this collection.
+    /// Widget renders the Scan button disabled with a spinner-style label so
+    /// the operator can't double-fire while the engine is walking UTxOs.
+    pub scan_payments_in_flight: bool,
 }
 
 /// Actions emitted while the widget was on screen this frame. Parent
@@ -181,6 +192,22 @@ pub enum CollectionListAction {
     /// User clicked Restore on an archived card. Symmetric to
     /// [`Archive`]; only emitted from archived rows.
     Unarchive { policy_id: String },
+    /// User clicked the `+ Ingest` toggle. Host opens/closes a single-field
+    /// (tx_hash) form below the row and submits a manual `IngestPayment`
+    /// action on confirm. Only emitted when [`CollectionList::with_payments`]
+    /// is `true`.
+    IngestPayment { policy_id: String },
+    /// User clicked the `🔍 Scan` button. Host fires a `ScanPayments` action
+    /// that walks every unspent payment on the collection's deposit address.
+    /// No form — single click, result lands in a toast. Only emitted when
+    /// [`CollectionList::with_payments`] is `true` and `scan_payments_in_flight`
+    /// is `false` (widget self-enforces the no-double-fire rule).
+    ScanPayments { policy_id: String },
+    /// User clicked the `⚙ Configure` button. Host opens (or focuses) the
+    /// floating Configure window for this collection — the operator's
+    /// surface for editing phases, gates, and allowlist. Only emitted when
+    /// [`CollectionList::with_configure`] is `true`.
+    Configure { policy_id: String },
 }
 
 /// Rendering style. Both styles share the same row VM and action emission —
@@ -206,6 +233,8 @@ pub struct CollectionList<'a> {
     show_activity: bool,
     show_refuel: bool,
     show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
     hide_archived: bool,
 }
 
@@ -256,6 +285,8 @@ impl<'a> CollectionList<'a> {
             show_activity: false,
             show_refuel: false,
             show_archive: false,
+            show_payments: false,
+            show_configure: false,
             hide_archived: false,
         }
     }
@@ -336,6 +367,24 @@ impl<'a> CollectionList<'a> {
         self
     }
 
+    /// Show the per-card payment-monitor buttons (`🔍 Scan` + `+ Ingest`).
+    /// Off by default. The host wires the matching actions: `ScanPayments`
+    /// fires immediately (single click, result toast); `IngestPayment`
+    /// toggles a single-field form for a tx hash. See
+    /// `docs/design/MINT_PAYMENT_MONITOR.md`.
+    pub fn with_payments(mut self, enabled: bool) -> Self {
+        self.show_payments = enabled;
+        self
+    }
+
+    /// Show the per-card `⚙ Configure` button. Off by default. Click →
+    /// emits [`CollectionListAction::Configure`]; host opens / focuses the
+    /// floating Configure window for editing phases, gates, and allowlist.
+    pub fn with_configure(mut self, enabled: bool) -> Self {
+        self.show_configure = enabled;
+        self
+    }
+
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
@@ -383,6 +432,8 @@ impl<'a> CollectionList<'a> {
                             self.show_activity,
                             self.show_refuel,
                             self.show_archive,
+                            self.show_payments,
+                            self.show_configure,
                             &mut response,
                         );
                     }
@@ -398,6 +449,8 @@ impl<'a> CollectionList<'a> {
                                 self.show_activity,
                                 self.show_refuel,
                                 self.show_archive,
+                                self.show_payments,
+                                self.show_configure,
                                 &mut response,
                             );
                         }
@@ -445,6 +498,8 @@ fn render_one(
     show_activity: bool,
     show_refuel: bool,
     show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
@@ -456,6 +511,8 @@ fn render_one(
             show_activity,
             show_refuel,
             show_archive,
+            show_payments,
+            show_configure,
             response,
         ),
         CollectionListLayout::List => render_list_row(
@@ -466,6 +523,8 @@ fn render_one(
             show_activity,
             show_refuel,
             show_archive,
+            show_payments,
+            show_configure,
             response,
         ),
     }
@@ -480,8 +539,14 @@ fn render_card(
     show_activity: bool,
     show_refuel: bool,
     show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
     response: &mut CollectionListResponse,
 ) {
+    // `PhosphorIcon::*.rich_text()` doesn't auto-install the font (unlike
+    // `.show()`); the inline copy / chip / configure buttons below all
+    // rely on the glyph being available. Idempotent.
+    install_phosphor_font(ui.ctx());
     let archived = row.archived_at.is_some();
     let fill = if archived { ROW_BG_ARCHIVED } else { ROW_BG };
     Frame::new()
@@ -492,7 +557,11 @@ fn render_card(
         .show(ui, |ui| {
             ui.set_width(ui.available_width());
 
-            // ── Title row: title + chips + (right) action buttons ──
+            // ── Title row: title + chips only ──────────────────────
+            // Action buttons moved out to their own dedicated bar below so
+            // the title stays readable at any card width (the previous
+            // shape squeezed the title under {chips × ≥4 buttons} at
+            // ~half-width). The bar wraps via `horizontal_wrapped`.
             ui.horizontal(|ui| {
                 let title = RichText::new(&row.title).heading();
                 ui.label(if archived {
@@ -510,70 +579,34 @@ fn render_card(
                 if archived {
                     ui.colored_label(Color32::LIGHT_YELLOW, RichText::new("archived").small());
                 }
-
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if show_archive {
-                        archive_button(ui, row, archived, response);
-                    }
-                    if show_test_mint {
-                        let label = if row.test_mint_open {
-                            "− Test mint"
-                        } else {
-                            "🧪 Test mint"
-                        };
-                        if ui
-                            .small_button(RichText::new(label).small())
-                            .on_hover_text(
-                                "Open the test-mint form for this collection \
-                                     (operator/super-admin only)",
-                            )
-                            .clicked()
-                        {
-                            response.actions.push(CollectionListAction::TestMint {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                    if show_seed_stubs {
-                        let label = if row.seed_stubs_open {
-                            "− Seed stubs"
-                        } else {
-                            "+ Seed stubs"
-                        };
-                        if ui
-                            .small_button(RichText::new(label).small())
-                            .on_hover_text(
-                                "Seed placeholder mintable assets \
-                                     (testing-only — real ingest replaces this)",
-                            )
-                            .clicked()
-                        {
-                            response.actions.push(CollectionListAction::SeedStubs {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                    if show_activity {
-                        let label = if row.activity_open {
-                            "− Activity"
-                        } else {
-                            "📜 Activity"
-                        };
-                        if ui
-                            .small_button(RichText::new(label).small())
-                            .on_hover_text(
-                                "Recent mint activity for this collection — \
-                                     fetched from the engine's mint_log",
-                            )
-                            .clicked()
-                        {
-                            response.actions.push(CollectionListAction::Activity {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                });
             });
+
+            // ── Action bar ─────────────────────────────────────────
+            if has_any_action(
+                show_test_mint,
+                show_seed_stubs,
+                show_activity,
+                show_refuel,
+                show_archive,
+                show_payments,
+                show_configure,
+                row,
+            ) {
+                ui.add_space(6.0);
+                render_operator_actions(
+                    ui,
+                    row,
+                    archived,
+                    show_test_mint,
+                    show_seed_stubs,
+                    show_activity,
+                    show_archive,
+                    show_payments,
+                    show_configure,
+                    true, // wrap — Card layout has its own dedicated bar row
+                    response,
+                );
+            }
 
             ui.add_space(8.0);
 
@@ -651,7 +684,7 @@ fn render_card(
                     ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
                     if let Some(full) = &row.wallet_address_full {
                         if ui
-                            .small_button(RichText::new("📋").small())
+                            .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
                             .on_hover_text("Copy wallet address to clipboard")
                             .clicked()
                         {
@@ -668,7 +701,10 @@ fn render_card(
                         WalletPoolBadgeHealth::Low => Color32::from_rgb(220, 200, 130),
                         WalletPoolBadgeHealth::Healthy => Color32::from_rgb(150, 210, 160),
                     };
-                    ui.label(RichText::new("●").small().color(fg));
+                    // Health indicator: the text colour itself carries the
+                    // signal (red/amber/green). The leading `●` glyph used
+                    // to do this here doesn't render in the browser font;
+                    // CLAUDE.md says drop geometric Unicode.
                     let ada_whole = pool.total_lovelace / 1_000_000;
                     ui.label(
                         RichText::new(format!("{} fuel · {} ADA", pool.fuel_count, ada_whole))
@@ -709,7 +745,7 @@ fn render_card(
                         .color(KEYHASH_GREY),
                 );
                 if ui
-                    .small_button(RichText::new("📋").small())
+                    .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
                     .on_hover_text("Copy policy_id to clipboard")
                     .clicked()
                 {
@@ -726,7 +762,7 @@ fn render_card(
                     ui.label(RichText::new("deposit · ").small().color(META_GREY));
                     ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
                     if ui
-                        .small_button(RichText::new("📋").small())
+                        .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
                         .on_hover_text(
                             "Copy this collection's deposit address — \
                              buyers send ADA here to mint",
@@ -749,8 +785,14 @@ fn render_list_row(
     show_activity: bool,
     show_refuel: bool,
     show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
     response: &mut CollectionListResponse,
 ) {
+    // `PhosphorIcon::*.rich_text()` doesn't auto-install the font (unlike
+    // `.show()`); the inline copy / chip / configure buttons below all
+    // rely on the glyph being available. Idempotent.
+    install_phosphor_font(ui.ctx());
     let archived = row.archived_at.is_some();
     let fill = if archived { ROW_BG_ARCHIVED } else { ROW_BG };
     Frame::new()
@@ -789,57 +831,35 @@ fn render_list_row(
                 );
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if show_archive {
-                        archive_button(ui, row, archived, response);
-                    }
-                    if show_test_mint {
-                        let label = if row.test_mint_open {
-                            "− Test mint"
-                        } else {
-                            "🧪 Test mint"
-                        };
-                        if ui.small_button(RichText::new(label).small()).clicked() {
-                            response.actions.push(CollectionListAction::TestMint {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                    if show_seed_stubs {
-                        let label = if row.seed_stubs_open {
-                            "− Seed stubs"
-                        } else {
-                            "+ Seed stubs"
-                        };
-                        if ui.small_button(RichText::new(label).small()).clicked() {
-                            response.actions.push(CollectionListAction::SeedStubs {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                    if show_activity {
-                        let label = if row.activity_open {
-                            "− Activity"
-                        } else {
-                            "📜 Activity"
-                        };
-                        if ui.small_button(RichText::new(label).small()).clicked() {
-                            response.actions.push(CollectionListAction::Activity {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
-                    }
-                    if ui
-                        .small_button(RichText::new("📋").small())
-                        .on_hover_text("Copy policy_id to clipboard")
-                        .clicked()
-                    {
-                        ui.ctx().copy_text(row.policy_id.clone());
-                    }
+                    // Right-edge: Refuel → Copy → operator action group.
+                    // Within `right_to_left`, items added first sit furthest
+                    // right; ButtonGroup's internal layout still flows
+                    // left-to-right inside its own cluster.
                     if show_refuel {
                         if let Some(pool) = &row.pool {
                             refuel_button(ui, row, pool, response);
                         }
                     }
+                    if ui
+                        .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
+                        .on_hover_text("Copy policy_id to clipboard")
+                        .clicked()
+                    {
+                        ui.ctx().copy_text(row.policy_id.clone());
+                    }
+                    render_operator_actions(
+                        ui,
+                        row,
+                        archived,
+                        show_test_mint,
+                        show_seed_stubs,
+                        show_activity,
+                        show_archive,
+                        show_payments,
+                        show_configure,
+                        false, // wrap — List layout is single-row by design
+                        response,
+                    );
                 });
             });
         });
@@ -863,7 +883,7 @@ fn refuel_button(
     if row.refuel_in_flight {
         ui.add_enabled(
             false,
-            egui::Button::new(RichText::new("⛽ Refuelling…").small()),
+            egui::Button::new(RichText::new("Refuelling…").small()),
         )
         .on_disabled_hover_text(
             "A refuel tx is in flight — wait for it to confirm before submitting another.",
@@ -872,7 +892,7 @@ fn refuel_button(
     }
     let healthy = pool.health == WalletPoolBadgeHealth::Healthy;
     if healthy {
-        ui.add_enabled(false, egui::Button::new(RichText::new("⛽ Refuel").small()))
+        ui.add_enabled(false, egui::Button::new(RichText::new("Refuel").small()))
             .on_disabled_hover_text(
                 "Fuel pool is healthy — no refuel needed. \
                  The pool tops up automatically during mints.",
@@ -880,7 +900,7 @@ fn refuel_button(
         return;
     }
     if ui
-        .small_button(RichText::new("⛽ Refuel").small())
+        .small_button(RichText::new("Refuel").small())
         .on_hover_text(
             "Split this wallet's pure-ADA balance into 10 ADA fuel UTxOs \
              so it's ready for parallel mints. Submits a self-spend tx.",
@@ -893,39 +913,190 @@ fn refuel_button(
     }
 }
 
-/// Archive ↔ Restore button, shared by both layouts. Emits
-/// [`CollectionListAction::Unarchive`] on an archived card, else
-/// [`CollectionListAction::Archive`]. Archiving halts the collection's
-/// engine DO + hides the card; restoring re-enables it.
-fn archive_button(
+/// Cheap predicate so we can suppress the spacing + action bar entirely
+/// on a card with no buttons configured (e.g. a list view that doesn't
+/// opt into any of the operator flags).
+#[allow(clippy::too_many_arguments)]
+fn has_any_action(
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+    show_activity: bool,
+    show_refuel: bool,
+    show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
+    row: &CollectionRow,
+) -> bool {
+    show_test_mint
+        || show_seed_stubs
+        || show_activity
+        || show_archive
+        || show_configure
+        || show_payments
+        // Refuel is a card-only affordance + sits in the wallet sub-line,
+        // not the action bar — but the predicate is shared with the bar's
+        // visibility check; counting it keeps the bar logic uniform.
+        || (show_refuel && row.pool.is_some())
+}
+
+/// Operator-action cluster — Test mint / Activity / Configure / Ingest
+/// / Scan / Seed stubs / Archive, all routed through a single
+/// [`ButtonGroup`] so layout / spacing / Phosphor-icon labelling are
+/// handled by the shared primitive rather than re-implemented inline.
+///
+/// `wrap = true` is the Card layout (a dedicated row below the title
+/// that wraps onto a second line on narrow surfaces). `wrap = false` is
+/// the List layout (one compact line, no wrap).
+///
+/// Archive lives at the natural end of the cluster rather than being
+/// pinned to the right edge (the previous shape) — when the cluster
+/// wraps, Archive lands on the last line which is visually equivalent.
+#[allow(clippy::too_many_arguments)]
+fn render_operator_actions(
     ui: &mut Ui,
     row: &CollectionRow,
     archived: bool,
+    show_test_mint: bool,
+    show_seed_stubs: bool,
+    show_activity: bool,
+    show_archive: bool,
+    show_payments: bool,
+    show_configure: bool,
+    wrap: bool,
     response: &mut CollectionListResponse,
 ) {
-    if archived {
-        if ui
-            .small_button(RichText::new("Restore").small())
-            .on_hover_text(
+    // Stable click ids — match the dispatch arm below. Locally scoped
+    // because the host never sees these; the widget emits its own
+    // `CollectionListAction` enum.
+    const ID_TEST_MINT: u64 = 1;
+    const ID_ACTIVITY: u64 = 2;
+    const ID_CONFIGURE: u64 = 3;
+    const ID_INGEST: u64 = 4;
+    const ID_SCAN: u64 = 5;
+    const ID_SEED_STUBS: u64 = 6;
+    const ID_ARCHIVE: u64 = 7;
+
+    let mut group = ButtonGroup::new().wrap(wrap);
+
+    if show_test_mint {
+        let label = if row.test_mint_open {
+            "- Test mint"
+        } else {
+            "Test mint"
+        };
+        group = group.add(ButtonGroupButton::new(ID_TEST_MINT, label).hover_text(
+            "Open the test-mint form for this collection \
+                 (operator/super-admin only)",
+        ));
+    }
+    if show_activity {
+        let label = if row.activity_open {
+            "- Activity"
+        } else {
+            "Activity"
+        };
+        group = group.add(ButtonGroupButton::new(ID_ACTIVITY, label).hover_text(
+            "Recent mint activity for this collection — \
+                 fetched from the engine's mint_log",
+        ));
+    }
+    if show_configure {
+        group = group.add(
+            ButtonGroupButton::new(ID_CONFIGURE, "Configure")
+                .icon(crate::PhosphorIcon::Gear)
+                .hover_text(
+                    "Open the mint configuration — phases (price + time window + \
+                     per-wallet limit), gates (public / allowlist / token-held), \
+                     and allowlist entries.",
+                ),
+        );
+    }
+    if show_payments {
+        let ingest_label = if row.ingest_payment_open {
+            "- Ingest"
+        } else {
+            "+ Ingest"
+        };
+        group = group.add(ButtonGroupButton::new(ID_INGEST, ingest_label).hover_text(
+            "Manually feed an on-chain payment tx through the resolver — \
+                 creates a mint order (or queues a refund). Idempotent on tx hash.",
+        ));
+        let scan_label = if row.scan_payments_in_flight {
+            "Scanning…"
+        } else {
+            "Scan"
+        };
+        let scan_hover = if row.scan_payments_in_flight {
+            "A payments scan is in flight — wait for it to complete before re-running."
+        } else {
+            "Walk this collection's deposit address and process every unspent \
+             payment through the resolver. Idempotent — already-handled txs \
+             short-circuit."
+        };
+        group = group.add(
+            ButtonGroupButton::new(ID_SCAN, scan_label)
+                .icon(crate::PhosphorIcon::MagnifyingGlass)
+                .enabled(!row.scan_payments_in_flight)
+                .hover_text(scan_hover),
+        );
+    }
+    if show_seed_stubs {
+        let label = if row.seed_stubs_open {
+            "- Seed stubs"
+        } else {
+            "+ Seed stubs"
+        };
+        group = group.add(ButtonGroupButton::new(ID_SEED_STUBS, label).hover_text(
+            "Seed placeholder mintable assets \
+                 (testing-only — real ingest replaces this)",
+        ));
+    }
+    if show_archive {
+        let (label, hover) = if archived {
+            (
+                "Restore",
                 "Bring this collection back — the engine resumes processing on the next signal.",
             )
-            .clicked()
-        {
-            response.actions.push(CollectionListAction::Unarchive {
-                policy_id: row.policy_id.clone(),
-            });
-        }
-    } else if ui
-        .small_button(RichText::new("Archive").small())
-        .on_hover_text(
-            "Retire this collection: halts its mint engine + hides it from the \
-             dashboard. Reversible.",
-        )
-        .clicked()
-    {
-        response.actions.push(CollectionListAction::Archive {
+        } else {
+            (
+                "Archive",
+                "Retire this collection: halts its mint engine + hides it from the \
+                 dashboard. Reversible.",
+            )
+        };
+        group = group.add(ButtonGroupButton::new(ID_ARCHIVE, label).hover_text(hover));
+    }
+
+    let clicked = group.show(ui).clicked;
+    let action = match clicked {
+        Some(ID_TEST_MINT) => Some(CollectionListAction::TestMint {
             policy_id: row.policy_id.clone(),
-        });
+        }),
+        Some(ID_ACTIVITY) => Some(CollectionListAction::Activity {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_CONFIGURE) => Some(CollectionListAction::Configure {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_INGEST) => Some(CollectionListAction::IngestPayment {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_SCAN) => Some(CollectionListAction::ScanPayments {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_SEED_STUBS) => Some(CollectionListAction::SeedStubs {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_ARCHIVE) if archived => Some(CollectionListAction::Unarchive {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_ARCHIVE) => Some(CollectionListAction::Archive {
+            policy_id: row.policy_id.clone(),
+        }),
+        _ => None,
+    };
+    if let Some(a) = action {
+        response.actions.push(a);
     }
 }
 

--- a/ui/egui-widgets/src/id_pill.rs
+++ b/ui/egui-widgets/src/id_pill.rs
@@ -1,0 +1,165 @@
+//! `IdPill` — small inline display of a long identifier with a copy
+//! affordance. The recurring `policy 8532f316dd09…45d87a1b 📋` pattern
+//! used for policy_id, wallet bech32 addresses, deposit addresses, tx
+//! hashes, and other hash-shaped strings.
+//!
+//! Composed of three parts, any subset optional:
+//! - small muted **label** ("policy" / "wallet" / "deposit" / "tx")
+//! - monospace **truncated value** (middle-elided) with the full value
+//!   on hover for verification
+//! - **copy button** (Phosphor `Copy` glyph by default; the widget
+//!   handles the clipboard call itself)
+//!
+//! The widget owns truncation: callers pass the full value + a
+//! `(prefix_width, suffix_width)` pair; if the value already fits the
+//! pill renders it verbatim. Hosts that need a specific truncation can
+//! pass their own pre-truncated string via [`IdPill::with_short`].
+//!
+//! ## Example
+//!
+//! ```ignore
+//! IdPill::new("policy", policy_id_full).show(ui);
+//! IdPill::new("wallet", address)
+//!     .with_widths(14, 8)
+//!     .show(ui);
+//! ```
+
+use egui::{Color32, RichText, Ui};
+
+use crate::icons::{install_phosphor_font, PhosphorIcon};
+
+/// Builder.
+pub struct IdPill<'a> {
+    label: Option<&'a str>,
+    value_full: &'a str,
+    value_short: Option<String>,
+    widths: (usize, usize),
+    copyable: bool,
+    label_color: Color32,
+    value_color: Color32,
+}
+
+/// Outcome of one `IdPill::show()` call.
+#[derive(Default, Debug)]
+pub struct IdPillResponse {
+    /// `true` when the user clicked the copy button (the widget has
+    /// already written `value_full` to the clipboard).
+    pub copied: bool,
+}
+
+impl<'a> IdPill<'a> {
+    /// Construct a pill. `label` shows in muted grey to the left of the
+    /// truncated value; pass an empty string (or use the no-label
+    /// constructor) to omit it.
+    pub fn new(label: &'a str, value_full: &'a str) -> Self {
+        Self {
+            label: Some(label).filter(|s| !s.is_empty()),
+            value_full,
+            value_short: None,
+            widths: (10, 6),
+            copyable: true,
+            label_color: Color32::from_gray(140),
+            value_color: Color32::from_gray(190),
+        }
+    }
+
+    /// Override the widget-computed middle-elision. Useful when the host
+    /// already has a pre-formatted display value (e.g. from a row VM
+    /// that pre-computed `address_short`).
+    pub fn with_short(mut self, short: impl Into<String>) -> Self {
+        self.value_short = Some(short.into());
+        self
+    }
+
+    /// Set the prefix / suffix widths for the middle-elision. Default
+    /// `(10, 6)` suits a 56-char policy_id; bech32 addresses normally
+    /// take `(14, 8)`.
+    pub fn with_widths(mut self, prefix: usize, suffix: usize) -> Self {
+        self.widths = (prefix, suffix);
+        self
+    }
+
+    /// Suppress the copy button.
+    pub fn copyable(mut self, b: bool) -> Self {
+        self.copyable = b;
+        self
+    }
+
+    /// Override the muted label colour.
+    pub fn label_color(mut self, c: Color32) -> Self {
+        self.label_color = c;
+        self
+    }
+
+    /// Override the value colour.
+    pub fn value_color(mut self, c: Color32) -> Self {
+        self.value_color = c;
+        self
+    }
+
+    /// Render.
+    pub fn show(self, ui: &mut Ui) -> IdPillResponse {
+        let mut response = IdPillResponse::default();
+        ui.horizontal(|ui| {
+            if let Some(label) = self.label {
+                ui.label(RichText::new(label).small().color(self.label_color));
+            }
+            let short = self
+                .value_short
+                .unwrap_or_else(|| truncate_middle(self.value_full, self.widths.0, self.widths.1));
+            ui.label(
+                RichText::new(short)
+                    .monospace()
+                    .small()
+                    .color(self.value_color),
+            )
+            .on_hover_text(self.value_full);
+            if self.copyable {
+                install_phosphor_font(ui.ctx());
+                if ui
+                    .small_button(PhosphorIcon::Copy.rich_text(11.0, self.label_color).small())
+                    .on_hover_text("Copy to clipboard")
+                    .clicked()
+                {
+                    ui.ctx().copy_text(self.value_full.to_string());
+                    response.copied = true;
+                }
+            }
+        });
+        response
+    }
+}
+
+/// Middle-elide a string at `prefix + ellipsis + suffix` width. Returns
+/// the input unchanged when it's already short enough.
+fn truncate_middle(s: &str, prefix: usize, suffix: usize) -> String {
+    if s.chars().count() <= prefix + suffix + 1 {
+        return s.to_string();
+    }
+    let p: String = s.chars().take(prefix).collect();
+    let q: String = s
+        .chars()
+        .rev()
+        .take(suffix)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    format!("{p}…{q}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate_middle("abc", 10, 6), "abc");
+    }
+
+    #[test]
+    fn truncate_long_string_elides() {
+        let s = "0123456789abcdef0123456789abcdef";
+        assert_eq!(truncate_middle(s, 8, 6), "01234567…abcdef");
+    }
+}

--- a/ui/egui-widgets/src/id_pill.rs
+++ b/ui/egui-widgets/src/id_pill.rs
@@ -24,9 +24,28 @@
 //!     .show(ui);
 //! ```
 
-use egui::{Color32, RichText, Ui};
+use egui::{Align, Color32, Layout, RichText, Ui};
 
 use crate::icons::{install_phosphor_font, PhosphorIcon};
+
+/// Visual layout pick — `IdPill::layout(…)` consumes one of these.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdPillLayout {
+    /// Three rows inside a subtle framed pill: **label** (small muted
+    /// header) over **value** (monospace body) over **copy button**
+    /// (right-aligned footer). The richer presentation, used as the
+    /// default. Shows the *full* value when it fits the available width;
+    /// auto-truncates only when constrained. Best for standalone display
+    /// stacks (the typical "Common uses" pattern: policy / wallet /
+    /// stake / tx all visible at once).
+    Stacked,
+    /// Single horizontal row: `label  value [Copy]`. Compact, no frame.
+    /// Truncation always applies (per [`IdPill::with_widths`] / the
+    /// default). Best for inline use in header bars where vertical
+    /// budget is tight (e.g. the portal's Configure-window header,
+    /// where the policy pill shares a row with a Refresh button).
+    Inline,
+}
 
 /// Builder.
 pub struct IdPill<'a> {
@@ -34,7 +53,11 @@ pub struct IdPill<'a> {
     value_full: &'a str,
     value_short: Option<String>,
     widths: (usize, usize),
+    label_min_width: Option<f32>,
+    value_min_width: Option<f32>,
+    min_width: Option<f32>,
     copyable: bool,
+    layout: IdPillLayout,
     label_color: Color32,
     value_color: Color32,
 }
@@ -56,11 +79,26 @@ impl<'a> IdPill<'a> {
             label: Some(label).filter(|s| !s.is_empty()),
             value_full,
             value_short: None,
-            widths: (10, 6),
+            // (10, 8) → 19-char middle-elision: `8532f316dd…45d87a1b`.
+            // Reads as a consistent total length across policy_id (56 chars),
+            // bech32 addresses (~103 chars), and tx hashes (64 chars).
+            widths: (10, 8),
+            label_min_width: None,
+            value_min_width: None,
+            min_width: None,
             copyable: true,
+            layout: IdPillLayout::Stacked,
             label_color: Color32::from_gray(140),
-            value_color: Color32::from_gray(190),
+            value_color: Color32::from_gray(220),
         }
+    }
+
+    /// Pick the visual presentation. Default is [`IdPillLayout::Stacked`]
+    /// (three-row framed pill); pass `Inline` for the compact one-row
+    /// shape suited to header bars.
+    pub fn layout(mut self, layout: IdPillLayout) -> Self {
+        self.layout = layout;
+        self
     }
 
     /// Override the widget-computed middle-elision. Useful when the host
@@ -85,6 +123,48 @@ impl<'a> IdPill<'a> {
         self
     }
 
+    /// Reserve a minimum width (px) for the label so a vertical stack of
+    /// `IdPill`s with different-length labels align their value columns.
+    /// Pick a width that fits the longest label in the stack — e.g. `45.0`
+    /// is comfortable for short labels like `policy`/`wallet`/`stake`/`tx`.
+    /// Without this set, the label takes its natural width (the source of
+    /// the alignment drift in stacked groups).
+    pub fn label_min_width(mut self, w: f32) -> Self {
+        self.label_min_width = Some(w);
+        self
+    }
+
+    /// Reserve a minimum width (px) for the value column so the copy
+    /// button sits at the same x-position across a stack of pills with
+    /// slightly different truncated value lengths (testnet addresses
+    /// usually push wider than mainnet because of the longer prefix).
+    pub fn value_min_width(mut self, w: f32) -> Self {
+        self.value_min_width = Some(w);
+        self
+    }
+
+    /// Reserve a minimum width (px) for the whole pill frame, so a
+    /// vertical stack of [`IdPillLayout::Stacked`] pills renders with a
+    /// uniform border regardless of value length. The widget has no view
+    /// of its siblings — pair with [`stacked_width_for`] across the
+    /// values you intend to render and take the max:
+    ///
+    /// ```ignore
+    /// let w = [policy, addr, stake, tx]
+    ///     .iter()
+    ///     .map(|v| stacked_width_for(ui, v, true))
+    ///     .fold(0.0_f32, f32::max);
+    /// IdPill::new("policy", policy).min_width(w).show(ui);
+    /// IdPill::new("wallet", addr).min_width(w).show(ui);
+    /// // …
+    /// ```
+    ///
+    /// Has no effect on [`IdPillLayout::Inline`].
+    pub fn min_width(mut self, w: f32) -> Self {
+        self.min_width = Some(w);
+        self
+    }
+
     /// Override the muted label colour.
     pub fn label_color(mut self, c: Color32) -> Self {
         self.label_color = c;
@@ -97,23 +177,133 @@ impl<'a> IdPill<'a> {
         self
     }
 
-    /// Render.
+    /// Render. Dispatches on [`IdPill::layout`].
     pub fn show(self, ui: &mut Ui) -> IdPillResponse {
+        match self.layout {
+            IdPillLayout::Stacked => self.show_stacked(ui),
+            IdPillLayout::Inline => self.show_inline(ui),
+        }
+    }
+
+    /// Two-row framed shape: label header / value-with-trailing-copy
+    /// body. Shows the full value when it fits the available width;
+    /// falls back to middle-elision (`widths`) when constrained.
+    fn show_stacked(self, ui: &mut Ui) -> IdPillResponse {
+        let mut response = IdPillResponse::default();
+        if self.copyable {
+            install_phosphor_font(ui.ctx());
+        }
+        // `min_width` caps the frame's *outer* width so a column of
+        // pills shares a uniform border AND stays at the natural
+        // max-content width of the stack — not the parent's full
+        // available width. `ui.set_min_width` only enforces a lower
+        // bound, so a wide parent (e.g. the storybook scroll, the
+        // dashboard centre panel) would still let the frame stretch.
+        // `allocate_ui_with_layout(vec2(w, 0), …)` carves out exactly
+        // `w` of horizontal space for the frame to occupy.
+        if let Some(w) = self.min_width {
+            ui.allocate_ui_with_layout(
+                egui::vec2(w, 0.0),
+                Layout::top_down(Align::Min),
+                |ui| self.render_stacked_frame(ui, &mut response, true),
+            );
+        } else {
+            self.render_stacked_frame(ui, &mut response, false);
+        }
+        response
+    }
+
+    /// Render the framed two-row pill. `right_align_copy` decides
+    /// whether the copy button rides the row's right edge (used when
+    /// `min_width` has carved out a uniform-width slot for the frame)
+    /// or trails inline next to the value (used when the frame is
+    /// content-sized — any `right_to_left` allocation there would
+    /// stretch the row across the parent's full available width,
+    /// re-introducing the original "frame grew huge" bug).
+    fn render_stacked_frame(
+        &self,
+        ui: &mut Ui,
+        response: &mut IdPillResponse,
+        right_align_copy: bool,
+    ) {
+        // Subtle dark fill + thin border — matches the crate's
+        // framed-block palette (Chip uses similar tones).
+        let fill = Color32::from_rgb(22, 24, 30);
+        let stroke = Color32::from_rgb(48, 52, 64);
+        egui::Frame::new()
+            .fill(fill)
+            .stroke(egui::Stroke::new(1.0, stroke))
+            .corner_radius(egui::CornerRadius::same(4))
+            .inner_margin(egui::Margin::symmetric(8, 6))
+            .show(ui, |ui| {
+                // Header: small muted label on its own row.
+                if let Some(label) = self.label {
+                    ui.label(RichText::new(label).small().color(self.label_color));
+                }
+                // Body row: monospace value + copy button.
+                ui.horizontal(|ui| {
+                    let copy_budget = if self.copyable { 22.0 } else { 0.0 };
+                    let display =
+                        self.choose_display_with_budget(ui, ui.available_width() - copy_budget);
+                    ui.label(
+                        RichText::new(display)
+                            .monospace()
+                            .color(self.value_color),
+                    )
+                    .on_hover_text(self.value_full);
+                    if !self.copyable {
+                        return;
+                    }
+                    let clicked = if right_align_copy {
+                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                            ui.small_button(PhosphorIcon::Copy.rich_text(12.0, self.label_color))
+                                .on_hover_text("Copy to clipboard")
+                                .clicked()
+                        })
+                        .inner
+                    } else {
+                        ui.small_button(PhosphorIcon::Copy.rich_text(12.0, self.label_color))
+                            .on_hover_text("Copy to clipboard")
+                            .clicked()
+                    };
+                    if clicked {
+                        ui.ctx().copy_text(self.value_full.to_string());
+                        response.copied = true;
+                    }
+                });
+            });
+    }
+
+    /// Single-row compact shape — `label  value [Copy]`, no frame.
+    /// `label_min_width` / `value_min_width` reserve column widths for
+    /// alignment within a vertical stack of Inline pills.
+    fn show_inline(self, ui: &mut Ui) -> IdPillResponse {
         let mut response = IdPillResponse::default();
         ui.horizontal(|ui| {
             if let Some(label) = self.label {
-                ui.label(RichText::new(label).small().color(self.label_color));
+                let label_widget =
+                    egui::Label::new(RichText::new(label).small().color(self.label_color));
+                if let Some(w) = self.label_min_width {
+                    ui.add_sized([w, ui.spacing().interact_size.y], label_widget);
+                } else {
+                    ui.add(label_widget);
+                }
             }
             let short = self
                 .value_short
                 .unwrap_or_else(|| truncate_middle(self.value_full, self.widths.0, self.widths.1));
-            ui.label(
+            let value_widget = egui::Label::new(
                 RichText::new(short)
                     .monospace()
                     .small()
                     .color(self.value_color),
-            )
-            .on_hover_text(self.value_full);
+            );
+            let value_resp = if let Some(w) = self.value_min_width {
+                ui.add_sized([w, ui.spacing().interact_size.y], value_widget)
+            } else {
+                ui.add(value_widget)
+            };
+            value_resp.on_hover_text(self.value_full);
             if self.copyable {
                 install_phosphor_font(ui.ctx());
                 if ui
@@ -128,6 +318,57 @@ impl<'a> IdPill<'a> {
         });
         response
     }
+
+    /// Choose the value display string against a caller-supplied width
+    /// budget: host override, or the full value when it fits the budget,
+    /// or a middle-elision otherwise. Used by the Stacked layout (which
+    /// subtracts the trailing copy button width from `ui.available_width`
+    /// so the button still fits inline); Inline always truncates per
+    /// [`IdPill::with_widths`].
+    fn choose_display_with_budget(&self, ui: &Ui, budget: f32) -> String {
+        if let Some(short) = &self.value_short {
+            return short.clone();
+        }
+        let monospace = egui::FontId::new(
+            egui::TextStyle::Body.resolve(ui.style()).size,
+            egui::FontFamily::Monospace,
+        );
+        // `painter().layout_no_wrap` returns an `Arc<Galley>` and handles
+        // the `Fonts` lock internally — `ui.fonts(|f| f.layout_no_wrap(…))`
+        // doesn't compile because `layout_no_wrap` needs `&mut Fonts`
+        // while the closure receives `&Fonts`.
+        let galley =
+            ui.painter()
+                .layout_no_wrap(self.value_full.to_string(), monospace, Color32::WHITE);
+        let full_width = galley.rect.width();
+        if full_width <= budget {
+            self.value_full.to_string()
+        } else {
+            truncate_middle(self.value_full, self.widths.0, self.widths.1)
+        }
+    }
+}
+
+/// Measure the natural width (in px) a [`IdPillLayout::Stacked`] pill
+/// needs for the given monospace value at the current ui's
+/// `TextStyle::Body` size. Accounts for the 8+8 frame padding and (when
+/// `copyable`) the trailing copy button. Fold a max across a slice of
+/// values you intend to render in the same stack and pass the result
+/// to [`IdPill::min_width`] on each.
+pub fn stacked_width_for(ui: &Ui, value: &str, copyable: bool) -> f32 {
+    let monospace = egui::FontId::new(
+        egui::TextStyle::Body.resolve(ui.style()).size,
+        egui::FontFamily::Monospace,
+    );
+    let text_w = ui
+        .painter()
+        .layout_no_wrap(value.to_string(), monospace, Color32::WHITE)
+        .rect
+        .width();
+    // Mirrors `inner_margin(symmetric(8, 6))` + trailing-button budget.
+    let frame_pad = 16.0;
+    let copy_w = if copyable { 22.0 } else { 0.0 };
+    text_w + frame_pad + copy_w
 }
 
 /// Middle-elide a string at `prefix + ellipsis + suffix` width. Returns

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -2,8 +2,10 @@ pub use egui_inbox;
 
 pub mod animated_counter;
 pub mod asset_card;
+pub mod button_group;
 pub mod buttons;
 pub mod card_browser;
+pub mod chip;
 pub mod collection_list;
 pub mod donut_chart;
 #[cfg(target_arch = "wasm32")]
@@ -12,6 +14,7 @@ pub mod flip_counter;
 pub mod fungibles_row;
 pub mod grouped_section;
 pub mod icons;
+pub mod id_pill;
 pub mod image_loader;
 pub mod listing_grid;
 pub mod marquee;
@@ -19,9 +22,11 @@ pub mod metric_card;
 pub mod mnemonic_display;
 pub mod offer_tile;
 pub mod persona_strip;
+pub mod phase_card;
 pub mod pip_row;
 pub mod printing_timeline;
 pub mod progress_bar;
+pub mod property_list;
 pub mod radar_chart;
 pub mod range_bar;
 pub mod screenshot;
@@ -82,10 +87,12 @@ pub mod utxo_shelf;
 pub mod wallet_asset_picker;
 
 pub use animated_counter::AnimatedCounter;
+pub use button_group::{ButtonGroup, ButtonGroupButton, ButtonGroupResponse};
 pub use buttons::UiButtonExt;
 pub use card_browser::{
     CardBrowserConfig, CardBrowserResponse, CardBrowserState, CardRenderContext,
 };
+pub use chip::{Chip, ChipResponse, ChipVariant};
 pub use collection_list::{
     CollectionList, CollectionListAction, CollectionListLayout, CollectionListResponse,
     CollectionRow,
@@ -98,6 +105,7 @@ pub use file_upload::{FileUploadButton, UploadedFile};
 pub use flip_counter::FlipCounter;
 pub use fungibles_row::{FungiblesRow, FungiblesRowConfig};
 pub use icons::{install_phosphor_font, PhosphorIcon};
+pub use id_pill::{IdPill, IdPillResponse};
 pub use image_loader::{iiif_asset_url, AssetImageSize};
 #[cfg(feature = "image-editor")]
 pub use image_text_editor::{
@@ -107,10 +115,12 @@ pub use listing_grid::{ListingCard, ListingGrid, ListingGridConfig};
 pub use marquee::{Marquee, MarqueeConfig, MarqueeItem};
 pub use metric_card::{MetricCard, Trend};
 pub use persona_strip::{PersonaStrip, PersonaStripConfig};
+pub use phase_card::{GateChip, PhaseCard, PhaseCardAction, PhaseCardResponse, PhaseCardRow};
 pub use pip_row::{
     HoverInfo, HoveredBin, HoveredPip, Pip, PipRowConfig, PipRowData, PipRowResponse,
 };
 pub use progress_bar::ProgressBar;
+pub use property_list::{PropertyLabelAlign, PropertyList};
 pub use radar_chart::{RadarChartConfig, RadarPoint};
 pub use range_bar::{RangeBarConfig, RangePoint};
 pub use screenshot::ScreenshotButton;

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -34,6 +34,7 @@ pub mod seven_segment;
 pub mod sparkline;
 pub mod swap_modal;
 pub mod theme;
+pub mod toast;
 pub mod trait_filter;
 pub mod utils;
 #[cfg(all(target_arch = "wasm32", feature = "cardano"))]
@@ -105,7 +106,7 @@ pub use file_upload::{FileUploadButton, UploadedFile};
 pub use flip_counter::FlipCounter;
 pub use fungibles_row::{FungiblesRow, FungiblesRowConfig};
 pub use icons::{install_phosphor_font, PhosphorIcon};
-pub use id_pill::{IdPill, IdPillResponse};
+pub use id_pill::{stacked_width_for as id_pill_stacked_width_for, IdPill, IdPillLayout, IdPillResponse};
 pub use image_loader::{iiif_asset_url, AssetImageSize};
 #[cfg(feature = "image-editor")]
 pub use image_text_editor::{
@@ -131,6 +132,7 @@ pub use swap_modal::{
     SwapProgress,
 };
 pub use theme::{rarity_rank_color, FontStrategy};
+pub use toast::{show_toasts, Toast, ToastKind, ToastQueue, DEFAULT_DURATION_FRAMES};
 pub use trait_filter::{FilterEntry, TraitFilterConfig, TraitFilterResponse, TraitFilterState};
 pub use utils::{
     format_ada, format_duration, format_lovelace, format_number, format_percent, section_heading,

--- a/ui/egui-widgets/src/phase_card.rs
+++ b/ui/egui-widgets/src/phase_card.rs
@@ -1,0 +1,279 @@
+//! `PhaseCard` — read-only display of one mint phase row.
+//!
+//! Composes [`Chip`], [`PropertyList`], and gate chips into the visual
+//! unit operators land on in the portal's Configure window. Header
+//! shows the phase name + status + priority + Edit/Delete; body shows
+//! Price / Window / Per-wallet via `PropertyList`; gates strip lists the
+//! phase's gates as removable `Chip`s with an "+ Add gate" affordance.
+//!
+//! **Read-only by design.** The edit form is host-state-heavy (text
+//! buffers, validation, submit-on-Enter) and lives in the application
+//! beside the rest of its form state. The card surfaces an `Edit`
+//! action so the host can swap it for its form in the layout.
+//!
+//! The allowlist sub-section is intentionally *not* part of this widget
+//! — allowlist rows are a list, not a phase property, and they have
+//! their own forms. Host stacks them below the card.
+//!
+//! ## VM
+//!
+//! The host projects its `SalePhaseConfig` (and matching gate rows) into
+//! a [`PhaseCardRow`] + a `Vec<GateChip>`. Pre-formatted strings (price
+//! as ADA, window as ISO) live in the VM — the widget renders verbatim
+//! and never does formatting that needs i18n or wall-clock arithmetic.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! let row = PhaseCardRow {
+//!     phase_key: "public".into(),
+//!     name: "Public".into(),
+//!     price_display: "FREE".into(),
+//!     window_display: "unbounded → unbounded".into(),
+//!     per_wallet_display: "unlimited".into(),
+//!     active: true,
+//!     priority: 0,
+//! };
+//! let gates = vec![GateChip { gate_id: 1, label: "public".into() }];
+//! let resp = PhaseCard::new(&row, &gates).show(ui);
+//! for action in resp.actions {
+//!     match action {
+//!         PhaseCardAction::Edit => { … }
+//!         PhaseCardAction::Delete => { … }
+//!         PhaseCardAction::AddGate => { … }
+//!         PhaseCardAction::RemoveGate { gate_id } => { … }
+//!     }
+//! }
+//! ```
+
+use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
+
+use crate::chip::{Chip, ChipVariant};
+use crate::property_list::PropertyList;
+
+/// View-model for the header + properties section. The widget renders
+/// `*_display` strings verbatim — the host owns formatting.
+#[derive(Clone, Debug)]
+pub struct PhaseCardRow {
+    /// Immutable identifier from the data layer. Used for egui Id
+    /// salting + as the gate-list key.
+    pub phase_key: String,
+    pub name: String,
+    /// Pre-formatted price (e.g. `"FREE"`, `"50 ADA"`, `"3.5 ADA"`).
+    pub price_display: String,
+    /// Pre-formatted time window (e.g.
+    /// `"2026-05-30T09:00:00 → unbounded"`).
+    pub window_display: String,
+    /// Pre-formatted per-wallet cap (e.g. `"3"`, `"unlimited"`).
+    pub per_wallet_display: String,
+    /// Drives the status chip's variant (Success vs Muted).
+    pub active: bool,
+    /// `sort_order` from the data layer. Rendered as `priority N`.
+    pub priority: i32,
+}
+
+/// One gate as the widget renders it. The host pre-formats the chip
+/// label (e.g. `"token_held(8532f316…, min 3)"`) so the widget doesn't
+/// know about gate-type semantics.
+#[derive(Clone, Debug)]
+pub struct GateChip {
+    pub gate_id: i64,
+    pub label: String,
+}
+
+/// Builder.
+pub struct PhaseCard<'a> {
+    row: &'a PhaseCardRow,
+    gates: &'a [GateChip],
+    show_edit: bool,
+    show_delete: bool,
+    show_add_gate: bool,
+    show_gate_remove: bool,
+}
+
+/// Action emitted by an interaction inside the card.
+#[derive(Clone, Debug)]
+pub enum PhaseCardAction {
+    /// Edit button clicked. Host opens its phase-edit form.
+    Edit,
+    /// Delete button clicked AND already confirmed (the widget owns the
+    /// click-to-confirm flow via egui memory). Host runs the delete.
+    Delete,
+    /// `+ Add gate` clicked. Host opens its new-gate form.
+    AddGate,
+    /// `×` on a gate chip clicked. Host removes the gate row.
+    RemoveGate { gate_id: i64 },
+}
+
+/// Drained actions for this frame — empty on a pure-render pass.
+#[derive(Default, Debug)]
+pub struct PhaseCardResponse {
+    pub actions: Vec<PhaseCardAction>,
+}
+
+impl<'a> PhaseCard<'a> {
+    /// Construct a card. All affordances default to enabled — call
+    /// `with_*(false)` to suppress on a read-only audit view.
+    pub fn new(row: &'a PhaseCardRow, gates: &'a [GateChip]) -> Self {
+        Self {
+            row,
+            gates,
+            show_edit: true,
+            show_delete: true,
+            show_add_gate: true,
+            show_gate_remove: true,
+        }
+    }
+
+    /// Show or hide the Edit button.
+    pub fn with_edit(mut self, enabled: bool) -> Self {
+        self.show_edit = enabled;
+        self
+    }
+
+    /// Show or hide the Delete button.
+    pub fn with_delete(mut self, enabled: bool) -> Self {
+        self.show_delete = enabled;
+        self
+    }
+
+    /// Show or hide the `+ Add gate` button.
+    pub fn with_add_gate(mut self, enabled: bool) -> Self {
+        self.show_add_gate = enabled;
+        self
+    }
+
+    /// Show or hide the `×` remove affordance on individual gate chips.
+    pub fn with_gate_remove(mut self, enabled: bool) -> Self {
+        self.show_gate_remove = enabled;
+        self
+    }
+
+    /// Render the card.
+    pub fn show(self, ui: &mut Ui) -> PhaseCardResponse {
+        let mut response = PhaseCardResponse::default();
+        // Scope every child Id to this phase_key so the internal `Grid`
+        // (used by `PropertyList`) + the delete-confirm flag stay unique
+        // when multiple phase cards stack in one Ui. egui's id system is
+        // hierarchical — `push_id` salts every descendant.
+        let salt = ("phase_card", self.row.phase_key.clone());
+        ui.push_id(salt, |ui| {
+            self.show_inner(ui, &mut response);
+        });
+        response
+    }
+
+    fn show_inner(self, ui: &mut Ui, response: &mut PhaseCardResponse) {
+        Frame::new()
+            .fill(Color32::from_rgb(22, 24, 32))
+            .stroke(Stroke::new(1.0, Color32::from_rgb(40, 44, 60)))
+            .corner_radius(CornerRadius::same(6))
+            .inner_margin(Margin::same(10))
+            .show(ui, |ui| {
+                ui.set_width(ui.available_width());
+
+                // ── Header: name + status chip + priority + Edit/Delete ──
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new(&self.row.name).strong());
+                    let chip = if self.row.active {
+                        Chip::new("active").variant(ChipVariant::Success)
+                    } else {
+                        Chip::new("paused").variant(ChipVariant::Muted)
+                    };
+                    chip.show(ui);
+                    ui.label(
+                        RichText::new(format!("priority {}", self.row.priority))
+                            .small()
+                            .color(Color32::from_gray(140)),
+                    );
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if self.show_delete && delete_button(ui, &self.row.phase_key) {
+                            response.actions.push(PhaseCardAction::Delete);
+                        }
+                        if self.show_edit && ui.small_button("Edit").clicked() {
+                            response.actions.push(PhaseCardAction::Edit);
+                        }
+                    });
+                });
+
+                ui.add_space(4.0);
+
+                // ── Properties ──────────────────────────────────────
+                PropertyList::new()
+                    .id("phase_card_props")
+                    .add("Price", &self.row.price_display)
+                    .add("Window", &self.row.window_display)
+                    .add("Per wallet", &self.row.per_wallet_display)
+                    .show(ui);
+
+                ui.add_space(8.0);
+
+                // ── Gates strip ─────────────────────────────────────
+                ui.label(
+                    RichText::new("Gates")
+                        .small()
+                        .color(Color32::from_gray(150)),
+                );
+                ui.horizontal_wrapped(|ui| {
+                    ui.spacing_mut().item_spacing.x = 4.0;
+                    if self.gates.is_empty() {
+                        Chip::new("none — phase ineligible")
+                            .variant(ChipVariant::Danger)
+                            .show(ui);
+                    }
+                    for gate in self.gates {
+                        let chip_resp = Chip::new(&gate.label)
+                            .variant(ChipVariant::Tag)
+                            .removable(self.show_gate_remove)
+                            .show(ui);
+                        if chip_resp.removed {
+                            response.actions.push(PhaseCardAction::RemoveGate {
+                                gate_id: gate.gate_id,
+                            });
+                        }
+                    }
+                });
+
+                if self.show_add_gate {
+                    ui.add_space(2.0);
+                    if ui.small_button("+ Add gate").clicked() {
+                        response.actions.push(PhaseCardAction::AddGate);
+                    }
+                }
+            });
+    }
+}
+
+/// Click-to-confirm Delete button. Returns `true` when the click is the
+/// confirmation (second click). Confirmation state lives in egui memory
+/// keyed by `phase_key`, so multiple cards on the same screen don't
+/// share a flag.
+fn delete_button(ui: &mut Ui, phase_key: &str) -> bool {
+    let confirm_id = ui.id().with(("phase_card_delete_confirm", phase_key));
+    let confirming = ui
+        .ctx()
+        .data_mut(|d| d.get_temp::<bool>(confirm_id))
+        .unwrap_or(false);
+    let (label, colour) = if confirming {
+        ("Confirm delete", Color32::LIGHT_RED)
+    } else {
+        ("Delete", Color32::from_gray(180))
+    };
+    let clicked = ui
+        .small_button(RichText::new(label).small().color(colour))
+        .on_hover_text(if confirming {
+            "Click again to delete this phase + its gates + allowlist"
+        } else {
+            "Delete this phase"
+        })
+        .clicked();
+    if clicked {
+        if confirming {
+            ui.ctx().data_mut(|d| d.remove::<bool>(confirm_id));
+            return true;
+        } else {
+            ui.ctx().data_mut(|d| d.insert_temp(confirm_id, true));
+        }
+    }
+    false
+}

--- a/ui/egui-widgets/src/property_list.rs
+++ b/ui/egui-widgets/src/property_list.rs
@@ -1,0 +1,128 @@
+//! `PropertyList` — compact label/value grid for read-only key data.
+//!
+//! Renders one row per `(label, value)` pair with the labels in a small
+//! muted colour and the values in the default text colour. Labels are
+//! right-aligned (or left, configurable) and given a stable width so the
+//! values column stays visually aligned even with mixed label lengths.
+//!
+//! Used wherever a small descriptive list of "field: value" would
+//! otherwise be hand-built with `egui::Grid` (the wallet card's
+//! fuel/total/health rows, the phase card's price/window/per-wallet
+//! rows, an offer's amount/expires/policy rows, etc.).
+//!
+//! ## Example
+//!
+//! ```ignore
+//! PropertyList::new()
+//!     .add("Price", "FREE")
+//!     .add("Window", "unbounded → unbounded")
+//!     .add("Per wallet", "unlimited")
+//!     .show(ui);
+//! ```
+
+use egui::{Color32, Grid, RichText, Ui};
+
+/// Builder.
+pub struct PropertyList<'a> {
+    items: Vec<(&'a str, String)>,
+    label_color: Color32,
+    label_align: PropertyLabelAlign,
+    id: &'static str,
+}
+
+/// Horizontal alignment of the label column. Default = `Left`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyLabelAlign {
+    Left,
+    Right,
+}
+
+impl<'a> Default for PropertyList<'a> {
+    fn default() -> Self {
+        Self {
+            items: Vec::new(),
+            label_color: Color32::from_gray(150),
+            label_align: PropertyLabelAlign::Left,
+            id: "property_list",
+        }
+    }
+}
+
+impl<'a> PropertyList<'a> {
+    /// Construct an empty `PropertyList`. Default label colour is a
+    /// neutral grey suited to dark backgrounds.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one row.
+    pub fn add(mut self, label: &'a str, value: impl Into<String>) -> Self {
+        self.items.push((label, value.into()));
+        self
+    }
+
+    /// Append a row conditionally — useful for optional fields without
+    /// having to compose a Vec at the call site.
+    pub fn add_optional<S: Into<String>>(self, label: &'a str, value: Option<S>) -> Self {
+        match value {
+            Some(v) => self.add(label, v),
+            None => self,
+        }
+    }
+
+    /// Set the label colour (default: neutral grey).
+    pub fn label_color(mut self, c: Color32) -> Self {
+        self.label_color = c;
+        self
+    }
+
+    /// Right-align the labels. Default = left-aligned.
+    pub fn label_align(mut self, a: PropertyLabelAlign) -> Self {
+        self.label_align = a;
+        self
+    }
+
+    /// Override the egui Id salt used by the underlying `Grid`. Set when
+    /// multiple `PropertyList`s render in the same `Ui` to avoid grid
+    /// column-width collisions.
+    ///
+    /// For per-row uniqueness (e.g. one `PropertyList` per item in a
+    /// loop), prefer wrapping the call in `ui.push_id(unique_key, |ui|
+    /// PropertyList::new()…show(ui))` over passing a static string here
+    /// — egui's Id system is hierarchical and `push_id` salts every
+    /// descendant. `id()` is for distinguishing one-off `PropertyList`s
+    /// that happen to live in the same scope.
+    pub fn id(mut self, id: &'static str) -> Self {
+        self.id = id;
+        self
+    }
+
+    /// Render.
+    pub fn show(self, ui: &mut Ui) {
+        if self.items.is_empty() {
+            return;
+        }
+        Grid::new(self.id)
+            .num_columns(2)
+            .spacing([12.0, 4.0])
+            .show(ui, |ui| {
+                for (label, value) in &self.items {
+                    match self.label_align {
+                        PropertyLabelAlign::Left => {
+                            ui.label(RichText::new(*label).small().color(self.label_color));
+                        }
+                        PropertyLabelAlign::Right => {
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    ui.label(RichText::new(*label).small().color(self.label_color));
+                                },
+                            );
+                        }
+                    }
+                    ui.label(value);
+                    ui.end_row();
+                }
+            });
+    }
+}

--- a/ui/egui-widgets/src/toast.rs
+++ b/ui/egui-widgets/src/toast.rs
@@ -1,0 +1,360 @@
+//! `Toast` / `ToastQueue` — transient overlay messages with
+//! frame-countdown auto-dismiss. The recurring "Copied to clipboard"
+//! / "Refuel submitted" / "Save failed" affordance used everywhere a
+//! widget completes an action and the host wants a brief acknowledgement
+//! without committing to a status bar.
+//!
+//! ## Shape
+//!
+//! - [`ToastQueue`] is a host-owned controller. Put one on your app
+//!   state. Push messages onto it as actions resolve (`queue.success(…)`
+//!   / `queue.error(…)` / etc.). Call [`show_toasts`] once per paint
+//!   from the top of your central panel — it renders the active toasts
+//!   as a bottom-right overlay stack, ticks the countdown, and disposes
+//!   of expired entries.
+//! - [`Toast`] is one message: `kind` + `message` + optional Phosphor
+//!   icon override + frames-remaining lifetime. Default duration is
+//!   [`DEFAULT_DURATION_FRAMES`] (~3 s at 60 fps).
+//! - Auto-dismiss is **frame-counted**, not wall-clock — works the same
+//!   in native and wasm with no `js_sys` dependency. The renderer calls
+//!   `ctx.request_repaint()` so the countdown keeps turning even when
+//!   no input arrives.
+//!
+//! ## Why not auto-trigger from `IdPill::show`?
+//!
+//! Kept host-driven so the primitive stays composable: `IdPill` returns
+//! `response.copied`, the host decides whether/where to surface it. The
+//! common case is a one-liner:
+//!
+//! ```ignore
+//! if IdPill::new("policy", policy_id).show(ui).copied {
+//!     toasts.info("policy copied to clipboard");
+//! }
+//! ```
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use egui_widgets::{show_toasts, ToastQueue};
+//!
+//! struct App {
+//!     toasts: ToastQueue,
+//! }
+//!
+//! impl eframe::App for App {
+//!     fn update(&mut self, ctx: &egui::Context, _: &mut eframe::Frame) {
+//!         egui::CentralPanel::default().show(ctx, |ui| {
+//!             // … render panels …
+//!             if ui.button("Save").clicked() {
+//!                 self.toasts.success("Saved");
+//!             }
+//!         });
+//!         show_toasts(ctx, &mut self.toasts);
+//!     }
+//! }
+//! ```
+
+use std::collections::VecDeque;
+
+use egui::{
+    Align, Align2, Area, Color32, Context, CornerRadius, Frame, Id, Layout, Margin, Order,
+    RichText, Stroke, Ui,
+};
+
+use crate::icons::{install_phosphor_font, PhosphorIcon};
+
+/// ~3 seconds at 60 fps. Used as the default lifetime for toasts pushed
+/// through the convenience helpers on [`ToastQueue`].
+pub const DEFAULT_DURATION_FRAMES: u32 = 180;
+
+/// Severity tint + default icon for a [`Toast`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToastKind {
+    /// Green — completed/confirmed actions.
+    Success,
+    /// Red — failed actions, validation errors.
+    Error,
+    /// Amber — non-blocking caution.
+    Warning,
+    /// Blue — neutral confirmations (clipboard, save, etc.).
+    Info,
+}
+
+impl ToastKind {
+    /// `(fill, stroke, icon_tint, text_tint)` — kept aligned with the
+    /// crate's framed-block palette (Chip / IdPill / portal Refuel
+    /// toast) so toasts visually belong to the same UI family.
+    fn palette(self) -> (Color32, Color32, Color32, Color32) {
+        match self {
+            ToastKind::Success => (
+                Color32::from_rgb(24, 36, 28),
+                Color32::from_rgb(60, 100, 70),
+                Color32::from_rgb(180, 220, 180),
+                Color32::from_rgb(220, 235, 220),
+            ),
+            ToastKind::Error => (
+                Color32::from_rgb(40, 24, 24),
+                Color32::from_rgb(110, 60, 60),
+                Color32::from_rgb(230, 160, 160),
+                Color32::from_rgb(240, 210, 210),
+            ),
+            ToastKind::Warning => (
+                Color32::from_rgb(40, 34, 22),
+                Color32::from_rgb(120, 100, 50),
+                Color32::from_rgb(235, 210, 140),
+                Color32::from_rgb(240, 225, 190),
+            ),
+            ToastKind::Info => (
+                Color32::from_rgb(22, 28, 38),
+                Color32::from_rgb(60, 80, 110),
+                Color32::from_rgb(160, 190, 230),
+                Color32::from_rgb(210, 220, 240),
+            ),
+        }
+    }
+
+    /// Default Phosphor glyph used when [`Toast::icon`] isn't set. The
+    /// crate's `PhosphorIcon` enum has no dedicated "info" symbol — the
+    /// `Info` kind ships iconless and relies on the blue tint for
+    /// affordance.
+    fn default_icon(self) -> Option<PhosphorIcon> {
+        match self {
+            ToastKind::Success => Some(PhosphorIcon::CheckCircle),
+            ToastKind::Error => Some(PhosphorIcon::X),
+            ToastKind::Warning => Some(PhosphorIcon::Warning),
+            ToastKind::Info => None,
+        }
+    }
+}
+
+/// One toast message in the queue.
+pub struct Toast {
+    /// The body text rendered next to the icon.
+    pub message: String,
+    /// Severity — drives the palette and default icon.
+    pub kind: ToastKind,
+    /// Leading Phosphor glyph override. `None` falls back to
+    /// [`ToastKind::default_icon`]; pass [`Toast::no_icon`] to suppress
+    /// the icon explicitly.
+    pub icon: Option<Option<PhosphorIcon>>,
+    /// Frames remaining before auto-dismissal. Decremented once per
+    /// paint by [`show_toasts`]; the entry drops at 0.
+    pub frames_remaining: u32,
+}
+
+impl Toast {
+    /// Construct with the default icon (per `kind`) and the default
+    /// duration. Override either with the builders.
+    pub fn new(message: impl Into<String>, kind: ToastKind) -> Self {
+        Self {
+            message: message.into(),
+            kind,
+            icon: None,
+            frames_remaining: DEFAULT_DURATION_FRAMES,
+        }
+    }
+
+    /// Override the leading Phosphor glyph (e.g. `Copy` for a
+    /// clipboard ack rather than the default `CheckCircle`).
+    pub fn icon(mut self, icon: PhosphorIcon) -> Self {
+        self.icon = Some(Some(icon));
+        self
+    }
+
+    /// Suppress the leading icon entirely.
+    pub fn no_icon(mut self) -> Self {
+        self.icon = Some(None);
+        self
+    }
+
+    /// Override the auto-dismiss duration in frames (60 ≈ 1 s).
+    pub fn duration_frames(mut self, frames: u32) -> Self {
+        self.frames_remaining = frames;
+        self
+    }
+
+    fn resolved_icon(&self) -> Option<PhosphorIcon> {
+        self.icon.unwrap_or_else(|| self.kind.default_icon())
+    }
+}
+
+/// Host-owned toast controller. Place one on app state, push toasts as
+/// actions resolve, and call [`show_toasts`] once per paint to surface
+/// them.
+pub struct ToastQueue {
+    toasts: VecDeque<Toast>,
+    max_visible: usize,
+}
+
+impl Default for ToastQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ToastQueue {
+    /// Empty queue with a default cap of 5 simultaneously-visible
+    /// toasts. Older entries drop off the front when the cap is hit.
+    pub fn new() -> Self {
+        Self {
+            toasts: VecDeque::new(),
+            max_visible: 5,
+        }
+    }
+
+    /// Override the max-visible cap. Useful for dense dashboards where
+    /// you want a longer stack, or single-shot contexts where 1 is
+    /// enough.
+    pub fn with_max_visible(mut self, n: usize) -> Self {
+        self.max_visible = n.max(1);
+        self
+    }
+
+    /// Append a fully-built [`Toast`].
+    pub fn push(&mut self, toast: Toast) {
+        self.toasts.push_back(toast);
+        while self.toasts.len() > self.max_visible {
+            self.toasts.pop_front();
+        }
+    }
+
+    /// Push a green confirmation toast with the default duration +
+    /// `CheckCircle` icon.
+    pub fn success(&mut self, message: impl Into<String>) {
+        self.push(Toast::new(message, ToastKind::Success));
+    }
+
+    /// Push a red failure toast with the default duration + `X` icon.
+    pub fn error(&mut self, message: impl Into<String>) {
+        self.push(Toast::new(message, ToastKind::Error));
+    }
+
+    /// Push an amber caution toast with the default duration +
+    /// `Warning` icon.
+    pub fn warning(&mut self, message: impl Into<String>) {
+        self.push(Toast::new(message, ToastKind::Warning));
+    }
+
+    /// Push a blue neutral toast with the default duration, no icon.
+    pub fn info(&mut self, message: impl Into<String>) {
+        self.push(Toast::new(message, ToastKind::Info));
+    }
+
+    /// `true` when nothing is currently being displayed.
+    pub fn is_empty(&self) -> bool {
+        self.toasts.is_empty()
+    }
+
+    /// Number of live toasts in the queue.
+    pub fn len(&self) -> usize {
+        self.toasts.len()
+    }
+
+    /// Drop every live toast immediately (e.g. on a route change).
+    pub fn clear(&mut self) {
+        self.toasts.clear();
+    }
+}
+
+/// Render the queue's active toasts as a bottom-right overlay stack,
+/// tick the frame-countdown, and drop expired entries. Call exactly
+/// once per paint, **after** the central panel (so the overlay sits on
+/// top).
+///
+/// Drives `ctx.request_repaint()` while the queue is non-empty so the
+/// countdown keeps ticking without external input events.
+pub fn show_toasts(ctx: &Context, queue: &mut ToastQueue) {
+    // Reap expired entries before measuring.
+    queue.toasts.retain(|t| t.frames_remaining > 0);
+    if queue.toasts.is_empty() {
+        return;
+    }
+
+    // Some toast paths land before any other widget has installed the
+    // Phosphor font (e.g. an error toast from a boot-time fetch).
+    install_phosphor_font(ctx);
+
+    // Tick countdowns + keep the paint pump turning so the toast
+    // dismisses itself with no external input event.
+    for t in queue.toasts.iter_mut() {
+        t.frames_remaining = t.frames_remaining.saturating_sub(1);
+    }
+    ctx.request_repaint();
+
+    // Pin to the bottom-right of the *content* area (inside chrome) so
+    // the overlay doesn't drift off-viewport on platforms with custom
+    // window decorations.
+    let content_rect = ctx.content_rect();
+    let anchor = content_rect.right_bottom() + egui::vec2(-16.0, -16.0);
+
+    Area::new(Id::new("egui_widgets_toast_overlay"))
+        .order(Order::Foreground)
+        .fixed_pos(anchor)
+        .pivot(Align2::RIGHT_BOTTOM)
+        .interactable(false)
+        .show(ctx, |ui| {
+            ui.spacing_mut().item_spacing.y = 6.0;
+            // bottom_up so newer toasts surface at the bottom of the
+            // stack (closest to the user's cursor on a typical click)
+            // while older ones float upward and fade out of the way.
+            ui.with_layout(Layout::bottom_up(Align::Max), |ui| {
+                for toast in queue.toasts.iter() {
+                    render_one(ui, toast);
+                }
+            });
+        });
+}
+
+fn render_one(ui: &mut Ui, toast: &Toast) {
+    let (fill, stroke, icon_col, text_col) = toast.kind.palette();
+    Frame::new()
+        .fill(fill)
+        .stroke(Stroke::new(1.0, stroke))
+        .corner_radius(CornerRadius::same(6))
+        .inner_margin(Margin::symmetric(12, 8))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                if let Some(icon) = toast.resolved_icon() {
+                    ui.label(icon.rich_text(14.0, icon_col));
+                }
+                ui.label(RichText::new(&toast.message).color(text_col).small());
+            });
+        });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_caps_at_max_visible() {
+        let mut q = ToastQueue::new().with_max_visible(2);
+        q.info("a");
+        q.info("b");
+        q.info("c");
+        assert_eq!(q.len(), 2);
+        // Oldest dropped: queue now holds b, c.
+        assert_eq!(q.toasts.front().unwrap().message, "b");
+        assert_eq!(q.toasts.back().unwrap().message, "c");
+    }
+
+    #[test]
+    fn default_icons_match_kind() {
+        assert_eq!(ToastKind::Success.default_icon(), Some(PhosphorIcon::CheckCircle));
+        assert_eq!(ToastKind::Error.default_icon(), Some(PhosphorIcon::X));
+        assert_eq!(ToastKind::Warning.default_icon(), Some(PhosphorIcon::Warning));
+        assert_eq!(ToastKind::Info.default_icon(), None);
+    }
+
+    #[test]
+    fn icon_override_takes_precedence_over_default() {
+        let t = Toast::new("x", ToastKind::Success).icon(PhosphorIcon::Copy);
+        assert_eq!(t.resolved_icon(), Some(PhosphorIcon::Copy));
+    }
+
+    #[test]
+    fn no_icon_suppresses_default() {
+        let t = Toast::new("x", ToastKind::Success).no_icon();
+        assert_eq!(t.resolved_icon(), None);
+    }
+}


### PR DESCRIPTION
Three independently-useful workstreams packaged together on the same branch.

## 1. Maestro v1 alignment — field renames + dead fallback removal

The Maestro Cardano Blockchain Indexer API has drifted from what the workspace was modelling against (verified against the [authoritative spec](https://docs.gomaestro.org/cardano/blockchain-indexer-api/transactions/transaction-details)). Two crates needed updates.

### `indexers/maestro`

`TransactionDetails` is now narrowed to what current callers actually read, with the field names Maestro returns today:

```rust
pub struct TransactionDetails {
    pub tx_hash: String,
    pub block_height: u64,
    pub block_absolute_slot: u64,   // was `slot: u64`
    pub block_timestamp: u64,       // was `timestamp: DateTime<Utc>` (ISO-8601 → unix int)
    pub fee: u64,
    // dropped: size, metadata, scripts (unused by callers; `scripts` was renamed by Maestro
    // to scripts_executed/scripts_successful anyway)
}
```

`TransactionAsset.amount` got the same `wasm_safe_serde::u64_required` + `alias = "quantity"` treatment that `AssetAmount` has had since day one — Maestro's `NumOrString` schema can return amounts as JSON strings for high-supply tokens, and the bare `u64` was a silent deser failure waiting to happen.

The richer `CompleteTransactionDetails` (used by `tx-classifier`, the `transactions` feature) was already correct and unchanged.

### `pipeline/tx-classifier`

`get_tx_from_maestro` rewritten from a 124-LOC try/fallback shape into a 17-LOC single-call wrapper. The previous fallback referenced `get_transaction_utxos`, which **Maestro retired** — the endpoint now returns 404, so the fallback had been broken at runtime ever since (silently producing near-empty `RawTxData` with no inputs/outputs/mint). Doc comment captures the *why* so the next maintainer doesn't reintroduce it.

**Net**: `−123 LOC` of broken code, every caller now reaches the working `get_complete_transaction` path.

### Symptoms this fixes

`scan failed: status 502: scan failed: get_transaction <hash>: Deserialization("missing field 'slot' …")` — and the follow-on `get_transaction_utxos: Http(Custom("HTTP error 404: "))` once the deser was patched but the legacy `/utxos` call remained.

## 2. cardano-tx — inline refund output support

Additive build-side changes so consumers can fold pure-ADA refund outputs into mint txs (Mode A in the upcoming refund pipeline at https://github.com/[REDACTED]/cnft.dev-workers/blob/main/docs/design/MINT_REFUNDS.md).

### `builder/mint.rs`

New superset fn `build_cip25_mint_multi_with_change_and_refunds`:

```rust
pub fn build_cip25_mint_multi_with_change_and_refunds(
    deps: &TxDeps,
    policy: &MintingPolicy,
    mints: &[MintRecipientEntry],
    metadata: Option<&serde_json::Value>,
    inputs: Option<&[UtxoApi]>,
    extra_self_outputs: Option<&[u64]>,
    refund_outputs: &[(Address, u64)],  // ← new
) -> Result<(UnsignedTx, Option<ChangeOutput>), TxBuildError>
```

Existing `build_cip25_mint_multi_with_change` is now a thin shim delegating with `refund_outputs: &[]` — **no caller updates required**, existing signature preserved. Refund handling weaves through 5 touchpoints (totals, size estimate, sanity check, output emission, change index). Each refund output is sanity-checked against the pure-ADA min UTxO before signing, with a friendly error pointing callers at `minting_core::REFUND_OUTPUT_MIN_LOVELACE` / `classify_refund` as the upstream filter.

### `metadata/cip25.rs`

`build_cip25_auxiliary_data` now also emits **CIP-674** (label 674) when the input JSON carries a `"674"` key, alongside the existing `"721"` CIP-25 entry. Pure additive — existing callers without `"674"` see identical output. Used by the minting engine to tag refund outputs with `refund:<order_id>` for explorer visibility + worker idempotency.

### Tests

All 20 `cardano-tx` mint tests still pass — the existing `_with_change` path delegates through the new code path with empty refunds, exercising the refactor on every test.

## 3. egui-widgets primitives + Toast + storybook stories

New widget primitives + their storybook stories, plus a `WIDGETS.md` catalog so future UI work can find existing primitives before reinventing them.

**New widgets** (all with storybook stories):

| Widget | What |
|---|---|
| `Toast` + `ToastQueue` | Transient overlay messages with frame-countdown auto-dismiss. Severity-tinted (Success/Error/Warning/Info), Phosphor icon defaults, bottom-right stack, host-owned queue. Replaces the ad-hoc per-app refuel-toast pattern. |
| `Chip` | Filled-tag label with `Success`/`Warning`/`Danger`/`Tag`/`Info`/`Muted` variants + optional `×` remove. |
| `IdPill` | `label policy_id_truncated [Copy]` for the recurring hash-shaped-string display. Two layouts: stacked frame (default, framed with right-aligned copy button) + inline (single row). Owns middle-elision + clipboard. `min_width` + `id_pill_stacked_width_for` helper for normalized stacks. |
| `PropertyList` | Label/value grid via `.add(k,v)` / `.add_optional(k, opt)` — replaces hand-built `egui::Grid` of descriptive rows. |
| `ButtonGroup` | Row of related action buttons with optional Phosphor icons + tooltips + disabled state, `horizontal_wrapped` by default. Returns clicked button's `id` for host dispatch. |
| `PhaseCard` | Read-only mint phase: header (name + status + priority + Edit/Delete), Price/Window/Per-wallet via `PropertyList`, gate chips with × remove. |

**`CollectionList` refactor** — sweep of raw Unicode glyphs (per workspace style rule), button-bar moved below heading, ButtonGroup adoption for the operator actions, IdPill adoption for policy/wallet display.

**`WIDGETS.md` catalog** — every widget in the crate, grouped by use case, one-line "when to reach for it" hook. Linked from `CLAUDE.md` so it's the first thing future UI work consults.

## Verification

```bash
cargo clippy --workspace --all-features -- -D warnings    # clean
cargo test -p tx-classifier --all-features                # 2/2
cargo test -p cardano-tx --lib                            # 20/20 mint
cargo test -p egui-widgets --lib                          # all primitives
# Per-crate wasm32 checks done from consumer repos (cnft.dev-workers, mitos).
```

🤖 Generated with [Claude Code