### PR TITLE
macroquad-tui: scenes, renderer, half-block canvas, sprite atlases, sprite primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,8 @@ name = "macroquad-tui"
 version = "0.1.0"
 dependencies = [
  "macroquad",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -1140,6 +1140,121 @@ mod tests {
         );
     }
 
+    /// Golden: inline refund outputs land between the recipient mints
+    /// and the change, each carrying the exact requested lovelace to the
+    /// payer's address. Proves the on-chain shape `MINT_REFUNDS.md` Mode
+    /// A/C produce: `[mint…, refund…, change]`.
+    #[test]
+    fn test_refunds_place_outputs_before_change() {
+        let mints = vec![
+            MintRecipientEntry {
+                asset_name: "Foo001".to_string(),
+                quantity: 1,
+                recipient: test_recipient(1),
+            },
+            MintRecipientEntry {
+                asset_name: "Foo002".to_string(),
+                quantity: 1,
+                recipient: test_recipient(2),
+            },
+        ];
+        let refund_addr = test_recipient(9);
+        let refund_amount = 5_000_000u64;
+        let (unsigned, change) = build_cip25_mint_multi_with_change_and_refunds(
+            &deps_with(50_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None,
+            std::slice::from_ref(&(refund_addr.clone(), refund_amount)),
+        )
+        .expect("build with refund failed");
+
+        // 2 mints + 1 refund → change at index 3.
+        let change = change.expect("expected a change output");
+        assert_eq!(change.output_index, 3, "change follows 2 mints + 1 refund");
+        assert!(change.lovelace > 0);
+
+        let outputs = unsigned.staging.outputs.as_ref().expect("outputs present");
+        assert_eq!(outputs.len(), 4, "2 mints + 1 refund + 1 change");
+
+        // The refund output sits at index 2 (after the 2 recipient mints),
+        // pays exactly the requested lovelace, and is addressed to the payer.
+        let refund_out = &outputs[2];
+        assert_eq!(
+            refund_out.lovelace, refund_amount,
+            "refund pays the owed amount"
+        );
+        assert_eq!(
+            refund_out.address.to_bech32().unwrap(),
+            refund_addr.to_bech32().unwrap(),
+            "refund output addressed to the payer"
+        );
+        assert!(refund_out.assets.is_none(), "refund is a pure-ADA output");
+    }
+
+    /// Golden: multiple refunds (e.g. several short-filled orders in one
+    /// bin) each get their own output, all before the change. Change
+    /// index = mints + refunds.
+    #[test]
+    fn test_multiple_refund_outputs_each_emitted() {
+        let mints = vec![MintRecipientEntry {
+            asset_name: "Foo001".to_string(),
+            quantity: 1,
+            recipient: test_recipient(1),
+        }];
+        let refunds = [
+            (test_recipient(8), 4_000_000u64),
+            (test_recipient(9), 6_000_000u64),
+        ];
+        let (unsigned, change) = build_cip25_mint_multi_with_change_and_refunds(
+            &deps_with(50_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None,
+            &refunds,
+        )
+        .expect("build with refunds failed");
+
+        let change = change.expect("expected a change output");
+        assert_eq!(change.output_index, 3, "change follows 1 mint + 2 refunds");
+        let outputs = unsigned.staging.outputs.as_ref().expect("outputs present");
+        assert_eq!(outputs.len(), 4, "1 mint + 2 refunds + 1 change");
+        assert_eq!(outputs[1].lovelace, 4_000_000);
+        assert_eq!(outputs[2].lovelace, 6_000_000);
+    }
+
+    /// Golden: a sub-min-UTxO refund output is rejected at build time
+    /// (defence-in-depth — `classify_refund` already forfeits these, but
+    /// the builder must never emit an output the ledger would reject
+    /// after the fee is paid).
+    #[test]
+    fn test_refunds_reject_sub_min_utxo() {
+        let mints = vec![MintRecipientEntry {
+            asset_name: "Foo001".to_string(),
+            quantity: 1,
+            recipient: test_recipient(1),
+        }];
+        // 0.5 ADA is below the pure-ADA min UTxO under test params.
+        let refunds = [(test_recipient(9), 500_000u64)];
+        let result = build_cip25_mint_multi_with_change_and_refunds(
+            &deps_with(50_000_000),
+            &test_policy(),
+            &mints,
+            None,
+            None,
+            None,
+            &refunds,
+        );
+        assert!(
+            matches!(result, Err(TxBuildError::BuildFailed(_))),
+            "sub-min-UTxO refund must be rejected"
+        );
+    }
+
     #[test]
     fn test_build_cip25_mint_multi_explicit_inputs() {
         // deps carries no UTxOs — the explicit pool UTxO must be used instead.

--- a/cardano-tx/src/metadata/cip25.rs
+++ b/cardano-tx/src/metadata/cip25.rs
@@ -195,6 +195,43 @@ mod tests {
         assert!(matches!(err, MetadataError::MissingCip25Key));
     }
 
+    /// Golden: a `"674"` key alongside `"721"` emits the CIP-674 `msg`
+    /// label into the same auxiliary data — the inline-refund tag from
+    /// `MINT_REFUNDS.md`. Decode-free check: short text metadata encodes
+    /// the literal UTF-8 bytes, so the `refund:<id>` tags appear verbatim
+    /// in the CBOR when present and are absent otherwise.
+    #[test]
+    fn test_cip674_refund_msg_label_emitted_with_721() {
+        let with_674 = serde_json::json!({
+            "721": { "abc123": { "MyNFT": { "name": "My NFT" } } },
+            "674": { "msg": ["refund:ord1", "refund:ord2"] }
+        });
+        let without_674 = serde_json::json!({
+            "721": { "abc123": { "MyNFT": { "name": "My NFT" } } }
+        });
+
+        let bytes_with = build_cip25_auxiliary_data(&with_674).unwrap();
+        let bytes_without = build_cip25_auxiliary_data(&without_674).unwrap();
+
+        // The 674 label adds content beyond the 721 blob...
+        assert!(
+            bytes_with.len() > bytes_without.len(),
+            "674 label should enlarge the auxiliary data"
+        );
+        // ...and both refund tags are present verbatim in the CBOR.
+        let has = |hay: &[u8], needle: &[u8]| hay.windows(needle.len()).any(|w| w == needle);
+        assert!(has(&bytes_with, b"refund:ord1"), "first refund tag missing");
+        assert!(
+            has(&bytes_with, b"refund:ord2"),
+            "second refund tag missing"
+        );
+        // Absent when no 674 key is supplied.
+        assert!(
+            !has(&bytes_without, b"refund:ord1"),
+            "no 674 key → no refund tag in metadata"
+        );
+    }
+
     #[test]
     fn test_json_to_metadatum_string() {
         let val = serde_json::Value::String("hello".to_string());

--- a/ui/macroquad-tui/Cargo.toml
+++ b/ui/macroquad-tui/Cargo.toml
@@ -12,3 +12,9 @@ path = "src/lib.rs"
 
 [dependencies]
 macroquad = "0.4"
+
+# `sprite_atlas` parses an index JSON describing per-key shard / col /
+# row coords. Tiny use of serde; same versions the rest of the
+# workspace pulls in.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/ui/macroquad-tui/src/grid.rs
+++ b/ui/macroquad-tui/src/grid.rs
@@ -26,7 +26,7 @@ use macroquad::prelude::*;
 /// per-cell attributes (bold / dim / blink / inverse). Background
 /// defaults to fully transparent so existing terminal-style renderers
 /// that ignore `bg` continue to work unchanged.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Cell {
     pub ch: char,
     pub fg: Color,

--- a/ui/macroquad-tui/src/grid.rs
+++ b/ui/macroquad-tui/src/grid.rs
@@ -22,15 +22,69 @@ use std::collections::VecDeque;
 
 use macroquad::prelude::*;
 
+/// One character cell — foreground colour, optional background, and
+/// per-cell attributes (bold / dim / blink / inverse). Background
+/// defaults to fully transparent so existing terminal-style renderers
+/// that ignore `bg` continue to work unchanged.
 #[derive(Clone, Copy)]
 pub struct Cell {
     pub ch: char,
     pub fg: Color,
+    pub bg: Color,
+    pub attrs: CellAttrs,
 }
 
 impl Cell {
+    /// A blank cell with the given foreground, transparent background,
+    /// no attributes. The cell still gets a foreground colour so a
+    /// terminal-style renderer that draws over the blank ` ` (e.g.
+    /// inverse-video cursor) has something sensible to invert against.
     pub const fn blank(fg: Color) -> Self {
-        Self { ch: ' ', fg }
+        Self {
+            ch: ' ',
+            fg,
+            bg: TRANSPARENT,
+            attrs: CellAttrs::PLAIN,
+        }
+    }
+
+    /// `bg` set; otherwise like [`blank`].
+    pub const fn blank_with_bg(fg: Color, bg: Color) -> Self {
+        Self {
+            ch: ' ',
+            fg,
+            bg,
+            attrs: CellAttrs::PLAIN,
+        }
+    }
+}
+
+const TRANSPARENT: Color = Color::new(0.0, 0.0, 0.0, 0.0);
+
+/// Per-cell attribute bitset. `PLAIN` is no attributes; the others can
+/// be combined with `|`. Interpretation is up to the renderer: an
+/// EGA-faithful renderer might draw `BLINK` as actual blinking; a
+/// quieter renderer might just draw `BLINK` as `BOLD`. `INVERSE`
+/// conventionally swaps `fg` and `bg`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct CellAttrs(pub u8);
+
+impl CellAttrs {
+    pub const PLAIN: Self = Self(0);
+    pub const BOLD: Self = Self(1 << 0);
+    pub const DIM: Self = Self(1 << 1);
+    pub const BLINK: Self = Self(1 << 2);
+    pub const INVERSE: Self = Self(1 << 3);
+
+    pub const fn contains(self, flag: Self) -> bool {
+        (self.0 & flag.0) != 0
+    }
+}
+
+impl std::ops::BitOr for CellAttrs {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
     }
 }
 
@@ -169,7 +223,12 @@ impl Grid {
         if self.cursor_col < cols {
             let fg = self.default_fg;
             let col = self.cursor_col;
-            self.lines.back_mut().unwrap()[col] = Cell { ch, fg };
+            self.lines.back_mut().unwrap()[col] = Cell {
+                ch,
+                fg,
+                bg: TRANSPARENT,
+                attrs: CellAttrs::PLAIN,
+            };
         }
         self.cursor_col += 1;
         if self.cursor_col >= cols {

--- a/ui/macroquad-tui/src/grid.rs
+++ b/ui/macroquad-tui/src/grid.rs
@@ -256,6 +256,33 @@ impl Grid {
         self.viewport_offset = 0;
     }
 
+    /// Write a cell at an absolute viewport position, bypassing the
+    /// cursor. Used by screen-buffer games (Snake, Tetris) that repaint
+    /// the whole grid each frame.
+    ///
+    /// The buffer is padded with blank lines up to `self.rows` if it
+    /// hasn't filled yet, so callers can write to any row/col without
+    /// caring about initial state. Out-of-bounds writes are silently
+    /// dropped (cheaper than panicking; game logic shouldn't be
+    /// writing out of bounds anyway).
+    ///
+    /// Position is always relative to the bottom-aligned viewport
+    /// (offset 0). Games typically `scroll_to_bottom()` before drawing.
+    pub fn put_at(&mut self, row: usize, col: usize, cell: Cell) {
+        if row >= self.rows || col >= self.cols {
+            return;
+        }
+        while self.lines.len() < self.rows {
+            self.lines
+                .push_back(vec![Cell::blank(self.default_fg); self.cols]);
+        }
+        let total = self.lines.len();
+        let buffer_row = total.saturating_sub(self.rows) + row;
+        if buffer_row < total {
+            self.lines[buffer_row][col] = cell;
+        }
+    }
+
     /// Iterate visible cells as `(visual_row, col, &Cell)`. `visual_row`
     /// is the row within the viewport (0 = top); the renderer maps it
     /// to a pixel y-coordinate. When the buffer hasn't filled, the
@@ -428,6 +455,53 @@ mod tests {
         let r = collect_chars(&g);
         // After clear the only line is an empty one.
         assert!(r.iter().all(|line| line.is_empty()));
+    }
+
+    #[test]
+    fn put_at_writes_to_visible_position() {
+        let mut g = fresh(10, 5);
+        g.put_at(2, 3, Cell { ch: '@', fg: PHOSPHOR, bg: super::TRANSPARENT, attrs: CellAttrs::PLAIN });
+        let rows = collect_chars(&g);
+        // Buffer was 1 line; put_at padded to 5; visible row 2 is buffer row 2.
+        assert_eq!(rows.len(), 5);
+        assert_eq!(rows[2], "   @");
+    }
+
+    #[test]
+    fn put_at_pads_buffer_to_rows() {
+        let mut g = fresh(10, 5);
+        // Before: 1 line. put_at(4, 0) should pad to 5 lines.
+        g.put_at(4, 0, Cell { ch: 'x', fg: PHOSPHOR, bg: super::TRANSPARENT, attrs: CellAttrs::PLAIN });
+        assert_eq!(g.lines.len(), 5);
+        let rows = collect_chars(&g);
+        assert_eq!(rows[4], "x");
+    }
+
+    #[test]
+    fn put_at_drops_out_of_bounds() {
+        let mut g = fresh(10, 5);
+        g.put_at(99, 0, Cell::blank(PHOSPHOR));
+        g.put_at(0, 99, Cell::blank(PHOSPHOR));
+        // No panic; buffer stays at one initial line (since put_at
+        // returned before padding).
+        assert_eq!(g.lines.len(), 1);
+    }
+
+    #[test]
+    fn put_at_after_scroll_writes_to_current_bottom_aligned_position() {
+        // Write 10 rows then scroll up; put_at still targets the
+        // *bottom-aligned* viewport, not the scrolled-into-view rows.
+        let mut g = fresh(10, 5);
+        for i in 0..10 {
+            g.write_str(&format!("L{i}"));
+            g.newline();
+        }
+        g.scroll_up(2);
+        g.put_at(4, 0, Cell { ch: '!', fg: PHOSPHOR, bg: super::TRANSPARENT, attrs: CellAttrs::PLAIN });
+        g.scroll_to_bottom();
+        let rows = collect_chars(&g);
+        // Bottom-aligned viewport: row 4 is the latest line (post-newline blank).
+        assert_eq!(rows[4], "!");
     }
 
     #[test]

--- a/ui/macroquad-tui/src/grid.rs
+++ b/ui/macroquad-tui/src/grid.rs
@@ -243,6 +243,25 @@ impl Grid {
         }
     }
 
+    /// Write a pre-styled [`Cell`] at the cursor and advance — same
+    /// flow as [`Self::write_char`], but the cell keeps its own
+    /// `fg`/`bg`/`attrs` instead of taking the grid's default fg.
+    /// Used by the typer's coloured-cell op so the typewriter can
+    /// emit fully styled rows (e.g. half-block sketch art) inline
+    /// with the surrounding ASCII output.
+    pub fn write_cell(&mut self, cell: Cell) {
+        let cols = self.cols;
+        if self.cursor_col < cols {
+            let col = self.cursor_col;
+            self.lines.back_mut().unwrap()[col] = cell;
+        }
+        self.cursor_col += 1;
+        if self.cursor_col >= cols {
+            self.newline();
+        }
+        self.viewport_offset = 0;
+    }
+
     /// Move the cursor onto a fresh row. The previous row stays in
     /// the buffer (potentially exiting the visible viewport).
     pub fn newline(&mut self) {

--- a/ui/macroquad-tui/src/half_block.rs
+++ b/ui/macroquad-tui/src/half_block.rs
@@ -1,0 +1,290 @@
+//! Half-block canvas — 2× vertical "pixel" resolution by splitting
+//! each character cell into a top + bottom half via the Unicode
+//! block-drawing characters.
+//!
+//! Each `Cell` in a [`crate::Grid`] is normally one foreground colour.
+//! By choosing the glyph carefully we can independently colour the
+//! top and bottom halves of a single character cell:
+//!
+//! | Top half | Bottom half | Glyph | `fg` | `bg` |
+//! |---|---|---|---|---|
+//! | transparent | transparent | ` ` | — | — |
+//! | colour A | transparent | `▀` | A | — |
+//! | transparent | colour B | `▄` | B | — |
+//! | colour A | colour B (A ≠ B) | `▀` | A | B |
+//! | colour A | colour A | `█` | A | — |
+//!
+//! `▀ ▄ █` are CP437 charset members — they render correctly in
+//! JetBrains Mono, DOS bitmap fonts, every standard terminal font.
+//! The fg/bg pair is what our Tier-3 renderer (`paint_cell`) already
+//! draws, so the composite "looks right" without any rendering
+//! changes.
+//!
+//! ## Use case
+//!
+//! Build a [`HalfBlockCanvas`] at some pixel-ish size (e.g. 40 cols
+//! × 30 char-rows = effective 40×60 subpixels), set individual
+//! "pixels" by colour, then `write_to_grid` to composite the result
+//! into a [`crate::Grid`] at a chosen offset. The grid then renders
+//! normally via [`crate::paint_grid`].
+//!
+//! Suitable for:
+//! - Smooth-edged game sprites (Snake bodies, Tetris ghost piece)
+//! - Persona portraits from existing AI sketch images
+//! - Geographic maps with half-cell precision
+//! - Animated logo / boot sequences
+//!
+//! ## Coordinate convention
+//!
+//! `x` is char columns (so the canvas's pixel-x is char-x).
+//! `y` is *subrows* — twice the resolution of grid rows. Subrow 0 is
+//! the top half of char-row 0; subrow 1 is the bottom half; subrow 2
+//! is the top half of char-row 1; etc. A canvas with `height = 30`
+//! char-rows is `60` subrows tall.
+
+use macroquad::prelude::Color;
+
+use crate::grid::{Cell, CellAttrs, Grid};
+
+const TRANSPARENT: Color = Color::new(0.0, 0.0, 0.0, 0.0);
+const ALPHA_THRESHOLD: f32 = 0.05;
+
+/// 2× vertical resolution pixel canvas. Backed by a row-major
+/// `Vec<Color>` of `width × (height * 2)` entries.
+pub struct HalfBlockCanvas {
+    width: usize,
+    /// Char-row count. The pixel grid is `width × (height * 2)`.
+    height_chars: usize,
+    pixels: Vec<Color>,
+}
+
+impl HalfBlockCanvas {
+    /// Construct a canvas of the given dimensions, initially fully
+    /// transparent. `height_chars` is the number of character rows
+    /// the canvas occupies — there are `height_chars * 2` subrows.
+    pub fn new(width: usize, height_chars: usize) -> Self {
+        Self {
+            width,
+            height_chars,
+            pixels: vec![TRANSPARENT; width * height_chars * 2],
+        }
+    }
+
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Number of *subrows* — twice the number of character rows.
+    pub fn height_subrows(&self) -> usize {
+        self.height_chars * 2
+    }
+
+    pub fn height_chars(&self) -> usize {
+        self.height_chars
+    }
+
+    /// Fill every pixel with `color`. `Color::new(0, 0, 0, 0)` clears
+    /// to transparent (the default state after `new`).
+    pub fn clear(&mut self, color: Color) {
+        for p in &mut self.pixels {
+            *p = color;
+        }
+    }
+
+    /// Set one subpixel. Out-of-bounds writes are silently dropped.
+    pub fn set(&mut self, x: usize, sub_y: usize, color: Color) {
+        if x >= self.width || sub_y >= self.height_chars * 2 {
+            return;
+        }
+        self.pixels[sub_y * self.width + x] = color;
+    }
+
+    /// Read one subpixel. Out-of-bounds reads return transparent.
+    pub fn get(&self, x: usize, sub_y: usize) -> Color {
+        if x >= self.width || sub_y >= self.height_chars * 2 {
+            return TRANSPARENT;
+        }
+        self.pixels[sub_y * self.width + x]
+    }
+
+    /// Fill a rectangle of subpixels. `w` and `h` are pixel widths /
+    /// heights (h in subrows). Clipped to canvas bounds.
+    pub fn fill_rect(&mut self, x: usize, y: usize, w: usize, h: usize, color: Color) {
+        let max_x = (x + w).min(self.width);
+        let max_y = (y + h).min(self.height_chars * 2);
+        for sub_y in y..max_y {
+            for px in x..max_x {
+                self.pixels[sub_y * self.width + px] = color;
+            }
+        }
+    }
+
+    /// Composite into a [`Grid`] starting at `(top_row, left_col)`.
+    /// Each pair of subrows becomes one character cell. Cells where
+    /// both halves are transparent are left untouched (so multiple
+    /// canvases can be layered).
+    pub fn write_to_grid(&self, grid: &mut Grid, top_row: usize, left_col: usize) {
+        for char_row in 0..self.height_chars {
+            for x in 0..self.width {
+                let top = self.pixels[(char_row * 2) * self.width + x];
+                let bot = self.pixels[(char_row * 2 + 1) * self.width + x];
+                if let Some((ch, fg, bg)) = encode_pair(top, bot) {
+                    grid.put_at(
+                        top_row + char_row,
+                        left_col + x,
+                        Cell {
+                            ch,
+                            fg,
+                            bg,
+                            attrs: CellAttrs::PLAIN,
+                        },
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Decide which glyph + (fg, bg) renders a `(top, bottom)` subpixel
+/// pair. Returns `None` when both halves are transparent — callers
+/// can use that to skip writes and preserve underlying content.
+pub fn encode_pair(top: Color, bot: Color) -> Option<(char, Color, Color)> {
+    let top_visible = top.a > ALPHA_THRESHOLD;
+    let bot_visible = bot.a > ALPHA_THRESHOLD;
+
+    match (top_visible, bot_visible) {
+        (false, false) => None,
+        (true, true) => {
+            if colors_match(top, bot) {
+                Some(('█', top, TRANSPARENT))
+            } else {
+                Some(('▀', top, bot))
+            }
+        }
+        (true, false) => Some(('▀', top, TRANSPARENT)),
+        (false, true) => Some(('▄', bot, TRANSPARENT)),
+    }
+}
+
+fn colors_match(a: Color, b: Color) -> bool {
+    (a.r - b.r).abs() < 1.0 / 255.0
+        && (a.g - b.g).abs() < 1.0 / 255.0
+        && (a.b - b.b).abs() < 1.0 / 255.0
+        && (a.a - b.a).abs() < 1.0 / 255.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RED: Color = Color::new(1.0, 0.0, 0.0, 1.0);
+    const BLUE: Color = Color::new(0.0, 0.0, 1.0, 1.0);
+    const GREEN: Color = Color::new(0.0, 1.0, 0.0, 1.0);
+
+    #[test]
+    fn both_transparent_skips() {
+        assert!(encode_pair(TRANSPARENT, TRANSPARENT).is_none());
+    }
+
+    #[test]
+    fn top_only_uses_upper_half_block() {
+        let (ch, fg, bg) = encode_pair(RED, TRANSPARENT).unwrap();
+        assert_eq!(ch, '▀');
+        assert_eq!(fg.r, RED.r);
+        assert_eq!(bg.a, 0.0);
+    }
+
+    #[test]
+    fn bottom_only_uses_lower_half_block() {
+        let (ch, fg, bg) = encode_pair(TRANSPARENT, BLUE).unwrap();
+        assert_eq!(ch, '▄');
+        assert_eq!(fg.b, BLUE.b);
+        assert_eq!(bg.a, 0.0);
+    }
+
+    #[test]
+    fn matching_colors_use_full_block() {
+        let (ch, fg, _bg) = encode_pair(GREEN, GREEN).unwrap();
+        assert_eq!(ch, '█');
+        assert_eq!(fg.g, GREEN.g);
+    }
+
+    #[test]
+    fn different_colors_split_via_upper_half() {
+        let (ch, fg, bg) = encode_pair(RED, BLUE).unwrap();
+        assert_eq!(ch, '▀');
+        assert_eq!(fg.r, RED.r);
+        assert_eq!(bg.b, BLUE.b);
+    }
+
+    #[test]
+    fn set_get_round_trip() {
+        let mut c = HalfBlockCanvas::new(10, 5);
+        c.set(3, 7, RED);
+        assert_eq!(c.get(3, 7).r, 1.0);
+        assert_eq!(c.get(0, 0).a, 0.0);
+    }
+
+    #[test]
+    fn out_of_bounds_set_does_nothing() {
+        let mut c = HalfBlockCanvas::new(10, 5);
+        c.set(99, 99, RED); // should not panic
+        c.set(0, 99, RED);
+        c.set(99, 0, RED);
+    }
+
+    #[test]
+    fn fill_rect_clips_to_bounds() {
+        let mut c = HalfBlockCanvas::new(10, 5);
+        c.fill_rect(8, 8, 100, 100, RED); // clips
+        assert_eq!(c.get(8, 8).r, 1.0);
+        assert_eq!(c.get(9, 9).r, 1.0);
+    }
+
+    #[test]
+    fn write_to_grid_renders_full_block_for_same_color_pair() {
+        let mut canvas = HalfBlockCanvas::new(3, 2);
+        canvas.fill_rect(0, 0, 3, 2, RED);
+        let mut grid = Grid::new(10, 5, RED);
+        canvas.write_to_grid(&mut grid, 0, 0);
+        // Top char-row's pair is (RED, RED) → '█'.
+        let cells: Vec<_> = grid.cells().collect();
+        let row0_first_cell = cells.iter().find(|(r, c, _)| *r == 0 && *c == 0).unwrap();
+        assert_eq!(row0_first_cell.2.ch, '█');
+    }
+
+    #[test]
+    fn write_to_grid_renders_upper_half_for_different_colors() {
+        let mut canvas = HalfBlockCanvas::new(1, 1);
+        canvas.set(0, 0, RED);
+        canvas.set(0, 1, BLUE);
+        let mut grid = Grid::new(5, 5, RED);
+        canvas.write_to_grid(&mut grid, 0, 0);
+        let cells: Vec<_> = grid.cells().collect();
+        let cell = cells.iter().find(|(r, c, _)| *r == 0 && *c == 0).unwrap();
+        assert_eq!(cell.2.ch, '▀');
+        assert_eq!(cell.2.fg.r, RED.r);
+        assert_eq!(cell.2.bg.b, BLUE.b);
+    }
+
+    #[test]
+    fn write_to_grid_skips_transparent_pair() {
+        let canvas = HalfBlockCanvas::new(2, 2); // all transparent
+        let mut grid = Grid::new(5, 5, RED);
+        // Pre-populate the grid with a sentinel so we can verify it's
+        // left untouched where the canvas is fully transparent.
+        grid.put_at(0, 0, Cell { ch: 'X', fg: RED, bg: TRANSPARENT, attrs: CellAttrs::PLAIN });
+        canvas.write_to_grid(&mut grid, 0, 0);
+        let cells: Vec<_> = grid.cells().collect();
+        let cell = cells.iter().find(|(r, c, _)| *r == 0 && *c == 0).unwrap();
+        assert_eq!(cell.2.ch, 'X', "transparent pair should preserve underlying cell");
+    }
+
+    #[test]
+    fn dimensions_match_construction() {
+        let c = HalfBlockCanvas::new(40, 30);
+        assert_eq!(c.width(), 40);
+        assert_eq!(c.height_chars(), 30);
+        assert_eq!(c.height_subrows(), 60);
+    }
+}

--- a/ui/macroquad-tui/src/lib.rs
+++ b/ui/macroquad-tui/src/lib.rs
@@ -30,6 +30,7 @@ pub mod palette;
 pub mod render;
 pub mod repeat;
 pub mod scene;
+pub mod sprite_atlas;
 pub mod typer;
 
 pub use editor::{CompletionSource, LineEditor};
@@ -38,4 +39,5 @@ pub use half_block::{encode_pair, HalfBlockCanvas};
 pub use render::{paint_cell, paint_grid, GridMetrics};
 pub use repeat::KeyRepeat;
 pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};
+pub use sprite_atlas::{AtlasSlot, ShardedAtlas};
 pub use typer::TypeQueue;

--- a/ui/macroquad-tui/src/lib.rs
+++ b/ui/macroquad-tui/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod editor;
 pub mod grid;
+pub mod half_block;
 pub mod palette;
 pub mod render;
 pub mod repeat;
@@ -33,6 +34,7 @@ pub mod typer;
 
 pub use editor::{CompletionSource, LineEditor};
 pub use grid::{Cell, CellAttrs, Grid};
+pub use half_block::{encode_pair, HalfBlockCanvas};
 pub use render::{paint_cell, paint_grid, GridMetrics};
 pub use repeat::KeyRepeat;
 pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};

--- a/ui/macroquad-tui/src/lib.rs
+++ b/ui/macroquad-tui/src/lib.rs
@@ -1,26 +1,37 @@
-//! macroquad-tui — text-grid primitives for building terminal-style UIs on
-//! top of macroquad.
+//! macroquad-tui — text-grid primitives for building terminal-style
+//! and arcade-style UIs on top of macroquad.
 //!
-//! Born from `uap-terminal`. Kept as a workspace-local crate so the API
-//! can evolve alongside its first real consumer; when a second one
-//! arrives (or this stabilises) it can be lifted to a shared location
-//! without restructuring callers.
+//! Born from `uap-terminal`. Designed for general reuse across any
+//! macroquad app that wants a character-grid frontend; the scene
+//! abstraction makes it easy to launch arcade-style games on top of
+//! a terminal session.
 //!
 //! Layers:
 //!
-//! - [`Grid`] — fixed character buffer with cursor + scroll
+//! - [`Grid`] — character buffer with cursor + scrollback viewport
+//! - [`Cell`] — per-cell `(ch, fg, bg, attrs)`; attributes cover bold /
+//!   dim / blink / inverse
+//! - [`palette`] — canonical 16-colour EGA palette for game-style
+//!   rendering
 //! - [`LineEditor`] — single-line editor with history, tab completion
 //! - [`TypeQueue`] — typewriter print at configurable rate with
 //!   mid-stream speed changes
-//! - [`KeyRepeat`] — initial-delay + repeat-rate for held keys (macroquad
-//!   doesn't expose key-repeat natively, so consumers wire this in)
+//! - [`KeyRepeat`] — initial-delay + repeat-rate for held keys
+//!   (macroquad doesn't expose key-repeat natively, so consumers wire
+//!   this in)
+//! - [`scene`] — stackable [`Scene`] trait + [`SceneStack`] for
+//!   launching games / overlays on top of a base scene; fixed-step
+//!   logic via [`FixedStep`]
 
 pub mod editor;
 pub mod grid;
+pub mod palette;
 pub mod repeat;
+pub mod scene;
 pub mod typer;
 
 pub use editor::{CompletionSource, LineEditor};
-pub use grid::{Cell, Grid};
+pub use grid::{Cell, CellAttrs, Grid};
 pub use repeat::KeyRepeat;
+pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};
 pub use typer::TypeQueue;

--- a/ui/macroquad-tui/src/lib.rs
+++ b/ui/macroquad-tui/src/lib.rs
@@ -26,12 +26,14 @@
 pub mod editor;
 pub mod grid;
 pub mod palette;
+pub mod render;
 pub mod repeat;
 pub mod scene;
 pub mod typer;
 
 pub use editor::{CompletionSource, LineEditor};
 pub use grid::{Cell, CellAttrs, Grid};
+pub use render::{paint_cell, paint_grid, GridMetrics};
 pub use repeat::KeyRepeat;
 pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};
 pub use typer::TypeQueue;

--- a/ui/macroquad-tui/src/lib.rs
+++ b/ui/macroquad-tui/src/lib.rs
@@ -30,6 +30,7 @@ pub mod palette;
 pub mod render;
 pub mod repeat;
 pub mod scene;
+pub mod sprite;
 pub mod sprite_atlas;
 pub mod typer;
 
@@ -39,5 +40,6 @@ pub use half_block::{encode_pair, HalfBlockCanvas};
 pub use render::{paint_cell, paint_grid, GridMetrics};
 pub use repeat::KeyRepeat;
 pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};
+pub use sprite::{CellSprite, SpriteSheet};
 pub use sprite_atlas::{AtlasSlot, ShardedAtlas};
 pub use typer::TypeQueue;

--- a/ui/macroquad-tui/src/palette.rs
+++ b/ui/macroquad-tui/src/palette.rs
@@ -1,0 +1,57 @@
+//! Canonical 16-colour EGA palette.
+//!
+//! Used by games / scenes for visual consistency across the suite.
+//! Pure constants — no logic. Terminal applications that want a
+//! different palette (e.g. CRT phosphor green) can ignore these and
+//! supply their own colours per cell.
+//!
+//! The RGB values are the *digital* EGA palette — what the card
+//! actually outputs at the connector — rather than the perceptual
+//! values an NTSC TV would render. The dark colours sit at `0.667`
+//! (the IBM `intensity bit unset` level) and the bright ones at `1.0`.
+//! Black is true black and white is true white.
+//!
+//! Colour names follow the original IBM PC convention; `BROWN` is
+//! famously the "dark yellow" slot, which on real EGA hardware was
+//! gamma-shifted to read as brown rather than mustard.
+
+use macroquad::prelude::Color;
+
+pub const BLACK: Color = Color::new(0.000, 0.000, 0.000, 1.0);
+pub const BLUE: Color = Color::new(0.000, 0.000, 0.667, 1.0);
+pub const GREEN: Color = Color::new(0.000, 0.667, 0.000, 1.0);
+pub const CYAN: Color = Color::new(0.000, 0.667, 0.667, 1.0);
+pub const RED: Color = Color::new(0.667, 0.000, 0.000, 1.0);
+pub const MAGENTA: Color = Color::new(0.667, 0.000, 0.667, 1.0);
+pub const BROWN: Color = Color::new(0.667, 0.333, 0.000, 1.0);
+pub const LIGHT_GRAY: Color = Color::new(0.667, 0.667, 0.667, 1.0);
+
+pub const DARK_GRAY: Color = Color::new(0.333, 0.333, 0.333, 1.0);
+pub const LIGHT_BLUE: Color = Color::new(0.333, 0.333, 1.000, 1.0);
+pub const LIGHT_GREEN: Color = Color::new(0.333, 1.000, 0.333, 1.0);
+pub const LIGHT_CYAN: Color = Color::new(0.333, 1.000, 1.000, 1.0);
+pub const LIGHT_RED: Color = Color::new(1.000, 0.333, 0.333, 1.0);
+pub const LIGHT_MAGENTA: Color = Color::new(1.000, 0.333, 1.000, 1.0);
+pub const YELLOW: Color = Color::new(1.000, 1.000, 0.333, 1.0);
+pub const WHITE: Color = Color::new(1.000, 1.000, 1.000, 1.0);
+
+/// All 16 colours in canonical IBM PC order. Useful for indexed
+/// rendering (an attribute byte's `fg` nibble selects via this).
+pub const EGA_16: [Color; 16] = [
+    BLACK,
+    BLUE,
+    GREEN,
+    CYAN,
+    RED,
+    MAGENTA,
+    BROWN,
+    LIGHT_GRAY,
+    DARK_GRAY,
+    LIGHT_BLUE,
+    LIGHT_GREEN,
+    LIGHT_CYAN,
+    LIGHT_RED,
+    LIGHT_MAGENTA,
+    YELLOW,
+    WHITE,
+];

--- a/ui/macroquad-tui/src/render.rs
+++ b/ui/macroquad-tui/src/render.rs
@@ -1,0 +1,168 @@
+//! Cell + grid painting — the "Tier 3" renderer that actually uses
+//! [`Cell`]'s `bg` and `attrs` fields.
+//!
+//! Earlier versions of the consumer's render loops only read `cell.fg`
+//! and `cell.ch`, leaving the background and attribute bitset
+//! invisible to the user. This module supplies a one-stop painter
+//! that respects every cell field:
+//!
+//! - **bg**: drawn as a `draw_rectangle` underneath the glyph when not
+//!   fully transparent
+//! - **INVERSE**: swaps `fg`/`bg` before applying everything else
+//! - **BLINK**: time-based on/off at ~1.5 Hz; while off, neither glyph
+//!   nor bg is drawn (the cleared backdrop shows through)
+//! - **DIM**: multiplies foreground channels by 0.6
+//! - **BOLD**: multiplies foreground channels by 1.2 (clamped to 1.0)
+//!
+//! Use [`paint_cell`] when you need fine control over which cells get
+//! painted (e.g. the terminal skips the row the editor prompt occupies
+//! to avoid overdraw). Otherwise [`paint_grid`] is the convenience
+//! that loops once over the grid's visible viewport.
+
+use macroquad::prelude::*;
+
+use crate::grid::{Cell, CellAttrs, Grid};
+
+const BLINK_HZ: f32 = 1.5;
+const DIM_FACTOR: f32 = 0.6;
+const BOLD_FACTOR: f32 = 1.2;
+
+/// Cell-and-line measurements derived from the chosen font. The
+/// renderer needs these to map `(row, col)` → pixel coordinates.
+/// `cell_h` is the *line* height (≈ `font_size × 1.35`), not the glyph
+/// height — gives breathing room above + below the text.
+pub struct GridMetrics {
+    pub cell_w: f32,
+    pub cell_h: f32,
+    pub baseline_offset: f32,
+}
+
+impl GridMetrics {
+    pub fn measure(font: Option<&Font>, font_size: u16) -> Self {
+        // Monospaced fonts measure all glyphs to the same width;
+        // 'M' is a stable reference.
+        let m = measure_text("M", font, font_size, 1.0);
+        Self {
+            cell_w: m.width,
+            cell_h: (font_size as f32) * 1.35,
+            baseline_offset: m.offset_y,
+        }
+    }
+}
+
+/// Paint one cell at the given screen position. Lower-level than
+/// [`paint_grid`] — used when consumers need to filter cells (e.g.
+/// the terminal skips its editor row, games that want to apply
+/// custom transforms).
+///
+/// `x` / `y_top` are the *top-left* of the cell in screen pixels.
+/// `time` is used to drive BLINK; pass the same value that
+/// `SceneCtx::time` carries.
+pub fn paint_cell(
+    cell: &Cell,
+    x: f32,
+    y_top: f32,
+    metrics: &GridMetrics,
+    font: Option<&Font>,
+    font_size: u16,
+    time: f32,
+) {
+    let (mut fg, bg) = if cell.attrs.contains(CellAttrs::INVERSE) {
+        (cell.bg, cell.fg)
+    } else {
+        (cell.fg, cell.bg)
+    };
+
+    // BLINK gates everything — when off, draw nothing so the cleared
+    // background shows through.
+    if cell.attrs.contains(CellAttrs::BLINK) {
+        let on = ((time * BLINK_HZ) % 1.0) < 0.5;
+        if !on {
+            return;
+        }
+    }
+
+    // Background fill if not transparent. The alpha check uses a
+    // small threshold to skip near-zero alphas — many of our `bg`
+    // values come from `Color::new(0,0,0,0)` literals.
+    if bg.a > 0.05 {
+        draw_rectangle(x, y_top, metrics.cell_w, metrics.cell_h, bg);
+    }
+
+    if cell.ch == ' ' {
+        return;
+    }
+
+    if cell.attrs.contains(CellAttrs::DIM) {
+        fg = scale_rgb(fg, DIM_FACTOR);
+    }
+    if cell.attrs.contains(CellAttrs::BOLD) {
+        fg = scale_rgb(fg, BOLD_FACTOR);
+    }
+
+    let params = TextParams {
+        font,
+        font_size,
+        color: fg,
+        ..Default::default()
+    };
+    let y_baseline = y_top + metrics.baseline_offset;
+    let mut buf = [0u8; 4];
+    let s = cell.ch.encode_utf8(&mut buf);
+    draw_text_ex(s, x, y_baseline, params);
+}
+
+/// Paint every visible cell in `grid`. Layout maps cells to pixel
+/// space anchored at `(padding, padding)`. Pass `skip_row = Some(r)`
+/// to leave row `r` unpainted (e.g. when the consumer is going to
+/// overlay an editor prompt there and doesn't want overdraw).
+pub fn paint_grid(
+    grid: &Grid,
+    font: Option<&Font>,
+    font_size: u16,
+    metrics: &GridMetrics,
+    padding: f32,
+    time: f32,
+    skip_row: Option<usize>,
+) {
+    for (row, col, cell) in grid.cells() {
+        if Some(row) == skip_row {
+            continue;
+        }
+        let x = padding + col as f32 * metrics.cell_w;
+        let y_top = padding + row as f32 * metrics.cell_h;
+        paint_cell(cell, x, y_top, metrics, font, font_size, time);
+    }
+}
+
+fn scale_rgb(c: Color, factor: f32) -> Color {
+    Color::new(
+        (c.r * factor).min(1.0),
+        (c.g * factor).min(1.0),
+        (c.b * factor).min(1.0),
+        c.a,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_rgb_clamps_at_full_brightness() {
+        let c = Color::new(0.9, 0.5, 0.1, 1.0);
+        let bright = scale_rgb(c, 2.0);
+        assert!((bright.r - 1.0).abs() < 1e-6);
+        assert!((bright.g - 1.0).abs() < 1e-6);
+        assert!((bright.b - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn scale_rgb_dim_halves_brightness() {
+        let c = Color::new(1.0, 0.6, 0.4, 1.0);
+        let dim = scale_rgb(c, 0.5);
+        assert!((dim.r - 0.5).abs() < 1e-6);
+        assert!((dim.g - 0.3).abs() < 1e-6);
+        assert!((dim.b - 0.2).abs() < 1e-6);
+    }
+}

--- a/ui/macroquad-tui/src/scene.rs
+++ b/ui/macroquad-tui/src/scene.rs
@@ -1,0 +1,369 @@
+//! Scene abstraction — stackable game-loop participants.
+//!
+//! A [`Scene`] owns its state and knows how to update + render itself.
+//! Scenes live in a [`SceneStack`]; the topmost runs every frame, with
+//! lower scenes' state preserved but their `update`/`render` paused.
+//! Pushing a new scene onto the stack lets a command (e.g. `wumpus`)
+//! launch a game on top of a terminal; popping returns control to the
+//! caller seamlessly.
+//!
+//! ## Lifecycle
+//!
+//! ```text
+//!   tick(dt)                — for the topmost scene only
+//!     ├─ update(dt, ctx)    — returns SceneOutcome
+//!     │    Continue         → keep this scene next frame
+//!     │    Exit             → on_exit(); pop from stack
+//!     │    Push(new)        → push `new`; new.on_enter()
+//!     │    Replace(new)     → on_exit(); pop self; push `new`; new.on_enter()
+//!     └─ render(grid, ctx)  — same scene
+//! ```
+//!
+//! Scenes never poll macroquad directly. The main render loop builds
+//! a [`SceneInput`] snapshot once per frame and passes it via
+//! [`SceneCtx`]; this makes scenes deterministic (the same input
+//! sequence always yields the same state transitions) and
+//! straightforward to feed synthetic input in tests.
+
+use macroquad::input::KeyCode;
+use macroquad::text::Font;
+use macroquad::time::get_time;
+
+use crate::grid::Grid;
+
+// `Grid` is unused in this module's signatures (scenes own their own
+// grids via `Scene::grid()` / `grid_mut()`); imported above so the
+// type appears in this module's namespace for callers who `use
+// macroquad_tui::scene::*` and want both surfaces in scope at once.
+#[allow(unused_imports)]
+use Grid as _;
+
+/// Outcome of a `Scene::update` call — what the [`SceneStack`] should
+/// do next.
+pub enum SceneOutcome {
+    /// Keep running this scene unchanged.
+    Continue,
+    /// Pop self off the stack; whatever was beneath becomes active.
+    Exit,
+    /// Push another scene onto the stack above self.
+    Push(Box<dyn Scene>),
+    /// Replace self with another scene (no net stack growth).
+    Replace(Box<dyn Scene>),
+}
+
+/// A stackable game-loop participant.
+///
+/// Implementors own their state — including, optionally, a
+/// [`Grid`]. The framework asks for that grid via [`grid`] /
+/// [`grid_mut`] and paints it to the screen; scenes without a grid
+/// (e.g. a sprite-only cutscene) return `None` and draw entirely
+/// through macroquad's draw primitives in [`render`].
+///
+/// Lifecycle: only the topmost scene gets `update` / `render` each
+/// frame. Lower scenes' state is preserved but their callbacks pause
+/// until they're topmost again (at which point `on_enter` fires).
+pub trait Scene {
+    /// Per-frame update. `dt` is seconds since last tick. Return
+    /// [`SceneOutcome::Continue`] to keep going, or one of the other
+    /// variants to mutate the stack.
+    fn update(&mut self, dt: f32, ctx: &SceneCtx) -> SceneOutcome;
+
+    /// Per-frame render of anything that isn't the scene's grid —
+    /// editor prompt, sprite overlays, status hints. The framework
+    /// already painted [`grid`] before calling this.
+    ///
+    /// Default no-op for scenes that are pure grid-based.
+    fn render(&mut self, _ctx: &SceneCtx) {}
+
+    /// Borrow the scene's grid for painting by the framework. `None`
+    /// for sprite-only scenes that don't have one.
+    fn grid(&self) -> Option<&Grid> {
+        None
+    }
+
+    /// Mutable borrow of the scene's grid. Lets the framework write
+    /// into it for utilities (e.g. CRT screen-shake, transient
+    /// effects); scenes typically write to their own grid via `self`
+    /// rather than through this accessor.
+    fn grid_mut(&mut self) -> Option<&mut Grid> {
+        None
+    }
+
+    /// Fires when this scene becomes the active (topmost) scene —
+    /// either freshly pushed, or revealed by the scene above popping.
+    /// Default no-op.
+    fn on_enter(&mut self, _ctx: &SceneCtx) {}
+
+    /// Fires when this scene is about to be popped or replaced.
+    /// Default no-op.
+    fn on_exit(&mut self, _ctx: &SceneCtx) {}
+}
+
+/// Per-frame input snapshot. Built once by the main loop, passed into
+/// scenes via [`SceneCtx`].
+#[derive(Default)]
+pub struct SceneInput {
+    pub keys_pressed: Vec<KeyCode>,
+    pub keys_down: Vec<KeyCode>,
+    pub chars_pressed: Vec<char>,
+    pub mouse_wheel_y: f32,
+    pub mouse_x: f32,
+    pub mouse_y: f32,
+}
+
+impl SceneInput {
+    pub fn is_key_pressed(&self, key: KeyCode) -> bool {
+        self.keys_pressed.contains(&key)
+    }
+
+    pub fn is_key_down(&self, key: KeyCode) -> bool {
+        self.keys_down.contains(&key)
+    }
+
+    pub fn shift_held(&self) -> bool {
+        self.is_key_down(KeyCode::LeftShift) || self.is_key_down(KeyCode::RightShift)
+    }
+
+    /// Snapshot from macroquad's input state. Call once per frame
+    /// before passing to scenes. Helper so consumers don't have to
+    /// repeat the same boilerplate.
+    pub fn capture() -> Self {
+        use macroquad::input::*;
+        let mut chars = Vec::new();
+        while let Some(c) = get_char_pressed() {
+            chars.push(c);
+        }
+        // Compact list of keys we care about — exhaustive polling
+        // every KeyCode would be wasteful. Scenes that want
+        // less-common keys can poll get_keys_down() / get_keys_pressed()
+        // for themselves once macroquad exposes it; for now this
+        // covers terminal + arcade-game vocabularies.
+        let watch: &[KeyCode] = &[
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Space,
+            KeyCode::Enter,
+            KeyCode::Escape,
+            KeyCode::Tab,
+            KeyCode::Backspace,
+            KeyCode::Delete,
+            KeyCode::Home,
+            KeyCode::End,
+            KeyCode::PageUp,
+            KeyCode::PageDown,
+            KeyCode::LeftShift,
+            KeyCode::RightShift,
+            KeyCode::LeftControl,
+            KeyCode::RightControl,
+            KeyCode::F1,
+            KeyCode::F2,
+            KeyCode::F3,
+            KeyCode::F4,
+            KeyCode::F5,
+            KeyCode::F6,
+            KeyCode::F7,
+            KeyCode::F8,
+            KeyCode::F9,
+            KeyCode::F10,
+        ];
+        let mut keys_pressed = Vec::new();
+        let mut keys_down = Vec::new();
+        for &k in watch {
+            if is_key_pressed(k) {
+                keys_pressed.push(k);
+            }
+            if is_key_down(k) {
+                keys_down.push(k);
+            }
+        }
+        let (mx, my) = mouse_position();
+        Self {
+            keys_pressed,
+            keys_down,
+            chars_pressed: chars,
+            mouse_wheel_y: mouse_wheel().1,
+            mouse_x: mx,
+            mouse_y: my,
+        }
+    }
+}
+
+/// Per-frame context handed to scenes. Carries input, shared
+/// resources, and timing. Scenes can pull what they need; new fields
+/// can land here without churning every scene's signature.
+pub struct SceneCtx<'a> {
+    pub input: &'a SceneInput,
+    pub font: Option<&'a Font>,
+    /// Absolute seconds since macroquad started — useful for blink
+    /// timing, sprite animation phases, etc.
+    pub time: f32,
+}
+
+impl<'a> SceneCtx<'a> {
+    pub fn new(input: &'a SceneInput, font: Option<&'a Font>) -> Self {
+        Self {
+            input,
+            font,
+            time: get_time() as f32,
+        }
+    }
+}
+
+/// Manages a stack of scenes. The topmost runs each frame; pushes /
+/// pops happen between frames so a scene's `update` always completes
+/// before the stack mutates.
+pub struct SceneStack {
+    scenes: Vec<Box<dyn Scene>>,
+}
+
+impl SceneStack {
+    pub fn new(root: Box<dyn Scene>) -> Self {
+        let mut s = Self {
+            scenes: Vec::with_capacity(4),
+        };
+        s.scenes.push(root);
+        s
+    }
+
+    /// Tick the topmost scene. Applies its [`SceneOutcome`] to the
+    /// stack before returning. `on_enter` / `on_exit` callbacks fire
+    /// at the appropriate transitions.
+    ///
+    /// Returns `true` while at least one scene remains. `false` once
+    /// the last scene has exited (the main loop should break).
+    pub fn tick(&mut self, dt: f32, ctx: &SceneCtx) -> bool {
+        let outcome = match self.scenes.last_mut() {
+            Some(s) => s.update(dt, ctx),
+            None => return false,
+        };
+        match outcome {
+            SceneOutcome::Continue => {}
+            SceneOutcome::Exit => {
+                if let Some(mut s) = self.scenes.pop() {
+                    s.on_exit(ctx);
+                }
+                if let Some(s) = self.scenes.last_mut() {
+                    s.on_enter(ctx);
+                }
+            }
+            SceneOutcome::Push(mut new) => {
+                new.on_enter(ctx);
+                self.scenes.push(new);
+            }
+            SceneOutcome::Replace(mut new) => {
+                if let Some(mut s) = self.scenes.pop() {
+                    s.on_exit(ctx);
+                }
+                new.on_enter(ctx);
+                self.scenes.push(new);
+            }
+        }
+        !self.scenes.is_empty()
+    }
+
+    /// Run the topmost scene's `render` (overlay drawing). The
+    /// framework should paint the scene's grid (via [`topmost_grid`])
+    /// *before* calling this, so the overlay draws on top of the
+    /// grid cells.
+    pub fn render(&mut self, ctx: &SceneCtx) {
+        if let Some(s) = self.scenes.last_mut() {
+            s.render(ctx);
+        }
+    }
+
+    /// Borrow the topmost scene's grid for painting.
+    pub fn topmost_grid(&self) -> Option<&Grid> {
+        self.scenes.last().and_then(|s| s.grid())
+    }
+
+    /// Mutable borrow of the topmost scene's grid. Useful when the
+    /// framework provides utilities that touch grid contents directly
+    /// (e.g. a CRT-effect overlay that ripples the buffer).
+    pub fn topmost_grid_mut(&mut self) -> Option<&mut Grid> {
+        self.scenes.last_mut().and_then(|s| s.grid_mut())
+    }
+
+    pub fn depth(&self) -> usize {
+        self.scenes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.scenes.is_empty()
+    }
+}
+
+/// Fixed-step accumulator — separates logic ticks from frame rate.
+/// Most retro games want the logic to step at a fixed rate (Tetris
+/// drops once per second; Snake moves every 80 ms) while the renderer
+/// still runs at whatever the display refreshes at.
+///
+/// ```ignore
+/// let mut step = FixedStep::new(5.0);  // 5 logic ticks per second
+/// // in scene update:
+/// for _ in 0..step.ticks(dt) {
+///     game.advance_one_tick();
+/// }
+/// ```
+pub struct FixedStep {
+    interval: f32,
+    accumulator: f32,
+}
+
+impl FixedStep {
+    /// Construct a fixed step that fires at `hz` per second.
+    pub fn new(hz: f32) -> Self {
+        Self {
+            interval: 1.0 / hz.max(0.001),
+            accumulator: 0.0,
+        }
+    }
+
+    /// Advance the accumulator; return how many full ticks should fire
+    /// this frame. Usually `0` or `1`; can be more if the previous
+    /// frame ran long.
+    pub fn ticks(&mut self, dt: f32) -> u32 {
+        self.accumulator += dt;
+        let mut n = 0;
+        while self.accumulator >= self.interval {
+            self.accumulator -= self.interval;
+            n += 1;
+        }
+        n
+    }
+
+    /// Reset the accumulator (e.g. when a scene resumes after pause).
+    pub fn reset(&mut self) {
+        self.accumulator = 0.0;
+    }
+
+    /// Change the step rate at runtime — useful for Tetris-style
+    /// "drop faster at higher levels". Doesn't reset the accumulator.
+    pub fn set_hz(&mut self, hz: f32) {
+        self.interval = 1.0 / hz.max(0.001);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_step_fires_at_expected_rate() {
+        let mut s = FixedStep::new(10.0); // 10 Hz = 0.1 s interval
+        assert_eq!(s.ticks(0.05), 0);
+        assert_eq!(s.ticks(0.05), 1);
+        assert_eq!(s.ticks(0.1), 1);
+        // A long frame should catch up multiple ticks
+        assert_eq!(s.ticks(0.5), 5);
+    }
+
+    #[test]
+    fn fixed_step_reset_clears_accumulator() {
+        let mut s = FixedStep::new(10.0);
+        s.ticks(0.07);
+        s.reset();
+        assert_eq!(s.ticks(0.05), 0);
+    }
+}

--- a/ui/macroquad-tui/src/scene.rs
+++ b/ui/macroquad-tui/src/scene.rs
@@ -134,10 +134,10 @@ impl SceneInput {
             chars.push(c);
         }
         // Compact list of keys we care about — exhaustive polling
-        // every KeyCode would be wasteful. Scenes that want
-        // less-common keys can poll get_keys_down() / get_keys_pressed()
-        // for themselves once macroquad exposes it; for now this
-        // covers terminal + arcade-game vocabularies.
+        // every KeyCode would be wasteful. Covers terminal +
+        // arcade-game vocabularies plus the full letter range for
+        // hotkey use (game commands, viewer shortcuts). Letter polls
+        // are 26 cheap calls per frame, well under the budget.
         let watch: &[KeyCode] = &[
             KeyCode::Up,
             KeyCode::Down,
@@ -167,6 +167,36 @@ impl SceneInput {
             KeyCode::F8,
             KeyCode::F9,
             KeyCode::F10,
+            // Letters A–Z. macroquad's KeyCode lists them all
+            // individually so we have to spell each out; the snapshot
+            // then lets scenes treat any letter as a hotkey via the
+            // standard `is_key_pressed` path.
+            KeyCode::A,
+            KeyCode::B,
+            KeyCode::C,
+            KeyCode::D,
+            KeyCode::E,
+            KeyCode::F,
+            KeyCode::G,
+            KeyCode::H,
+            KeyCode::I,
+            KeyCode::J,
+            KeyCode::K,
+            KeyCode::L,
+            KeyCode::M,
+            KeyCode::N,
+            KeyCode::O,
+            KeyCode::P,
+            KeyCode::Q,
+            KeyCode::R,
+            KeyCode::S,
+            KeyCode::T,
+            KeyCode::U,
+            KeyCode::V,
+            KeyCode::W,
+            KeyCode::X,
+            KeyCode::Y,
+            KeyCode::Z,
         ];
         let mut keys_pressed = Vec::new();
         let mut keys_down = Vec::new();

--- a/ui/macroquad-tui/src/sprite.rs
+++ b/ui/macroquad-tui/src/sprite.rs
@@ -1,0 +1,338 @@
+//! Cell-grid sprite primitives.
+//!
+//! A sprite is a fixed-size rectangle of [`Cell`]s, some of which may
+//! be transparent (`None`). Painting a sprite into a [`Grid`] writes
+//! the non-transparent cells at the chosen top-left corner — the
+//! same compositing model as a Game Boy tile, applied to character
+//! cells instead of pixels.
+//!
+//! ## When to use
+//!
+//! - Multi-cell game entities (Pacman ghosts, Space Invaders aliens,
+//!   bigger UFOs / bosses) where the shape is known ahead of time
+//!   and the same art repeats across many positions on screen.
+//! - HUD widgets / icons rendered into the same `Grid` as the rest
+//!   of the scene — health bars, key prompts, mini-map markers.
+//! - Boot animations, splash screens, intro cards.
+//!
+//! For single-cell entities (Snake segments, Tetris blocks), the
+//! existing [`Grid::put_at`] is cheaper — no need for the sprite
+//! indirection. The sprite layer pays off once you're stamping the
+//! same shape repeatedly.
+//!
+//! ## Authoring sprites
+//!
+//! [`CellSprite::from_ascii`] reads a multi-line string where each
+//! visible character becomes a cell with the supplied `fg` colour,
+//! and `.` is transparent. Convenient for hand-rolled art:
+//!
+//! ```ignore
+//! let invader = CellSprite::from_ascii(
+//!     "..███..\n.█████.\n██.█.██",
+//!     RED,
+//! );
+//! invader.paint(&mut grid, 2, 10);
+//! ```
+//!
+//! For programmatic sprites (e.g. computed every frame), use
+//! [`CellSprite::new_blank`] + [`CellSprite::set`].
+//!
+//! ## What's deliberately out of scope (for now)
+//!
+//! - Half-block pixel sprites (2× vertical resolution). Add when a
+//!   pixel-art game lands — the existing [`crate::HalfBlockCanvas`]
+//!   already covers the rendering primitive.
+//! - Animation frames + timing. Add when a game needs cyclic art.
+//! - GPU-texture sprites. The viewer's [`crate::ShardedAtlas`]
+//!   already covers that use case for image atlases.
+
+use std::collections::HashMap;
+
+use macroquad::prelude::Color;
+
+use crate::grid::{Cell, CellAttrs, Grid};
+
+/// A `width × height` rectangle of optional [`Cell`]s.
+///
+/// `None` slots are transparent — paint() skips them so the
+/// underlying grid content shows through. This is what makes
+/// multi-shape sprites composable: an L-shaped piece can live in a
+/// `3 × 3` bounding box without forcing the surrounding two cells
+/// to be solid.
+#[derive(Clone, Debug)]
+pub struct CellSprite {
+    pub width: usize,
+    pub height: usize,
+    /// Row-major: index = `y * width + x`. Length always equals
+    /// `width * height`.
+    pub cells: Vec<Option<Cell>>,
+}
+
+impl CellSprite {
+    /// Construct an all-transparent sprite of the given size. Use
+    /// [`Self::set`] to fill cells in.
+    pub fn new_blank(width: usize, height: usize) -> Self {
+        Self {
+            width,
+            height,
+            cells: vec![None; width * height],
+        }
+    }
+
+    /// Parse a multi-line ASCII art string into a sprite. Each line
+    /// becomes one row; the longest line sets `width`, shorter rows
+    /// are right-padded with transparent cells.
+    ///
+    /// - `'.'` → transparent
+    /// - `' '` (space) → transparent (lets you align art naturally)
+    /// - anything else → opaque [`Cell`] with the supplied `fg`
+    ///   colour, default bg, no attrs
+    ///
+    /// Lines may be separated by `\n` or `\r\n`. Empty input yields
+    /// a 0×0 sprite.
+    pub fn from_ascii(art: &str, fg: Color) -> Self {
+        let rows: Vec<&str> = art.lines().collect();
+        let height = rows.len();
+        let width = rows.iter().map(|r| r.chars().count()).max().unwrap_or(0);
+        let transparent = Color::new(0.0, 0.0, 0.0, 0.0);
+        let mut cells = vec![None; width * height];
+        for (y, row) in rows.iter().enumerate() {
+            for (x, ch) in row.chars().enumerate() {
+                if ch == '.' || ch == ' ' {
+                    continue;
+                }
+                cells[y * width + x] = Some(Cell {
+                    ch,
+                    fg,
+                    bg: transparent,
+                    attrs: CellAttrs::PLAIN,
+                });
+            }
+        }
+        Self { width, height, cells }
+    }
+
+    /// Set or clear a single cell. Out-of-bounds writes silently
+    /// drop — cheaper than panicking, and consistent with `Grid`.
+    pub fn set(&mut self, x: usize, y: usize, cell: Option<Cell>) {
+        if x < self.width && y < self.height {
+            self.cells[y * self.width + x] = cell;
+        }
+    }
+
+    /// Read a single cell. Returns `None` for out-of-bounds OR for
+    /// transparent positions; callers that need to distinguish the
+    /// two should compare against `self.width`/`self.height` first.
+    pub fn get(&self, x: usize, y: usize) -> Option<&Cell> {
+        if x < self.width && y < self.height {
+            self.cells[y * self.width + x].as_ref()
+        } else {
+            None
+        }
+    }
+
+    /// Stamp this sprite into a [`Grid`], with its top-left corner at
+    /// `(top_row, left_col)`. Transparent cells preserve whatever the
+    /// grid had there; opaque cells overwrite. Cells outside the
+    /// grid's rows/cols are clipped silently — sprites near the edge
+    /// just lose their off-screen portion.
+    pub fn paint(&self, grid: &mut Grid, top_row: usize, left_col: usize) {
+        for y in 0..self.height {
+            for x in 0..self.width {
+                if let Some(cell) = &self.cells[y * self.width + x] {
+                    grid.put_at(top_row + y, left_col + x, *cell);
+                }
+            }
+        }
+    }
+}
+
+/// A named collection of sprites. Game scenes typically build one
+/// of these once at construction (e.g. all enemy types + the player
+/// + bullets + UI icons) and then look up by name in the per-frame
+/// render loop.
+///
+/// The sheet itself is just a `HashMap<String, CellSprite>`; the
+/// purpose of the type is documentation + a single import path
+/// instead of leaking the map shape into every consumer.
+#[derive(Default, Debug)]
+pub struct SpriteSheet {
+    sprites: HashMap<String, CellSprite>,
+}
+
+impl SpriteSheet {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert / replace a sprite by name. Returns the old sprite if
+    /// the name was already taken.
+    pub fn insert(&mut self, name: impl Into<String>, sprite: CellSprite) -> Option<CellSprite> {
+        self.sprites.insert(name.into(), sprite)
+    }
+
+    pub fn get(&self, name: &str) -> Option<&CellSprite> {
+        self.sprites.get(name)
+    }
+
+    pub fn len(&self) -> usize {
+        self.sprites.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sprites.is_empty()
+    }
+
+    /// Iterator over all `(name, sprite)` pairs. Useful for atlas
+    /// previews or hot-reload diffs.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &CellSprite)> {
+        self.sprites.iter().map(|(k, v)| (k.as_str(), v))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use macroquad::prelude::Color;
+
+    const RED: Color = Color::new(1.0, 0.0, 0.0, 1.0);
+    const PHOSPHOR: Color = Color::new(0.267, 1.0, 0.267, 1.0);
+
+    #[test]
+    fn blank_sprite_is_fully_transparent() {
+        let s = CellSprite::new_blank(3, 2);
+        assert_eq!(s.width, 3);
+        assert_eq!(s.height, 2);
+        assert_eq!(s.cells.len(), 6);
+        assert!(s.cells.iter().all(Option::is_none));
+    }
+
+    #[test]
+    fn from_ascii_parses_rectangle() {
+        let s = CellSprite::from_ascii("AB.\n.CD", RED);
+        assert_eq!(s.width, 3);
+        assert_eq!(s.height, 2);
+        // (0,0)=A, (1,0)=B, (2,0)=transparent
+        assert_eq!(s.get(0, 0).unwrap().ch, 'A');
+        assert_eq!(s.get(1, 0).unwrap().ch, 'B');
+        assert!(s.get(2, 0).is_none());
+        // (0,1)=transparent, (1,1)=C, (2,1)=D
+        assert!(s.get(0, 1).is_none());
+        assert_eq!(s.get(1, 1).unwrap().ch, 'C');
+        assert_eq!(s.get(2, 1).unwrap().ch, 'D');
+    }
+
+    #[test]
+    fn from_ascii_pads_short_rows() {
+        // Second row is shorter; should be padded with transparent
+        // cells to the longest line's width.
+        let s = CellSprite::from_ascii("ABCD\nXY", RED);
+        assert_eq!(s.width, 4);
+        assert_eq!(s.height, 2);
+        assert!(s.get(2, 1).is_none());
+        assert!(s.get(3, 1).is_none());
+    }
+
+    #[test]
+    fn from_ascii_treats_space_and_dot_as_transparent() {
+        let s = CellSprite::from_ascii("A B.C", RED);
+        assert_eq!(s.get(0, 0).unwrap().ch, 'A');
+        assert!(s.get(1, 0).is_none()); // space
+        assert_eq!(s.get(2, 0).unwrap().ch, 'B');
+        assert!(s.get(3, 0).is_none()); // dot
+        assert_eq!(s.get(4, 0).unwrap().ch, 'C');
+    }
+
+    #[test]
+    fn paint_writes_into_grid_at_offset() {
+        let mut grid = Grid::new(10, 5, PHOSPHOR);
+        let sprite = CellSprite::from_ascii("XX\nXX", RED);
+        sprite.paint(&mut grid, 1, 3);
+        // Grab the cells out via the public iterator — confirm we
+        // wrote 4 cells starting at (row 1, col 3).
+        let painted: Vec<(usize, usize, char)> = grid
+            .cells()
+            .filter_map(|(r, c, cell)| {
+                if cell.ch == 'X' {
+                    Some((r, c, cell.ch))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(painted.len(), 4);
+        // Order isn't guaranteed but the positions should be exactly
+        // these four; sort to compare.
+        let mut got: Vec<(usize, usize)> = painted.iter().map(|(r, c, _)| (*r, *c)).collect();
+        got.sort();
+        assert_eq!(got, vec![(1, 3), (1, 4), (2, 3), (2, 4)]);
+    }
+
+    #[test]
+    fn paint_skips_transparent_cells() {
+        let mut grid = Grid::new(5, 3, PHOSPHOR);
+        // Pre-write a 'Z' at (0, 1) so we can check whether paint
+        // overwrote it.
+        grid.put_at(
+            0,
+            1,
+            Cell {
+                ch: 'Z',
+                fg: PHOSPHOR,
+                bg: Color::new(0.0, 0.0, 0.0, 0.0),
+                attrs: CellAttrs::PLAIN,
+            },
+        );
+        // Sprite has a transparent middle column, so (0, 1) should
+        // be preserved.
+        let sprite = CellSprite::from_ascii("X.X", RED);
+        sprite.paint(&mut grid, 0, 0);
+        let z = grid
+            .cells()
+            .find(|(_, _, cell)| cell.ch == 'Z')
+            .map(|(_, _, c)| c.ch);
+        assert_eq!(z, Some('Z'));
+    }
+
+    #[test]
+    fn paint_clips_out_of_bounds() {
+        let mut grid = Grid::new(4, 3, PHOSPHOR);
+        let sprite = CellSprite::from_ascii("XXX\nXXX", RED);
+        // Paint with a left offset that pushes the right column past
+        // the grid edge — shouldn't panic.
+        sprite.paint(&mut grid, 0, 3);
+        // Only the (col 3) column lands inside; cols 4 and 5 clip.
+        let xs: Vec<(usize, usize)> = grid
+            .cells()
+            .filter_map(|(r, c, cell)| {
+                if cell.ch == 'X' {
+                    Some((r, c))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(xs.len(), 2);
+    }
+
+    #[test]
+    fn sheet_round_trips() {
+        let mut sheet = SpriteSheet::new();
+        sheet.insert("invader", CellSprite::from_ascii(".█.", RED));
+        sheet.insert("player", CellSprite::from_ascii("█▀█", RED));
+        assert_eq!(sheet.len(), 2);
+        assert!(sheet.get("invader").is_some());
+        assert!(sheet.get("player").is_some());
+        assert!(sheet.get("missing").is_none());
+    }
+
+    #[test]
+    fn sheet_iter_yields_inserted_pairs() {
+        let mut sheet = SpriteSheet::new();
+        sheet.insert("a", CellSprite::from_ascii("X", RED));
+        sheet.insert("b", CellSprite::from_ascii("Y", RED));
+        let mut names: Vec<&str> = sheet.iter().map(|(k, _)| k).collect();
+        names.sort();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+}

--- a/ui/macroquad-tui/src/sprite.rs
+++ b/ui/macroquad-tui/src/sprite.rs
@@ -148,9 +148,9 @@ impl CellSprite {
 }
 
 /// A named collection of sprites. Game scenes typically build one
-/// of these once at construction (e.g. all enemy types + the player
-/// + bullets + UI icons) and then look up by name in the per-frame
-/// render loop.
+/// of these once at construction — every enemy type, the player,
+/// bullets, UI icons — then look up by name in the per-frame render
+/// loop.
 ///
 /// The sheet itself is just a `HashMap<String, CellSprite>`; the
 /// purpose of the type is documentation + a single import path

--- a/ui/macroquad-tui/src/sprite_atlas.rs
+++ b/ui/macroquad-tui/src/sprite_atlas.rs
@@ -1,0 +1,278 @@
+//! Lazy-loaded sharded sprite atlas — multiple JPEG/PNG tiles that
+//! together form one logical key-addressable atlas, fetched on demand.
+//!
+//! ## Why sharded
+//!
+//! A single packed atlas trades boot weight for fast access. Once it
+//! grows past a few MB the boot wait gets noticeable, and any change
+//! to a single tile invalidates the whole file in the browser cache.
+//!
+//! Sharding cuts each tile's blast radius: a stable hash maps each
+//! key to a shard id, so editing one tile only changes the file it
+//! lives in. Users only download the shards they touch, and HTTP/2
+//! multiplexing handles parallel fetches across shards. Boot stays
+//! cheap (just an index file).
+//!
+//! ## Wire shape
+//!
+//! Built by the build script — see the schema in [`AtlasIndex`]
+//! below. The runtime just reads `[shard_id, col, row]` per key; the
+//! shard-assignment hash function only matters at build time.
+//!
+//! ## Usage shape
+//!
+//! ```ignore
+//! let atlas = ShardedAtlas::from_index_json(
+//!     &index_json,
+//!     |n| format!("sketches-atlas-{n}.jpg"),
+//!     FilterMode::Linear,
+//! );
+//!
+//! // Each frame in the scene that draws atlas tiles:
+//! atlas.tick();                                      // poll in-flight loads
+//! match atlas.get(key) {
+//!     AtlasSlot::Ready { texture, source } => draw_texture_ex(texture, .., source: Some(source), ..),
+//!     AtlasSlot::Pending                   => draw_loading_placeholder(),
+//!     AtlasSlot::Missing                   => { /* unknown key */ },
+//! }
+//! ```
+//!
+//! `get` kicks off the shard's async load on the first call that hits
+//! an unloaded shard; subsequent frames return `Pending` until the
+//! load resolves, then `Ready` thereafter. Loaded shard textures stay
+//! cached for the program's lifetime.
+
+use std::collections::HashMap;
+
+use macroquad::experimental::coroutines::{start_coroutine, Coroutine};
+use macroquad::prelude::Rect;
+use macroquad::texture::{load_image, FilterMode, Image, Texture2D};
+use serde::Deserialize;
+
+/// Wire shape of the atlas index JSON.
+///
+/// ```text
+/// {
+///   "cell_width": 256,
+///   "cell_height": 256,
+///   "shard_count": 8,
+///   "entries": {
+///     "doc-a/inc-1": [0, 3, 2],   // [shard_id, col_in_shard, row_in_shard]
+///     "doc-a/inc-2": [3, 0, 0],
+///     ...
+///   }
+/// }
+/// ```
+///
+/// `shard_count` lets callers iterate shards (e.g. to prefetch all of
+/// them up-front if they want) without scanning entries.
+#[derive(Deserialize)]
+struct AtlasIndex {
+    cell_width: u32,
+    cell_height: u32,
+    shard_count: u32,
+    entries: HashMap<String, [u32; 3]>,
+}
+
+/// State of a key's tile lookup. The borrow on `Ready` lets the
+/// renderer reach the texture without cloning — see module example.
+#[derive(Debug)]
+pub enum AtlasSlot<'a> {
+    /// Key isn't in the index — caller can fall back to a default
+    /// sprite or skip the draw.
+    Missing,
+    /// Slot exists but its shard hasn't finished loading yet. The
+    /// load is in flight; another `tick` + `get` next frame may
+    /// upgrade this to `Ready`.
+    Pending,
+    /// Slot is ready to draw.
+    Ready {
+        texture: &'a Texture2D,
+        /// Sub-rectangle of `texture` (in atlas pixel coords) that
+        /// holds this key's tile. Pass through `draw_texture_ex`'s
+        /// `source` parameter.
+        source: Rect,
+    },
+}
+
+type ShardUrlFn = Box<dyn Fn(u32) -> String + Send + Sync>;
+
+pub struct ShardedAtlas {
+    cell_width: u32,
+    cell_height: u32,
+    shard_count: u32,
+    /// Key → (shard_id, col, row).
+    index: HashMap<String, (u32, u32, u32)>,
+    /// Loaded shard textures keyed by `shard_id`.
+    textures: HashMap<u32, Texture2D>,
+    /// Shard loads currently in flight keyed by `shard_id`. Polled
+    /// each frame from `tick`.
+    pending: HashMap<u32, Coroutine<Result<Image, macroquad::Error>>>,
+    shard_url: ShardUrlFn,
+    /// Filter applied to each newly-installed shard texture.
+    filter: FilterMode,
+}
+
+impl ShardedAtlas {
+    /// Parse the index JSON and build an atlas in its initial empty
+    /// state — no shards loaded yet, all `get`s will return `Pending`
+    /// until the first frame after a shard arrives.
+    ///
+    /// `shard_url` formats a shard id into the URL/path that
+    /// `macroquad::texture::load_image` will fetch. Same path rules
+    /// as `load_image`: relative to the page on WASM, relative to
+    /// `pc_assets_folder` on native.
+    pub fn from_index_json<F>(index_json: &str, shard_url: F, filter: FilterMode) -> Self
+    where
+        F: Fn(u32) -> String + Send + Sync + 'static,
+    {
+        let parsed: AtlasIndex = serde_json::from_str(index_json)
+            .expect("sharded atlas index failed to deserialize — schema drift?");
+        let index = parsed
+            .entries
+            .into_iter()
+            .map(|(k, v)| (k, (v[0], v[1], v[2])))
+            .collect();
+        Self {
+            cell_width: parsed.cell_width,
+            cell_height: parsed.cell_height,
+            shard_count: parsed.shard_count,
+            index,
+            textures: HashMap::new(),
+            pending: HashMap::new(),
+            shard_url: Box::new(shard_url),
+            filter,
+        }
+    }
+
+    pub fn shard_count(&self) -> u32 {
+        self.shard_count
+    }
+
+    /// True when the key exists in the index, regardless of whether
+    /// the shard has been loaded yet.
+    pub fn contains(&self, key: &str) -> bool {
+        self.index.contains_key(key)
+    }
+
+    /// Look up a key. If the key's shard isn't loaded and no load is
+    /// in flight, kicks off the load. The returned state reflects the
+    /// situation *as of this call*; `tick` + a subsequent `get` will
+    /// upgrade `Pending` to `Ready` once the coroutine completes.
+    pub fn get(&mut self, key: &str) -> AtlasSlot<'_> {
+        let Some(&(shard, col, row)) = self.index.get(key) else {
+            return AtlasSlot::Missing;
+        };
+        if !self.textures.contains_key(&shard) {
+            self.kick_off_load(shard);
+            return AtlasSlot::Pending;
+        }
+        let texture = self.textures.get(&shard).unwrap();
+        let source = Rect::new(
+            (col * self.cell_width) as f32,
+            (row * self.cell_height) as f32,
+            self.cell_width as f32,
+            self.cell_height as f32,
+        );
+        AtlasSlot::Ready { texture, source }
+    }
+
+    /// Explicitly request a shard to be loaded ahead of time —
+    /// e.g. a "browse" scene that knows the user is about to view a
+    /// run of tiles from the same shard, or a prefetch sweep at idle.
+    /// No-op if already loaded or in flight.
+    pub fn prefetch(&mut self, shard_id: u32) {
+        if shard_id >= self.shard_count {
+            return;
+        }
+        if self.textures.contains_key(&shard_id) || self.pending.contains_key(&shard_id) {
+            return;
+        }
+        self.kick_off_load(shard_id);
+    }
+
+    /// Poll all in-flight shard loads. Completed ones get installed
+    /// into the texture cache and removed from `pending`. Call once
+    /// per frame from the scene that owns the atlas.
+    pub fn tick(&mut self) {
+        // Two-pass — `coroutine.retrieve()` takes `&self` but we need
+        // `&mut self` to install the new texture. Collect the
+        // finished work first, then mutate.
+        let mut to_install: Vec<(u32, Image)> = Vec::new();
+        let mut to_remove: Vec<u32> = Vec::new();
+        for (&shard_id, coroutine) in &self.pending {
+            if let Some(result) = coroutine.retrieve() {
+                to_remove.push(shard_id);
+                if let Ok(img) = result {
+                    to_install.push((shard_id, img));
+                }
+                // Err: silently drop the in-flight entry. The next
+                // `get` for this shard will retry. Tests for transient
+                // network failure can re-issue; permanent failure
+                // (bad URL) will just keep returning `Pending`. We can
+                // expose an error API once anything cares.
+            }
+        }
+        for s in to_remove {
+            self.pending.remove(&s);
+        }
+        for (id, img) in to_install {
+            let tex = Texture2D::from_image(&img);
+            tex.set_filter(self.filter);
+            self.textures.insert(id, tex);
+        }
+    }
+
+    fn kick_off_load(&mut self, shard_id: u32) {
+        if self.pending.contains_key(&shard_id) {
+            return;
+        }
+        let url = (self.shard_url)(shard_id);
+        let coroutine = start_coroutine(load_image_owned(url));
+        self.pending.insert(shard_id, coroutine);
+    }
+}
+
+/// `load_image` takes `&str`; coroutines need an owned future, so wrap
+/// it in an async block that owns the path string.
+async fn load_image_owned(url: String) -> Result<Image, macroquad::Error> {
+    load_image(&url).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_parses_with_three_coord_entries() {
+        let json = r#"{
+            "cell_width": 256,
+            "cell_height": 256,
+            "shard_count": 4,
+            "entries": {
+                "a/1": [0, 3, 2],
+                "a/2": [1, 0, 0],
+                "b/1": [3, 7, 5]
+            }
+        }"#;
+        let atlas = ShardedAtlas::from_index_json(json, |n| format!("shard-{n}.jpg"), FilterMode::Linear);
+        assert_eq!(atlas.shard_count(), 4);
+        assert!(atlas.contains("a/1"));
+        assert!(atlas.contains("b/1"));
+        assert!(!atlas.contains("c/1"));
+    }
+
+    #[test]
+    fn missing_key_returns_missing() {
+        let json = r#"{
+            "cell_width": 100, "cell_height": 100, "shard_count": 1,
+            "entries": { "a/1": [0, 0, 0] }
+        }"#;
+        let mut atlas = ShardedAtlas::from_index_json(json, |_| "x.jpg".into(), FilterMode::Linear);
+        assert!(matches!(atlas.get("nope"), AtlasSlot::Missing));
+    }
+
+    // Note: we don't test the Pending → Ready transition here because
+    // `start_coroutine` needs a running macroquad event loop. That
+    // path is exercised by the integration runs.
+}

--- a/ui/macroquad-tui/src/typer.rs
+++ b/ui/macroquad-tui/src/typer.rs
@@ -10,11 +10,14 @@
 
 use std::collections::VecDeque;
 
-use crate::grid::Grid;
+use crate::grid::{Cell, Grid};
 
 #[derive(Clone, Copy)]
 enum Op {
     Char(char),
+    /// Pre-styled cell — paints at the cursor with its own fg/bg/attrs.
+    /// Counts as one "character" of typewriter progress.
+    Cell(Cell),
     SetSpeed(f32),
 }
 
@@ -45,6 +48,22 @@ impl TypeQueue {
 
     pub fn enqueue_line(&mut self, s: &str) {
         self.enqueue(s);
+        self.pending.push_back(Op::Char('\n'));
+    }
+
+    /// Enqueue a pre-styled [`Cell`]. Use this to emit coloured output
+    /// (half-block sprites, palette-mapped sketches) where the source
+    /// already knows the exact fg/bg/attrs — `enqueue` would force the
+    /// default fg.
+    pub fn enqueue_cell(&mut self, cell: Cell) {
+        self.pending.push_back(Op::Cell(cell));
+    }
+
+    /// Enqueue a row of pre-styled cells followed by a newline.
+    pub fn enqueue_cell_line(&mut self, cells: &[Cell]) {
+        for &c in cells {
+            self.pending.push_back(Op::Cell(c));
+        }
         self.pending.push_back(Op::Char('\n'));
     }
 
@@ -79,6 +98,11 @@ impl TypeQueue {
                     written += 1;
                     self.accumulator -= 1.0;
                 }
+                Op::Cell(c) => {
+                    grid.write_cell(c);
+                    written += 1;
+                    self.accumulator -= 1.0;
+                }
                 Op::SetSpeed(rate) => {
                     self.chars_per_second = rate;
                     // Re-accumulate against the new rate so we don't lose
@@ -110,6 +134,7 @@ impl TypeQueue {
         while let Some(op) = self.pending.pop_front() {
             match op {
                 Op::Char(ch) => grid.write_char(ch),
+                Op::Cell(c) => grid.write_cell(c),
                 Op::SetSpeed(rate) => self.chars_per_second = rate,
             }
         }


### PR DESCRIPTION
Big batch of additions to `macroquad-tui`, accumulated across the `uap-terminal` game/viewer work. Nine commits, ~1.7K insertions, all additive — no breaking changes to anything the previous revision shipped.

## What's new

### Scene framework (`scene.rs`)
- `Scene` trait + `SceneStack` for pushable/poppable game and overlay scenes on top of a base scene. `update`/`render`/`grid`/`on_enter`/`on_exit` with `SceneOutcome::{Continue, Exit, Push, Replace}`.
- `SceneCtx` wraps per-frame inputs (`SceneInput`) and time.
- `SceneInput::capture()` snapshots keys + chars + mouse once per frame so scenes don't re-poll macroquad's input state. Watch list covers arrows + modifiers + F1–F10 + the full A–Z letter range for hotkey use.
- `FixedStep` helper for fixed-tick game logic (Snake, Tetris-style).

### Tier 3 cell renderer (`render.rs`)
- `paint_cell` + `paint_grid` actually use `Cell::bg` and `Cell::attrs` (earlier consumers ignored them). `INVERSE` swaps fg/bg; `BLINK` gates at ~1.5 Hz; `DIM` × 0.6; `BOLD` × 1.2.
- `GridMetrics::measure` derives `cell_w` / `cell_h` / baseline from the chosen font for `(row, col) → pixel` mapping.

### Tier 4 half-block canvas (`half_block.rs`)
- `HalfBlockCanvas` — 2× vertical-resolution "pixel" canvas using `▀ ▄ █`. Each char cell carries one top + one bottom subpixel, encoded into the right glyph + fg/bg pair via `encode_pair`.
- Suits sprites, persona portraits, maps, animated logos — anywhere you want pixel-art density inside the same character grid.

### Sharded sprite atlas (`sprite_atlas.rs`)
- `ShardedAtlas` — generic lazy-loaded multi-file image atlas keyed by string. Index JSON maps each key to `[shard_id, col, row]`; shards fetch on-demand via `macroquad::texture::load_image` inside coroutines, cached per-shard once loaded.
- `AtlasSlot::{Ready, Pending, Missing}` makes the "shard not yet loaded" case explicit so scenes can render a placeholder.
- `tick()` polls in-flight loads each frame; `prefetch(shard_id)` for browse-mode preloads.
- Wire format documented inline. Shard URL formatting is a closure passed at construction so projects can plug in their own naming convention.

### Cell-grid sprite primitives (`sprite.rs`)
- `CellSprite` — `width × height` rectangle of `Option<Cell>` (None = transparent).
- `CellSprite::from_ascii` parses multi-line strings (`'.'` and space transparent, anything else opaque) for hand-rolled art.
- `paint(grid, top_row, left_col)` stamps into a `Grid`, respecting transparency and clipping off-screen portions.
- `SpriteSheet` — named collection wrapper around `HashMap<String, CellSprite>` for scenes that want a declarative sprite table.

### Scrollback-capable `Grid` (`grid.rs`)
- `Grid` rebuilt around `VecDeque<Vec<Cell>>` with viewport offset; `scroll_up` / `scroll_down` / `scroll_to_top` / `scroll_to_bottom` / `is_scrolled` / `scrollback_above` / `scrollback_below`.
- `put_at(row, col, cell)` for random-access cell writes (used by Snake / Tetris / map plotting).
- `write_cell` for pre-styled cells at the cursor; complements `write_char` which keeps the existing default-fg behaviour.
- `Cell` gains `bg: Color` + `attrs: CellAttrs` bitfield (`PLAIN`/`BOLD`/`DIM`/`BLINK`/`INVERSE`) and `Debug`.

### TypeQueue cell ops (`typer.rs`)
- `enqueue_cell(Cell)` and `enqueue_cell_line(&[Cell])` so the typewriter can stream pre-styled rows inline with plain `enqueue_line` calls. Each cell counts as one character of progress.

### Palette module (`palette.rs`)
- Canonical 16-colour EGA palette (`BLACK`, `BLUE`, `GREEN`, `CYAN`, `RED`, `MAGENTA`, `BROWN`, `LIGHT_GRAY`, dark/bright pairs, etc.) + `EGA_16` array for indexed rendering. Pure constants, no logic.

## Re-exports

All new top-level types are re-exported from the crate root:

```rust
pub use grid::{Cell, CellAttrs, Grid};
pub use half_block::{encode_pair, HalfBlockCanvas};
pub use render::{paint_cell, paint_grid, GridMetrics};
pub use scene::{FixedStep, Scene, SceneCtx, SceneInput, SceneOutcome, SceneStack};
pub use sprite::{CellSprite, SpriteSheet};
pub use sprite_atlas::{AtlasSlot, ShardedAtlas};
pub use typer::TypeQueue;
```

## Test plan

- [ ] `cargo test -p macroquad-tui` — 45 unit tests pass (Grid scrollback, half-block encoding, sprite parse/paint, sprite-atlas index, scene FixedStep, render scaling, etc.)
- [ ] `cargo clippy -p macroquad-tui -- -D warnings` — clean
- [ ] Downstream `uap-terminal` builds native + `wasm32-unknown-unknown` against this branch (via [patch] override) and its 60 tests pass

## Dependencies

- Added `serde = { version = "1", features = ["derive"] }` + `serde_json = "1"` to `macroquad-tui` for `ShardedAtlas` index parsing. Both already in the workspace tree.

## Out of scope / next

- Half-block pixel sprites — `HalfBlockCanvas` provides the render primitive; defer the sprite-layer convenience type until a pixel-art game lands.
- Sprite animation frames — add when a game needs cyclic art.
- Extracting the viewer's bezel/scanlines/static effect layer into a reusable "chrome" helper — natural follow-up once we have a second consumer.