### PR TITLE
feature: minting-portal widgets + collection-card overhaul + tx-size guards

### DIFF
--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -1545,49 +1545,4 @@ mod tests {
             best.1
         );
     }
-
-    /// A REAL on-chain-art piece (`test_data/sentience.json`, 15,281-byte
-    /// CIP-25 metadata — a generative HTML/canvas piece chunked per CIP-25)
-    /// plus the inline distribution's payout outputs must fit the 16,384-byte
-    /// tx limit. This is the production question behind the spikes above:
-    /// given the artist's `max_size = 15400` metadata budget, do our
-    /// platform + founder payouts still fit? Guards against art-size creep
-    /// silently eating the payout budget.
-    #[test]
-    fn real_onchain_art_with_inline_payouts_fits_tx_limit() {
-        const MAX_TX: usize = 16384;
-
-        let raw = include_str!("test_data/sentience.json");
-        let md: serde_json::Value = serde_json::from_str(raw).expect("sample metadata parses");
-
-        let aux = crate::metadata::cip25::build_cip25_auxiliary_data(&md)
-            .expect("real art metadata builds aux_data");
-        eprintln!(
-            "sentience.json: {} bytes JSON -> {} bytes on-chain aux_data ({:.1}% of {MAX_TX})",
-            raw.len(),
-            aux.len(),
-            aux.len() as f64 / MAX_TX as f64 * 100.0,
-        );
-
-        eprintln!("payouts | signed tx bytes | headroom");
-        for n in 0..=8 {
-            let size = inline_signed_tx_size(&md, n);
-            eprintln!("   {n}    |     {size:>6}    |  {}", MAX_TX as i64 - size as i64);
-        }
-
-        // Realistic inline distribution: refund-to-buyer + platform + 2 founders.
-        let realistic = inline_signed_tx_size(&md, 4);
-        assert!(
-            realistic < MAX_TX,
-            "real art ({} B JSON) + 4 inline payout outputs = {realistic} B, exceeds {MAX_TX} — \
-             distributions do NOT fit at this art size",
-            raw.len(),
-        );
-        // And there's room for at least the realistic shape with margin.
-        assert!(
-            MAX_TX - realistic >= 100,
-            "only {} B headroom over the limit with 4 payouts — too tight; art is crowding payouts",
-            MAX_TX - realistic,
-        );
-    }
 }

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -1364,4 +1364,185 @@ mod tests {
         );
         assert!(matches!(result, Err(TxBuildError::BuildFailed(_))));
     }
+
+    // ── Inline-distribution size spike ────────────────────────────────────
+    //
+    // Foundational check for the settle-as-you-mint pivot
+    // (docs/design/INLINE_MINT_DISTRIBUTION.md): does a single on-chain-art
+    // mint — metadata near the ~15 KB ceiling — still fit under the 16384-byte
+    // Cardano tx limit once we add the artist/platform payout outputs to the
+    // delivery tx? The payout outputs are pure-ADA, byte-identical to the
+    // builder's `refund_outputs`, so we measure with those.
+
+    /// CIP-25 metadata sized near the on-chain-art ceiling. Large generative
+    /// data is stored as an array of ≤64-byte string chunks per CIP-25.
+    fn art_metadata(n_chunks: usize) -> serde_json::Value {
+        use serde_json::{Map, Value};
+        // 60-char chunk (safely ≤ 64-byte metadatum limit).
+        let chunk = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab";
+        let src: Vec<Value> = (0..n_chunks)
+            .map(|_| Value::String(chunk.to_string()))
+            .collect();
+        let mut asset = Map::new();
+        asset.insert("name".into(), Value::String("On-Chain Art Piece #1".into()));
+        asset.insert("mediaType".into(), Value::String("image/svg+xml".into()));
+        asset.insert("artist".into(), Value::String("CM_GenArt".into()));
+        asset.insert("src".into(), Value::Array(src));
+        let mut by_asset = Map::new();
+        by_asset.insert("ArtPiece001".into(), Value::Object(asset));
+        let mut by_policy = Map::new();
+        by_policy.insert(
+            "9ad4da1c6da54e41ecbab2758323f1abcc7b6e6643f5b930065fcb29".into(),
+            Value::Object(by_asset),
+        );
+        let mut root = Map::new();
+        root.insert("721".into(), Value::Object(by_policy));
+        Value::Object(root)
+    }
+
+    /// Build + sign an inline mint: 1 payment input, mint 1 NFT to the buyer,
+    /// `n_payouts` pure-ADA payout outputs (refund + platform + founders),
+    /// change, and the art metadata. Returns the **signed** tx byte length.
+    fn inline_signed_tx_size(metadata: &serde_json::Value, n_payouts: usize) -> usize {
+        let deps = super::super::TxDeps {
+            utxos: vec![UtxoApi {
+                tx_hash: "a".repeat(64),
+                output_index: 0,
+                lovelace: 200_000_000, // the buyer's payment — covers everything
+                assets: vec![],
+                tags: vec![],
+            }],
+            params: test_params(),
+            from_address: test_address(),
+            network_id: 0,
+        };
+        let mints = vec![MintRecipientEntry {
+            asset_name: "ArtPiece001".to_string(),
+            quantity: 1,
+            recipient: test_recipient(1),
+        }];
+        let payouts: Vec<(Address, u64)> = (0..n_payouts)
+            .map(|i| (test_recipient(100 + i as u8), 2_000_000))
+            .collect();
+        let (unsigned, _change) = build_cip25_mint_multi_with_change_and_refunds(
+            &deps,
+            &test_policy(),
+            &mints,
+            Some(metadata),
+            None,
+            None,
+            &payouts,
+        )
+        .expect("inline mint builds");
+        let sk = pallas_crypto::key::ed25519::SecretKey::from([1u8; 32]);
+        let signed = unsigned.build_and_sign(&sk).expect("sign");
+        signed.tx_cbor_hex.len() / 2 // hex → bytes
+    }
+
+    #[test]
+    fn spike_inline_distribution_15kb_metadata_fits_tx_limit() {
+        const MAX_TX: usize = 16384;
+
+        // ~14.9 KB of metadata — at the observed on-chain-art ceiling.
+        let md = art_metadata(240);
+        let aux = crate::metadata::cip25::build_cip25_auxiliary_data(&md).unwrap();
+        eprintln!(
+            "metadata aux_data: {} bytes ({:.1}% of {MAX_TX})",
+            aux.len(),
+            aux.len() as f64 / MAX_TX as f64 * 100.0
+        );
+        assert!(
+            (13_500..=15_800).contains(&aux.len()),
+            "metadata not in the representative ~15KB range: {} bytes",
+            aux.len()
+        );
+
+        eprintln!("payouts | signed tx bytes | headroom");
+        for n in 0..=8 {
+            let size = inline_signed_tx_size(&md, n);
+            eprintln!(
+                "   {n}    |     {size:>6}    |  {}",
+                MAX_TX as i64 - size as i64
+            );
+        }
+
+        // The realistic inline case: refund-to-buyer + platform + 2 founders.
+        let realistic = inline_signed_tx_size(&md, 4);
+        assert!(
+            realistic < MAX_TX,
+            "inline mint with 4 payout outputs + ~15KB metadata = {realistic} bytes, \
+             exceeds the {MAX_TX} limit — the pivot's headroom assumption is wrong"
+        );
+    }
+
+    /// How much metadata fits with the *minimal* inline distribution — a
+    /// single payout output (one artist) and platform fees waived (no
+    /// platform output). Sweeps metadata up until the signed tx would exceed
+    /// the limit and reports the largest that fits.
+    #[test]
+    fn spike_max_metadata_single_payout_fee_waived() {
+        const MAX_TX: usize = 16384;
+
+        // Build helper that returns None if the tx won't build / serialise.
+        fn try_size(metadata: &serde_json::Value, n_payouts: usize) -> Option<usize> {
+            let deps = super::super::TxDeps {
+                utxos: vec![UtxoApi {
+                    tx_hash: "a".repeat(64),
+                    output_index: 0,
+                    lovelace: 200_000_000,
+                    assets: vec![],
+                    tags: vec![],
+                }],
+                params: test_params(),
+                from_address: test_address(),
+                network_id: 0,
+            };
+            let mints = vec![MintRecipientEntry {
+                asset_name: "ArtPiece001".to_string(),
+                quantity: 1,
+                recipient: test_recipient(1),
+            }];
+            let payouts: Vec<(Address, u64)> = (0..n_payouts)
+                .map(|i| (test_recipient(100 + i as u8), 2_000_000))
+                .collect();
+            let (unsigned, _) = build_cip25_mint_multi_with_change_and_refunds(
+                &deps,
+                &test_policy(),
+                &mints,
+                Some(metadata),
+                None,
+                None,
+                &payouts,
+            )
+            .ok()?;
+            let sk = pallas_crypto::key::ed25519::SecretKey::from([1u8; 32]);
+            let signed = unsigned.build_and_sign(&sk).ok()?;
+            Some(signed.tx_cbor_hex.len() / 2)
+        }
+
+        let mut best = (0usize, 0usize, 0usize); // (chunks, metadata_bytes, tx_bytes)
+        for chunks in (220..420).step_by(1) {
+            let md = art_metadata(chunks);
+            let aux = match crate::metadata::cip25::build_cip25_auxiliary_data(&md) {
+                Ok(a) => a,
+                Err(_) => break,
+            };
+            match try_size(&md, 1) {
+                Some(tx) if tx < MAX_TX => best = (chunks, aux.len(), tx),
+                _ => break,
+            }
+        }
+        eprintln!(
+            "single payout + fee waived: max metadata = {} bytes (signed tx {}, {} chunks, {} bytes spare)",
+            best.1,
+            best.2,
+            best.0,
+            MAX_TX - best.2,
+        );
+        assert!(
+            best.1 >= 15_000,
+            "expected to fit well over 15KB, got {}",
+            best.1
+        );
+    }
 }

--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -1545,4 +1545,49 @@ mod tests {
             best.1
         );
     }
+
+    /// A REAL on-chain-art piece (`test_data/sentience.json`, 15,281-byte
+    /// CIP-25 metadata — a generative HTML/canvas piece chunked per CIP-25)
+    /// plus the inline distribution's payout outputs must fit the 16,384-byte
+    /// tx limit. This is the production question behind the spikes above:
+    /// given the artist's `max_size = 15400` metadata budget, do our
+    /// platform + founder payouts still fit? Guards against art-size creep
+    /// silently eating the payout budget.
+    #[test]
+    fn real_onchain_art_with_inline_payouts_fits_tx_limit() {
+        const MAX_TX: usize = 16384;
+
+        let raw = include_str!("test_data/sentience.json");
+        let md: serde_json::Value = serde_json::from_str(raw).expect("sample metadata parses");
+
+        let aux = crate::metadata::cip25::build_cip25_auxiliary_data(&md)
+            .expect("real art metadata builds aux_data");
+        eprintln!(
+            "sentience.json: {} bytes JSON -> {} bytes on-chain aux_data ({:.1}% of {MAX_TX})",
+            raw.len(),
+            aux.len(),
+            aux.len() as f64 / MAX_TX as f64 * 100.0,
+        );
+
+        eprintln!("payouts | signed tx bytes | headroom");
+        for n in 0..=8 {
+            let size = inline_signed_tx_size(&md, n);
+            eprintln!("   {n}    |     {size:>6}    |  {}", MAX_TX as i64 - size as i64);
+        }
+
+        // Realistic inline distribution: refund-to-buyer + platform + 2 founders.
+        let realistic = inline_signed_tx_size(&md, 4);
+        assert!(
+            realistic < MAX_TX,
+            "real art ({} B JSON) + 4 inline payout outputs = {realistic} B, exceeds {MAX_TX} — \
+             distributions do NOT fit at this art size",
+            raw.len(),
+        );
+        // And there's room for at least the realistic shape with margin.
+        assert!(
+            MAX_TX - realistic >= 100,
+            "only {} B headroom over the limit with 4 payouts — too tight; art is crowding payouts",
+            MAX_TX - realistic,
+        );
+    }
 }

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -50,6 +50,7 @@ mod app {
         TxEstimate,
         WalletAssetPicker,
         UtxoMap,
+        ManagedWalletUtxos,
         // DEX split swap
         SlippageSelector,
         AmountInput,
@@ -130,6 +131,7 @@ mod app {
                 Self::TxEstimate,
                 Self::WalletAssetPicker,
                 Self::UtxoMap,
+                Self::ManagedWalletUtxos,
                 // DEX split swap
                 Self::SlippageSelector,
                 Self::AmountInput,
@@ -196,6 +198,7 @@ mod app {
                 Self::TxEstimate => "TX Estimate",
                 Self::WalletAssetPicker => "Wallet Asset Picker",
                 Self::UtxoMap => "UTxO Shelf",
+                Self::ManagedWalletUtxos => "Managed Wallet UTxOs",
                 Self::SlippageSelector => "Slippage Selector",
                 Self::AmountInput => "Amount Input",
                 Self::SplitAllocationBar => "Split Allocation Bar",
@@ -263,6 +266,7 @@ mod app {
                 | Self::TxEstimate
                 | Self::WalletAssetPicker => "Trade Desk",
                 Self::UtxoMap
+                | Self::ManagedWalletUtxos
                 | Self::WalletIdentityHeader
                 | Self::PersonaStrip
                 | Self::FungiblesRow => "Wallet",
@@ -362,6 +366,9 @@ mod app {
                 }
                 Self::UtxoMap => {
                     "UTxO health shelving unit: classify UTxOs into Collateral, Liquid, Clean, Cluttered, Bloated, Dust tiers"
+                }
+                Self::ManagedWalletUtxos => {
+                    "Role-aware UTxO breakdown for a custodial wallet: spendable ADA vs flagged asset-bearing (minted-to-self / stray) UTxOs"
                 }
                 Self::SlippageSelector => {
                     "Preset slippage buttons + custom input mode with high/low warnings"
@@ -501,6 +508,7 @@ mod app {
         trade_table_state: stories::trade_table::TradeTableStoryState,
         wallet_asset_picker_state: stories::wallet_asset_picker::WalletAssetPickerStoryState,
         utxo_map_state: stories::utxo_map::UtxoMapStoryState,
+        managed_wallet_utxos_state: stories::managed_wallet_utxos::ManagedWalletUtxosStoryState,
         // DEX split swap
         slippage_selector_state: stories::slippage_selector::SlippageSelectorStoryState,
         amount_input_state: stories::amount_input::AmountInputStoryState,
@@ -588,6 +596,8 @@ mod app {
                 wallet_asset_picker_state:
                     stories::wallet_asset_picker::WalletAssetPickerStoryState::default(),
                 utxo_map_state: stories::utxo_map::UtxoMapStoryState::default(),
+                managed_wallet_utxos_state:
+                    stories::managed_wallet_utxos::ManagedWalletUtxosStoryState::default(),
                 slippage_selector_state:
                     stories::slippage_selector::SlippageSelectorStoryState::default(),
                 amount_input_state: stories::amount_input::AmountInputStoryState::default(),
@@ -770,6 +780,10 @@ mod app {
                                 &mut self.utxo_map_state,
                                 &mut self.wallet_btn,
                                 &mut self.wallet_connector,
+                            ),
+                            Story::ManagedWalletUtxos => stories::managed_wallet_utxos::show(
+                                ui,
+                                &mut self.managed_wallet_utxos_state,
                             ),
                             // DEX split swap
                             Story::SlippageSelector => stories::slippage_selector::show(

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -51,6 +51,7 @@ mod app {
         WalletAssetPicker,
         UtxoMap,
         ManagedWalletUtxos,
+        DistributionWaterfall,
         // DEX split swap
         SlippageSelector,
         AmountInput,
@@ -132,6 +133,7 @@ mod app {
                 Self::WalletAssetPicker,
                 Self::UtxoMap,
                 Self::ManagedWalletUtxos,
+                Self::DistributionWaterfall,
                 // DEX split swap
                 Self::SlippageSelector,
                 Self::AmountInput,
@@ -199,6 +201,7 @@ mod app {
                 Self::WalletAssetPicker => "Wallet Asset Picker",
                 Self::UtxoMap => "UTxO Shelf",
                 Self::ManagedWalletUtxos => "Managed Wallet UTxOs",
+                Self::DistributionWaterfall => "Distribution Waterfall",
                 Self::SlippageSelector => "Slippage Selector",
                 Self::AmountInput => "Amount Input",
                 Self::SplitAllocationBar => "Split Allocation Bar",
@@ -267,6 +270,7 @@ mod app {
                 | Self::WalletAssetPicker => "Trade Desk",
                 Self::UtxoMap
                 | Self::ManagedWalletUtxos
+                | Self::DistributionWaterfall
                 | Self::WalletIdentityHeader
                 | Self::PersonaStrip
                 | Self::FungiblesRow => "Wallet",
@@ -369,6 +373,9 @@ mod app {
                 }
                 Self::ManagedWalletUtxos => {
                     "Role-aware UTxO breakdown for a custodial wallet: spendable ADA vs flagged asset-bearing (minted-to-self / stray) UTxOs"
+                }
+                Self::DistributionWaterfall => {
+                    "How a buyer's payment flows to each party (gross → fees → distributable → split), across Projected / Live / Final modes"
                 }
                 Self::SlippageSelector => {
                     "Preset slippage buttons + custom input mode with high/low warnings"
@@ -509,6 +516,8 @@ mod app {
         wallet_asset_picker_state: stories::wallet_asset_picker::WalletAssetPickerStoryState,
         utxo_map_state: stories::utxo_map::UtxoMapStoryState,
         managed_wallet_utxos_state: stories::managed_wallet_utxos::ManagedWalletUtxosStoryState,
+        distribution_waterfall_state:
+            stories::distribution_waterfall::DistributionWaterfallStoryState,
         // DEX split swap
         slippage_selector_state: stories::slippage_selector::SlippageSelectorStoryState,
         amount_input_state: stories::amount_input::AmountInputStoryState,
@@ -598,6 +607,8 @@ mod app {
                 utxo_map_state: stories::utxo_map::UtxoMapStoryState::default(),
                 managed_wallet_utxos_state:
                     stories::managed_wallet_utxos::ManagedWalletUtxosStoryState::default(),
+                distribution_waterfall_state:
+                    stories::distribution_waterfall::DistributionWaterfallStoryState::default(),
                 slippage_selector_state:
                     stories::slippage_selector::SlippageSelectorStoryState::default(),
                 amount_input_state: stories::amount_input::AmountInputStoryState::default(),
@@ -784,6 +795,10 @@ mod app {
                             Story::ManagedWalletUtxos => stories::managed_wallet_utxos::show(
                                 ui,
                                 &mut self.managed_wallet_utxos_state,
+                            ),
+                            Story::DistributionWaterfall => stories::distribution_waterfall::show(
+                                ui,
+                                &mut self.distribution_waterfall_state,
                             ),
                             // DEX split swap
                             Story::SlippageSelector => stories::slippage_selector::show(

--- a/ui/_storybook-egui/src/stories/collection_list.rs
+++ b/ui/_storybook-egui/src/stories/collection_list.rs
@@ -62,6 +62,7 @@ fn row(
         archived_at: None,
         deposit_address: None,
         deposit_address_short: None,
+        deposit_account_index: None,
         ingest_payment_open: false,
         scan_payments_in_flight: false,
     }
@@ -577,7 +578,9 @@ fn capture_actions(actions: Vec<CollectionListAction>, state: &mut CollectionLis
             | CollectionListAction::Unarchive { policy_id }
             | CollectionListAction::IngestPayment { policy_id }
             | CollectionListAction::ScanPayments { policy_id }
-            | CollectionListAction::Configure { policy_id } => {
+            | CollectionListAction::Configure { policy_id }
+            | CollectionListAction::FundWallet { policy_id }
+            | CollectionListAction::Settlement { policy_id } => {
                 state.last_other = Some(policy_id);
             }
         }

--- a/ui/_storybook-egui/src/stories/distribution_waterfall.rs
+++ b/ui/_storybook-egui/src/stories/distribution_waterfall.rs
@@ -1,0 +1,145 @@
+//! Storybook demo for the DistributionWaterfall widget.
+//!
+//! Shows how a buyer's payment flows down to each party's wallet, across the
+//! three lifecycle modes and from either the manager's or a party's point of
+//! view. The "thin price" toggle reproduces the classic confusion — a 2 ADA
+//! mint where the platform-fee floor eats the whole sale and the artist's
+//! "50%" is 0.
+
+use egui_widgets::{DistributionWaterfall, WaterfallMode, WaterfallParty};
+
+use crate::{ACCENT, BG_MAIN, TEXT_MUTED};
+
+pub struct DistributionWaterfallStoryState {
+    /// 0 = Projected, 1 = Live, 2 = Final.
+    pub mode_idx: usize,
+    /// Highlight the Artist line (a party-dashboard view).
+    pub view_as_artist: bool,
+    /// 2 ADA sale — the platform-fee floor dominates and founders get 0.
+    pub thin_price: bool,
+}
+
+impl Default for DistributionWaterfallStoryState {
+    fn default() -> Self {
+        Self {
+            mode_idx: 0,
+            view_as_artist: true,
+            thin_price: false,
+        }
+    }
+}
+
+fn party(name: &str, bps: u32, lovelace: u64) -> WaterfallParty {
+    WaterfallParty {
+        name: name.to_string(),
+        share_bps: bps,
+        lovelace,
+    }
+}
+
+/// Build a 50/50 waterfall for `sales` sales at `price` lovelace each.
+fn build(
+    price: u64,
+    sales: u64,
+    mode: WaterfallMode,
+    basis: String,
+    highlight: Option<String>,
+) -> DistributionWaterfall {
+    let gross = price * sales;
+    let delivery = 1_500_000 * sales;
+    let network = 400_000 * sales;
+    // 5% of (paid − refund), min 2 ADA, per sale.
+    let platform_per = ((price as u128 * 500 / 10_000) as u64).max(2_000_000);
+    let platform = platform_per * sales;
+    let distributable = gross
+        .saturating_sub(delivery)
+        .saturating_sub(network)
+        .saturating_sub(platform);
+    let founder = distributable / 2;
+    let artist = distributable - founder;
+    DistributionWaterfall {
+        mode,
+        basis,
+        gross_lovelace: gross,
+        delivery_lovelace: delivery,
+        refund_lovelace: 0,
+        network_fee_lovelace: network,
+        platform_fee_lovelace: platform,
+        platform_fee_label: Some("5%, min 2 ADA".to_string()),
+        distributable_lovelace: distributable,
+        parties: vec![
+            party("Founder", 5000, founder),
+            party("Artist", 5000, artist),
+        ],
+        highlight,
+    }
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut DistributionWaterfallStoryState) {
+    ui.label(
+        egui::RichText::new("DistributionWaterfall Widget")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "How a buyer's payment flows down to each party. The artist's \"50%\" is \
+             50% of the distributable — after NFT min-ADA, network fee, and the \
+             platform fee come off the top. Same shape Projected → Live → Final.",
+        )
+        .color(TEXT_MUTED)
+        .size(11.0),
+    );
+    ui.add_space(12.0);
+
+    // Controls
+    ui.horizontal(|ui| {
+        ui.label(egui::RichText::new("Mode:").size(11.0));
+        ui.selectable_value(&mut state.mode_idx, 0, "Projected");
+        ui.selectable_value(&mut state.mode_idx, 1, "Live");
+        ui.selectable_value(&mut state.mode_idx, 2, "Final");
+    });
+    ui.horizontal(|ui| {
+        ui.checkbox(&mut state.view_as_artist, "View as Artist (highlight)");
+        ui.add_space(12.0);
+        ui.checkbox(&mut state.thin_price, "Thin price (2 ADA — floor eats it)");
+    });
+    ui.add_space(12.0);
+
+    let price = if state.thin_price {
+        2_000_000
+    } else {
+        70_000_000
+    };
+    let (mode, sales, basis) = match state.mode_idx {
+        1 => (
+            WaterfallMode::Live,
+            142,
+            "across 142 sales so far".to_string(),
+        ),
+        2 => (WaterfallMode::Final, 500, "across 500 sales".to_string()),
+        _ => (
+            WaterfallMode::Projected,
+            1,
+            format!("per {} ADA sale", price / 1_000_000),
+        ),
+    };
+    let highlight = state.view_as_artist.then(|| "Artist".to_string());
+    let wf = build(price, sales, mode, basis, highlight);
+
+    ui.allocate_ui(egui::vec2(380.0, ui.available_height()), |ui| {
+        egui::Frame::new()
+            .fill(BG_MAIN)
+            .corner_radius(6.0)
+            .inner_margin(12.0)
+            .stroke(egui::Stroke::new(1.0, egui_widgets::theme::BG_HIGHLIGHT))
+            .show(ui, |ui| {
+                wf.show(ui);
+            });
+    });
+
+    ui.add_space(12.0);
+    if ui.button("Reset").clicked() {
+        *state = DistributionWaterfallStoryState::default();
+    }
+}

--- a/ui/_storybook-egui/src/stories/managed_wallet_utxos.rs
+++ b/ui/_storybook-egui/src/stories/managed_wallet_utxos.rs
@@ -1,0 +1,179 @@
+//! Storybook demo for the ManagedWalletUtxos widget.
+//!
+//! Role-aware breakdown of a custodial wallet's UTxOs. The default scenario
+//! mirrors a real unified mint+payments wallet that accidentally minted to
+//! itself: three ADA-only UTxOs (the spendable pool) plus one asset-bearing
+//! UTxO that gets flagged loudly.
+
+use cardano_assets::utxo::{AssetQuantity, UtxoApi};
+use cardano_assets::AssetId;
+use egui_widgets::ManagedWalletUtxos;
+
+use crate::{ACCENT, BG_MAIN, TEXT_MUTED};
+
+pub struct ManagedWalletUtxosStoryState {
+    /// Toggle the "assets are an anomaly" framing (mint wallet vs generic).
+    pub assets_unexpected: bool,
+    /// Include the asset-bearing UTxO (the minted-to-self anomaly).
+    pub show_anomaly: bool,
+    /// Render an empty wallet.
+    pub empty: bool,
+    /// Swap to a fragmented wallet (a scatter of small UTxOs) to show the
+    /// block strip + the "consider consolidating" read.
+    pub fragmented: bool,
+}
+
+impl Default for ManagedWalletUtxosStoryState {
+    fn default() -> Self {
+        Self {
+            assets_unexpected: true,
+            show_anomaly: true,
+            empty: false,
+            fragmented: false,
+        }
+    }
+}
+
+fn pure(tx: &str, idx: u32, lovelace: u64) -> UtxoApi {
+    UtxoApi {
+        tx_hash: tx.to_string(),
+        output_index: idx,
+        lovelace,
+        assets: vec![],
+        tags: vec![],
+    }
+}
+
+/// Asset-bearing UTxO. `names_hex` are CIP-25 asset names as hex — e.g.
+/// `"4b57494331"` decodes to `"KWIC1"` (the widget calls `asset_name()`).
+fn with_nfts(tx: &str, idx: u32, lovelace: u64, policy: &str, names_hex: &[&str]) -> UtxoApi {
+    let assets = names_hex
+        .iter()
+        .map(|h| AssetQuantity {
+            asset_id: AssetId::new_unchecked(policy.to_string(), (*h).to_string()),
+            quantity: 1,
+        })
+        .collect();
+    UtxoApi {
+        tx_hash: tx.to_string(),
+        output_index: idx,
+        lovelace,
+        assets,
+        tags: vec![],
+    }
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut ManagedWalletUtxosStoryState) {
+    ui.label(
+        egui::RichText::new("ManagedWalletUtxos Widget")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "Role-aware UTxO breakdown for a custodial wallet. ADA-only UTxOs are \
+             the spendable mint-funding pool; asset-bearing UTxOs are flagged as an \
+             anomaly (a mint+payments wallet should never hold NFTs — minted-to-self \
+             or stray inventory).",
+        )
+        .color(TEXT_MUTED)
+        .size(11.0),
+    );
+    ui.add_space(12.0);
+
+    // Controls
+    ui.horizontal(|ui| {
+        ui.checkbox(
+            &mut state.assets_unexpected,
+            "Assets unexpected (mint wallet)",
+        );
+        ui.add_space(12.0);
+        ui.checkbox(&mut state.empty, "Empty wallet");
+    });
+    ui.add_enabled_ui(!state.empty, |ui| {
+        ui.checkbox(
+            &mut state.show_anomaly,
+            "Include the minted-to-self UTxO (+2 NFTs)",
+        );
+        ui.checkbox(
+            &mut state.fragmented,
+            "Fragmented wallet (a scatter of small UTxOs)",
+        );
+    });
+    ui.add_space(12.0);
+
+    // Build the scenario. Mirrors the real KWIC mint wallet from testing.
+    let policy = "ce110b50f2b2565e823386574da0659f0c9295aa52b76d37a9eb660e";
+    let utxos: Vec<UtxoApi> = if state.empty {
+        vec![]
+    } else {
+        let mut v = if state.fragmented {
+            // A healthy bank UTxO + a long tail of small payment/change
+            // fragments — trips the consolidation read.
+            let mut frags = vec![pure(
+                "739df5ec0000000000000000000000000000000000006df854",
+                0,
+                140_000_000,
+            )];
+            for i in 0..16u32 {
+                frags.push(pure(
+                    "abcd12340000000000000000000000000000000000009f0011",
+                    i,
+                    1_200_000 + (i as u64 % 4) * 700_000,
+                ));
+            }
+            frags
+        } else {
+            vec![
+                pure(
+                    "739df5ec0000000000000000000000000000000000006df854",
+                    2,
+                    117_667_750,
+                ),
+                pure(
+                    "d0d962d20000000000000000000000000000000000000b063a1",
+                    3,
+                    39_163_625,
+                ),
+                pure(
+                    "d0d962d20000000000000000000000000000000000000b063a1",
+                    7,
+                    68_125_678,
+                ),
+            ]
+        };
+        if state.show_anomaly {
+            // The phantom-order mint delivered 2 NFTs back to the wallet.
+            v.insert(
+                1,
+                with_nfts(
+                    "d0d962d20000000000000000000000000000000000000b063a1",
+                    1,
+                    1_206_800,
+                    policy,
+                    &["4b57494331323334", "4b57494335363738"], // "KWIC1234", "KWIC5678"
+                ),
+            );
+        }
+        v
+    };
+
+    // Widget
+    ui.allocate_ui(egui::vec2(420.0, ui.available_height()), |ui| {
+        egui::Frame::new()
+            .fill(BG_MAIN)
+            .corner_radius(6.0)
+            .inner_margin(12.0)
+            .stroke(egui::Stroke::new(1.0, egui_widgets::theme::BG_HIGHLIGHT))
+            .show(ui, |ui| {
+                ManagedWalletUtxos::new(&utxos)
+                    .assets_unexpected(state.assets_unexpected)
+                    .show(ui);
+            });
+    });
+
+    ui.add_space(12.0);
+    if ui.button("Reset").clicked() {
+        *state = ManagedWalletUtxosStoryState::default();
+    }
+}

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -4,6 +4,7 @@ pub mod buttons;
 pub mod card_browser;
 pub mod collection_list;
 pub mod distribution;
+pub mod distribution_waterfall;
 pub mod flip_counter;
 pub mod formatting;
 pub mod icon_gallery;

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -47,6 +47,7 @@ pub mod image_text_editor;
 pub mod asset_strip;
 pub mod coverage_delta_bar;
 pub mod fee_report;
+pub mod managed_wallet_utxos;
 pub mod signing_status;
 pub mod trade_table;
 pub mod trait_delta;

--- a/ui/_storybook-egui/src/stories/printing_timeline.rs
+++ b/ui/_storybook-egui/src/stories/printing_timeline.rs
@@ -158,7 +158,7 @@ pub fn show(ui: &mut egui::Ui, demo: &mut PrintingTimelineDemo) {
         ..PrintingTimelineConfig::default()
     };
 
-    let resp = egui_widgets::printing_timeline::show(ui, &mut demo.state, &demo.nodes, &config);
+    let _ = egui_widgets::printing_timeline::show(ui, &mut demo.state, &demo.nodes, &config);
 
     // Show selection info below timeline
     ui.add_space(8.0);

--- a/ui/_storybook-egui/src/stories/toast.rs
+++ b/ui/_storybook-egui/src/stories/toast.rs
@@ -81,9 +81,9 @@ pub fn show(ui: &mut egui::Ui, state: &mut ToastState) {
     );
     ui.add_space(6.0);
     if IdPill::new("policy", &state.demo_policy).show(ui).copied {
-        state
-            .queue
-            .push(Toast::new("policy copied to clipboard", ToastKind::Info).icon(PhosphorIcon::Copy));
+        state.queue.push(
+            Toast::new("policy copied to clipboard", ToastKind::Info).icon(PhosphorIcon::Copy),
+        );
     }
 
     ui.add_space(16.0);
@@ -108,14 +108,13 @@ pub fn show(ui: &mut egui::Ui, state: &mut ToastState) {
     ui.horizontal(|ui| {
         if ui.button("Long-lived").clicked() {
             state.queue.push(
-                Toast::new("This one stays for 10 seconds", ToastKind::Info)
-                    .duration_frames(600),
+                Toast::new("This one stays for 10 seconds", ToastKind::Info).duration_frames(600),
             );
         }
         if ui.button("Custom icon").clicked() {
-            state.queue.push(
-                Toast::new("Shipping", ToastKind::Success).icon(PhosphorIcon::Lightning),
-            );
+            state
+                .queue
+                .push(Toast::new("Shipping", ToastKind::Success).icon(PhosphorIcon::Lightning));
         }
         if ui.button("Icon-suppressed").clicked() {
             state

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -217,6 +217,11 @@ pub enum CollectionListAction {
     /// surface for editing phases, gates, and allowlist. Only emitted when
     /// [`CollectionList::with_configure`] is `true`.
     Configure { policy_id: String },
+    /// User clicked the `Settlement` button. Host opens (or focuses) the
+    /// floating Settlement window — treasury config (founder split, float
+    /// targets, fee waiver) + the manual settle trigger. Only emitted when
+    /// [`CollectionList::with_settlement`] is `true`.
+    Settlement { policy_id: String },
 }
 
 /// Rendering style. Both styles share the same row VM and action emission —
@@ -244,6 +249,7 @@ pub struct CollectionList<'a> {
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     hide_archived: bool,
 }
 
@@ -296,6 +302,7 @@ impl<'a> CollectionList<'a> {
             show_archive: false,
             show_payments: false,
             show_configure: false,
+            show_settlement: false,
             hide_archived: false,
         }
     }
@@ -394,6 +401,15 @@ impl<'a> CollectionList<'a> {
         self
     }
 
+    /// Show the per-card `Settlement` button. Off by default. Click →
+    /// emits [`CollectionListAction::Settlement`]; host opens / focuses the
+    /// floating Settlement window for editing treasury config + triggering a
+    /// settlement run.
+    pub fn with_settlement(mut self, enabled: bool) -> Self {
+        self.show_settlement = enabled;
+        self
+    }
+
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
@@ -443,6 +459,7 @@ impl<'a> CollectionList<'a> {
                             self.show_archive,
                             self.show_payments,
                             self.show_configure,
+                            self.show_settlement,
                             &mut response,
                         );
                     }
@@ -460,6 +477,7 @@ impl<'a> CollectionList<'a> {
                                 self.show_archive,
                                 self.show_payments,
                                 self.show_configure,
+                                self.show_settlement,
                                 &mut response,
                             );
                         }
@@ -509,6 +527,7 @@ fn render_one(
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
@@ -522,6 +541,7 @@ fn render_one(
             show_archive,
             show_payments,
             show_configure,
+            show_settlement,
             response,
         ),
         CollectionListLayout::List => render_list_row(
@@ -534,6 +554,7 @@ fn render_one(
             show_archive,
             show_payments,
             show_configure,
+            show_settlement,
             response,
         ),
     }
@@ -550,6 +571,7 @@ fn render_card(
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     response: &mut CollectionListResponse,
 ) {
     // `PhosphorIcon::*.rich_text()` doesn't auto-install the font (unlike
@@ -599,6 +621,7 @@ fn render_card(
                 show_archive,
                 show_payments,
                 show_configure,
+                show_settlement,
                 row,
             ) {
                 ui.add_space(6.0);
@@ -612,6 +635,7 @@ fn render_card(
                     show_archive,
                     show_payments,
                     show_configure,
+                    show_settlement,
                     true, // wrap — Card layout has its own dedicated bar row
                     response,
                 );
@@ -746,6 +770,7 @@ fn render_list_row(
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     response: &mut CollectionListResponse,
 ) {
     // `PhosphorIcon::*.rich_text()` doesn't auto-install the font (unlike
@@ -816,6 +841,7 @@ fn render_list_row(
                         show_archive,
                         show_payments,
                         show_configure,
+                        show_settlement,
                         false, // wrap — List layout is single-row by design
                         response,
                     );
@@ -931,6 +957,7 @@ fn has_any_action(
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     row: &CollectionRow,
 ) -> bool {
     show_test_mint
@@ -939,6 +966,7 @@ fn has_any_action(
         || show_archive
         || show_configure
         || show_payments
+        || show_settlement
         // Refuel is a card-only affordance + sits in the wallet sub-line,
         // not the action bar — but the predicate is shared with the bar's
         // visibility check; counting it keeps the bar logic uniform.
@@ -968,6 +996,7 @@ fn render_operator_actions(
     show_archive: bool,
     show_payments: bool,
     show_configure: bool,
+    show_settlement: bool,
     wrap: bool,
     response: &mut CollectionListResponse,
 ) {
@@ -981,6 +1010,7 @@ fn render_operator_actions(
     const ID_SCAN: u64 = 5;
     const ID_SEED_STUBS: u64 = 6;
     const ID_ARCHIVE: u64 = 7;
+    const ID_SETTLEMENT: u64 = 8;
 
     let mut group = ButtonGroup::new().wrap(wrap);
 
@@ -1016,6 +1046,12 @@ fn render_operator_actions(
                      and allowlist entries.",
                 ),
         );
+    }
+    if show_settlement {
+        group = group.add(ButtonGroupButton::new(ID_SETTLEMENT, "Settlement").hover_text(
+            "Open the settlement config — founder distribution split, float \
+             targets, fee waiver — and trigger a settlement run.",
+        ));
     }
     if show_payments {
         let ingest_label = if row.ingest_payment_open {
@@ -1082,6 +1118,9 @@ fn render_operator_actions(
             policy_id: row.policy_id.clone(),
         }),
         Some(ID_CONFIGURE) => Some(CollectionListAction::Configure {
+            policy_id: row.policy_id.clone(),
+        }),
+        Some(ID_SETTLEMENT) => Some(CollectionListAction::Settlement {
             policy_id: row.policy_id.clone(),
         }),
         Some(ID_INGEST) => Some(CollectionListAction::IngestPayment {

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -1094,10 +1094,12 @@ fn render_operator_actions(
         );
     }
     if show_settlement {
-        group = group.add(ButtonGroupButton::new(ID_SETTLEMENT, "Settlement").hover_text(
-            "Open the settlement config — founder distribution split, float \
+        group = group.add(
+            ButtonGroupButton::new(ID_SETTLEMENT, "Settlement").hover_text(
+                "Open the settlement config — founder distribution split, float \
              targets, fee waiver — and trigger a settlement run.",
-        ));
+            ),
+        );
     }
     if show_payments {
         let ingest_label = if row.ingest_payment_open {

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -749,16 +749,16 @@ fn render_card(
                     // browser wallet. The primary action for an empty wallet,
                     // so it leads the controls row (before the fuel state +
                     // Refuel, which only shape funds already present).
-                    if show_fund && row.wallet_address_full.is_some() {
-                        if ui
+                    if show_fund
+                        && row.wallet_address_full.is_some()
+                        && ui
                             .small_button(RichText::new("Fund").small())
                             .on_hover_text("Top up this collection's mint wallet from your wallet")
                             .clicked()
-                        {
-                            response.actions.push(CollectionListAction::FundWallet {
-                                policy_id: row.policy_id.clone(),
-                            });
-                        }
+                    {
+                        response.actions.push(CollectionListAction::FundWallet {
+                            policy_id: row.policy_id.clone(),
+                        });
                     }
                     // Pool badge — same shape as the wallet-list card's
                     // pool pill so the visual is consistent across surfaces.

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -194,6 +194,12 @@ pub enum CollectionListAction {
     /// `pool.health != Healthy`. Widget self-enforces the no-op rule
     /// — host doesn't have to check.
     Refuel { policy_id: String },
+    /// User clicked the per-card "Fund" button on the mint-wallet pill. The
+    /// host opens its top-up flow (fund the collection's mint/fuel wallet
+    /// from the operator's browser wallet). Only emitted when
+    /// [`CollectionList::with_fund`] is `true` and the row has a mint
+    /// wallet address.
+    FundWallet { policy_id: String },
     /// User clicked Archive on an active card. Host soft-archives the
     /// collection (halts its engine DO + hides it). Only emitted when
     /// [`CollectionList::with_archive`] is `true`.
@@ -250,6 +256,7 @@ pub struct CollectionList<'a> {
     show_payments: bool,
     show_configure: bool,
     show_settlement: bool,
+    show_fund: bool,
     hide_archived: bool,
 }
 
@@ -303,6 +310,7 @@ impl<'a> CollectionList<'a> {
             show_payments: false,
             show_configure: false,
             show_settlement: false,
+            show_fund: false,
             hide_archived: false,
         }
     }
@@ -410,6 +418,14 @@ impl<'a> CollectionList<'a> {
         self
     }
 
+    /// Show a "Fund" button on the mint-wallet pill. Off by default. Click →
+    /// emits [`CollectionListAction::FundWallet`]; the host opens its
+    /// browser-wallet top-up flow for the collection's mint/fuel wallet.
+    pub fn with_fund(mut self, enabled: bool) -> Self {
+        self.show_fund = enabled;
+        self
+    }
+
     pub fn show(self, ui: &mut Ui) -> CollectionListResponse {
         let mut response = CollectionListResponse::default();
 
@@ -460,6 +476,7 @@ impl<'a> CollectionList<'a> {
                             self.show_payments,
                             self.show_configure,
                             self.show_settlement,
+                            self.show_fund,
                             &mut response,
                         );
                     }
@@ -478,6 +495,7 @@ impl<'a> CollectionList<'a> {
                                 self.show_payments,
                                 self.show_configure,
                                 self.show_settlement,
+                                self.show_fund,
                                 &mut response,
                             );
                         }
@@ -528,6 +546,7 @@ fn render_one(
     show_payments: bool,
     show_configure: bool,
     show_settlement: bool,
+    show_fund: bool,
     response: &mut CollectionListResponse,
 ) {
     match layout {
@@ -542,6 +561,7 @@ fn render_one(
             show_payments,
             show_configure,
             show_settlement,
+            show_fund,
             response,
         ),
         CollectionListLayout::List => render_list_row(
@@ -572,6 +592,7 @@ fn render_card(
     show_payments: bool,
     show_configure: bool,
     show_settlement: bool,
+    show_fund: bool,
     response: &mut CollectionListResponse,
 ) {
     // `PhosphorIcon::*.rich_text()` doesn't auto-install the font (unlike
@@ -705,7 +726,17 @@ fn render_card(
             // a stacked `IdPill` (labelled, copy-able address frame) with an
             // Inspect button that opens its UTxO panel. The mint pill also
             // carries the fuel-pool badge + Refuel on the controls row.
-            let mint_label = format!("wallet #{}", row.wallet_account_index);
+            // Under settle-as-you-mint the mint wallet IS the payment wallet —
+            // it signs the mint AND receives the buyer's ADA (no separate
+            // deposit address). Label it so the operator knows both roles live
+            // in one wallet. Legacy two-wallet collections (a separate deposit
+            // address is present) keep the plain "mint wallet" label, with the
+            // deposit pill rendered below.
+            let mint_label = if row.deposit_address.is_some() {
+                format!("mint wallet #{}", row.wallet_account_index)
+            } else {
+                format!("mint + payments #{}", row.wallet_account_index)
+            };
             render_wallet_pill(
                 ui,
                 &mint_label,
@@ -714,6 +745,21 @@ fn render_card(
                 Some(row.wallet_account_index),
                 response,
                 |ui, response| {
+                    // Fund — top up the mint/fuel wallet from the operator's
+                    // browser wallet. The primary action for an empty wallet,
+                    // so it leads the controls row (before the fuel state +
+                    // Refuel, which only shape funds already present).
+                    if show_fund && row.wallet_address_full.is_some() {
+                        if ui
+                            .small_button(RichText::new("Fund").small())
+                            .on_hover_text("Top up this collection's mint wallet from your wallet")
+                            .clicked()
+                        {
+                            response.actions.push(CollectionListAction::FundWallet {
+                                policy_id: row.policy_id.clone(),
+                            });
+                        }
+                    }
                     // Pool badge — same shape as the wallet-list card's
                     // pool pill so the visual is consistent across surfaces.
                     if let Some(pool) = &row.pool {

--- a/ui/egui-widgets/src/collection_list.rs
+++ b/ui/egui-widgets/src/collection_list.rs
@@ -62,6 +62,7 @@ use egui::{Color32, CornerRadius, Frame, Margin, RichText, Stroke, Ui};
 
 use crate::button_group::{ButtonGroup, ButtonGroupButton};
 use crate::icons::install_phosphor_font;
+use crate::id_pill::{IdPill, IdPillLayout};
 use crate::wallet_list::{WalletPoolBadge, WalletPoolBadgeHealth};
 use crate::PhosphorIcon;
 
@@ -150,6 +151,13 @@ pub struct CollectionRow {
     /// Pre-truncated `deposit_address` for inline display (caller picks the
     /// prefix/suffix widths). `None` hides the row.
     pub deposit_address_short: Option<String>,
+    /// BIP-44 account index of the collection's deposit wallet (the
+    /// `CollectionDeposit` band — `mint + 100_000`). Carried so the deposit
+    /// address pill can offer an Inspect button that opens that wallet's
+    /// UTxO panel via [`CollectionListAction::OpenWallet`], same as the mint
+    /// wallet. `None` hides the deposit Inspect affordance (legacy rows /
+    /// hosts that haven't wired it).
+    pub deposit_account_index: Option<u32>,
     /// `true` when the parent has the Ingest-payment form open below this
     /// row. Same toggle treatment as `test_mint_open` — `+ Ingest` flips to
     /// `− Ingest`.
@@ -172,8 +180,9 @@ pub enum CollectionListAction {
     /// User clicked the Activity toggle — open/close the recent-mint
     /// activity panel for this `policy_id`.
     Activity { policy_id: String },
-    /// User clicked the `wallet #N` link in the footer. Parent opens
-    /// that wallet's UTxO panel (or whatever it does for wallet focus).
+    /// User clicked an Inspect button on a wallet pill (the mint wallet
+    /// or — when `deposit_account_index` is set — the deposit wallet).
+    /// Parent opens that wallet's UTxO panel.
     OpenWallet { account_index: u32 },
     /// User clicked the per-card "Refuel" button. The host fires a
     /// server-side fan-out tx (keyed by `policy_id` — the collection
@@ -610,6 +619,19 @@ fn render_card(
 
             ui.add_space(8.0);
 
+            // ── Identity: policy_id as a stacked pill, above the supply
+            //    bar. The policy_id is the collection's primary on-chain
+            //    identity (and what `mintctl clone-policy` needs), so it
+            //    leads the body rather than trailing in a footer. The
+            //    stacked `IdPill` gives it a labelled, copy-able frame
+            //    consistent with the wallet/deposit pills below.
+            IdPill::new("policy", &row.policy_id)
+                .layout(IdPillLayout::Stacked)
+                .with_short(row.policy_id_short.clone())
+                .show(ui);
+
+            ui.add_space(10.0);
+
             // ── Supply: text + progress bar ──────────────────────────
             ui.horizontal(|ui| {
                 ui.label(
@@ -650,128 +672,65 @@ fn render_card(
 
             ui.add_space(10.0);
 
-            // ── Wallet sub-line: address + copy + pool badge + Refuel ─
+            // ── Wallets: stacked address pills, each inspectable ──────
             //
-            // The collection card is the primary surface for everything
-            // wallet-shaped that belongs to a collection — address, fuel
-            // level, refuel action. Collection wallets don't appear in
-            // the parent's "Wallets" section anymore, so this sub-line
-            // is the sole place where the operator interacts with the
-            // mint wallet for this collection.
-            //
-            // The `wallet #N` link is kept (left-most) so the
-            // collection-↔-wallet relationship is still visible, and
-            // clicking it still opens that wallet's UTxO panel.
-            ui.horizontal(|ui| {
-                let wallet_text = format!("wallet #{}", row.wallet_account_index);
-                if ui
-                    .small_button(RichText::new(wallet_text).small().color(META_GREY))
-                    .on_hover_text("Open this wallet's UTxOs")
-                    .clicked()
-                {
-                    response.actions.push(CollectionListAction::OpenWallet {
-                        account_index: row.wallet_account_index,
-                    });
-                }
-
-                // Inline address (truncated) + copy icon. The copy is
-                // done in-widget to match the policy_id pattern below
-                // (no host round-trip for a value the row already
-                // carries). Hidden when the row didn't supply one —
-                // older snapshots or wallets without a derived address.
-                if let Some(short) = &row.wallet_address_short {
-                    ui.label(RichText::new("·").color(KEYHASH_GREY).monospace().small());
-                    ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
-                    if let Some(full) = &row.wallet_address_full {
-                        if ui
-                            .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
-                            .on_hover_text("Copy wallet address to clipboard")
-                            .clicked()
-                        {
-                            ui.ctx().copy_text(full.clone());
+            // The collection card is the sole surface for the collection's
+            // wallets (they're filtered out of the parent's "Wallets"
+            // section), so both the **mint** wallet (fuel + minting) and the
+            // **deposit** wallet (where buyers send ADA) live here. Each is
+            // a stacked `IdPill` (labelled, copy-able address frame) with an
+            // Inspect button that opens its UTxO panel. The mint pill also
+            // carries the fuel-pool badge + Refuel on the controls row.
+            let mint_label = format!("wallet #{}", row.wallet_account_index);
+            render_wallet_pill(
+                ui,
+                &mint_label,
+                row.wallet_address_full.as_deref(),
+                row.wallet_address_short.as_deref(),
+                Some(row.wallet_account_index),
+                response,
+                |ui, response| {
+                    // Pool badge — same shape as the wallet-list card's
+                    // pool pill so the visual is consistent across surfaces.
+                    if let Some(pool) = &row.pool {
+                        let fg = match pool.health {
+                            WalletPoolBadgeHealth::Empty => Color32::from_rgb(220, 130, 130),
+                            WalletPoolBadgeHealth::Low => Color32::from_rgb(220, 200, 130),
+                            WalletPoolBadgeHealth::Healthy => Color32::from_rgb(150, 210, 160),
+                        };
+                        let ada_whole = pool.total_lovelace / 1_000_000;
+                        ui.label(
+                            RichText::new(format!("{} fuel · {} ADA", pool.fuel_count, ada_whole))
+                                .small()
+                                .color(fg),
+                        );
+                    }
+                    // Refuel — fan-out tx that splits the wallet's pure-ADA
+                    // balance into N × 10 ADA fuel slots. Self-disables (no
+                    // pool / healthy / in-flight) so the host doesn't re-check.
+                    if show_refuel {
+                        if let Some(pool) = &row.pool {
+                            refuel_button(ui, row, pool, response);
                         }
                     }
-                }
+                },
+            );
 
-                // Pool badge — same shape as the wallet-list card's
-                // pool pill so the visual is consistent across surfaces.
-                if let Some(pool) = &row.pool {
-                    let fg = match pool.health {
-                        WalletPoolBadgeHealth::Empty => Color32::from_rgb(220, 130, 130),
-                        WalletPoolBadgeHealth::Low => Color32::from_rgb(220, 200, 130),
-                        WalletPoolBadgeHealth::Healthy => Color32::from_rgb(150, 210, 160),
-                    };
-                    // Health indicator: the text colour itself carries the
-                    // signal (red/amber/green). The leading `●` glyph used
-                    // to do this here doesn't render in the browser font;
-                    // CLAUDE.md says drop geometric Unicode.
-                    let ada_whole = pool.total_lovelace / 1_000_000;
-                    ui.label(
-                        RichText::new(format!("{} fuel · {} ADA", pool.fuel_count, ada_whole))
-                            .small()
-                            .color(fg),
-                    );
-                }
-
-                // Refuel — fires a server-side fan-out tx that splits
-                // the wallet's pure-ADA balance into N × 10 ADA fuel
-                // slots, priming the wallet for parallel mints. The
-                // widget self-disables in three cases so the host
-                // doesn't have to:
-                //   - no pool snapshot yet — operator can't see fuel
-                //     state, button hidden
-                //   - pool already Healthy — refuel would be a no-op,
-                //     button shown but disabled with explanatory
-                //     hover text
-                //   - refuel already in flight — disabled, label is
-                //     "⛽ Refuelling…" until the host clears the flag
-                if show_refuel {
-                    if let Some(pool) = &row.pool {
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            refuel_button(ui, row, pool, response);
-                        });
-                    }
-                }
-            });
-
-            ui.add_space(4.0);
-
-            // ── Footer: policy_id + copy ────────────────────────────
-            ui.horizontal(|ui| {
-                ui.label(
-                    RichText::new(&row.policy_id_short)
-                        .monospace()
-                        .small()
-                        .color(KEYHASH_GREY),
+            // ── Deposit wallet — only when allocated (legacy rows hide it
+            //    cleanly). Inspectable too: the deposit wallet is a real
+            //    `CollectionDeposit` account, so its Inspect opens the same
+            //    UTxO panel (handy for eyeballing inbound payments).
+            if row.deposit_address.is_some() {
+                ui.add_space(4.0);
+                render_wallet_pill(
+                    ui,
+                    "deposit",
+                    row.deposit_address.as_deref(),
+                    row.deposit_address_short.as_deref(),
+                    row.deposit_account_index,
+                    response,
+                    |_ui, _response| {},
                 );
-                if ui
-                    .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
-                    .on_hover_text("Copy policy_id to clipboard")
-                    .clicked()
-                {
-                    ui.ctx().copy_text(row.policy_id.clone());
-                }
-            });
-
-            // ── Deposit address (where buyers send ADA) — only when
-            //    allocated (legacy rows hide it cleanly). Same shape as
-            //    the policy_id footer: prefix "deposit · " so it's
-            //    self-labelling at a glance, then the short bech32 + copy.
-            if let (Some(short), Some(full)) = (&row.deposit_address_short, &row.deposit_address) {
-                ui.horizontal(|ui| {
-                    ui.label(RichText::new("deposit · ").small().color(META_GREY));
-                    ui.label(RichText::new(short).monospace().small().color(KEYHASH_GREY));
-                    if ui
-                        .small_button(PhosphorIcon::Copy.rich_text(11.0, META_GREY).small())
-                        .on_hover_text(
-                            "Copy this collection's deposit address — \
-                             buyers send ADA here to mint",
-                        )
-                        .clicked()
-                    {
-                        ui.ctx().copy_text(full.clone());
-                    }
-                });
             }
         });
 }
@@ -863,6 +822,53 @@ fn render_list_row(
                 });
             });
         });
+}
+
+/// Render one collection wallet as a stacked `IdPill` (labelled, copy-able
+/// address frame) followed by a controls row: an **Inspect** button that
+/// opens the wallet's UTxO panel (via [`CollectionListAction::OpenWallet`])
+/// plus any caller-supplied controls (`extra` — the mint wallet passes its
+/// pool badge + Refuel; the deposit wallet passes nothing).
+///
+/// - `address_full` / `address_short`: the bech32 address + its pre-elided
+///   form. `None` (legacy rows without a derived address) falls back to just
+///   the label, no pill.
+/// - `account_index`: drives the Inspect button. `None` hides it (the host
+///   hasn't wired a UTxO panel for this wallet).
+fn render_wallet_pill(
+    ui: &mut Ui,
+    label: &str,
+    address_full: Option<&str>,
+    address_short: Option<&str>,
+    account_index: Option<u32>,
+    response: &mut CollectionListResponse,
+    extra: impl FnOnce(&mut Ui, &mut CollectionListResponse),
+) {
+    if let Some(full) = address_full {
+        let mut pill = IdPill::new(label, full).layout(IdPillLayout::Stacked);
+        if let Some(short) = address_short {
+            pill = pill.with_short(short.to_string());
+        }
+        pill.show(ui);
+    } else {
+        ui.label(RichText::new(label).small().color(META_GREY));
+    }
+
+    ui.add_space(2.0);
+    ui.horizontal(|ui| {
+        if let Some(idx) = account_index {
+            if ui
+                .small_button(RichText::new("Inspect").small().color(META_GREY))
+                .on_hover_text("Open this wallet's UTxOs")
+                .clicked()
+            {
+                response
+                    .actions
+                    .push(CollectionListAction::OpenWallet { account_index: idx });
+            }
+        }
+        extra(ui, response);
+    });
 }
 
 /// Shared Refuel button used by both card and list layouts. Owns the

--- a/ui/egui-widgets/src/distribution_waterfall.rs
+++ b/ui/egui-widgets/src/distribution_waterfall.rs
@@ -1,0 +1,327 @@
+//! `DistributionWaterfall` — how a buyer's payment flows down to what lands
+//! in each party's wallet under settle-as-you-mint.
+//!
+//! The recurring confusion: an artist is told "50/50" but sees less, because
+//! 50% is of the **distributable**, not of what the buyer paid — NFT min-ADA,
+//! network fee, and the platform fee come off the top first. This widget makes
+//! that flow legible: a stacked proportion bar (where every lovelace of the
+//! gross goes) over a labelled breakdown (the exact waterfall).
+//!
+//! One widget, three lifecycle modes ([`WaterfallMode`]) and two audiences:
+//! - **Projected** — pre-mint, on a hypothetical sale at the configured price.
+//! - **Live** — during the mint, actuals so far.
+//! - **Final** — ended, a historical artifact.
+//!
+//! The manager passes `highlight = None` (all parties neutral); a party
+//! dashboard passes `highlight = Some(their_name)` to emphasise their slice.
+//!
+//! Pure VM in, nothing computed here beyond layout — the caller builds the
+//! numbers (from `plan_inline_distribution` for a projection, or the recorded
+//! per-tx ledger for actuals).
+
+use egui::{Color32, Pos2, Rect, RichText, Sense, Stroke, StrokeKind, Ui, Vec2};
+
+use crate::theme;
+
+/// Where in its lifecycle the figures come from. Drives the badge + framing
+/// only; the waterfall shape is identical across modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WaterfallMode {
+    /// Pre-mint projection (a hypothetical sale at the configured price).
+    Projected,
+    /// Mid-mint actuals so far.
+    Live,
+    /// Ended — final actuals, a historical artifact.
+    Final,
+}
+
+impl WaterfallMode {
+    fn badge(self) -> (&'static str, Color32) {
+        match self {
+            WaterfallMode::Projected => ("PROJECTED", theme::ACCENT_BLUE),
+            WaterfallMode::Live => ("LIVE", theme::ACCENT_GREEN),
+            WaterfallMode::Final => ("FINAL", theme::TEXT_SECONDARY),
+        }
+    }
+}
+
+/// One distribution party (founder / artist / …).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WaterfallParty {
+    pub name: String,
+    /// Configured basis points of the **distributable** (snapshot).
+    pub share_bps: u32,
+    /// This party's lovelace in this waterfall.
+    pub lovelace: u64,
+}
+
+/// The waterfall view-model. Construct with the figures, then [`show`].
+///
+/// [`show`]: DistributionWaterfall::show
+#[derive(Debug, Clone)]
+pub struct DistributionWaterfall {
+    pub mode: WaterfallMode,
+    /// Free-text basis, e.g. `"per 70 ADA sale"` / `"across 142 sales"`.
+    pub basis: String,
+    /// Buyer payments in scope (the top of the waterfall).
+    pub gross_lovelace: u64,
+    /// NFT min-ADA delivered to buyers (rides the NFT).
+    pub delivery_lovelace: u64,
+    /// Inline overpayment/shortfall refunds returned to buyers.
+    pub refund_lovelace: u64,
+    /// Network (tx) fees.
+    pub network_fee_lovelace: u64,
+    /// Platform fee.
+    pub platform_fee_lovelace: u64,
+    /// Optional snapshot label for the platform fee, e.g. `"5%, min 2 ADA"`.
+    pub platform_fee_label: Option<String>,
+    /// The residual split among the parties.
+    pub distributable_lovelace: u64,
+    pub parties: Vec<WaterfallParty>,
+    /// Party name to emphasise ("your" view); `None` = manager/neutral.
+    pub highlight: Option<String>,
+}
+
+impl DistributionWaterfall {
+    /// Render the waterfall into `ui`.
+    pub fn show(&self, ui: &mut Ui) {
+        // ── Mode badge + basis caption ────────────────────────────
+        ui.horizontal(|ui| {
+            let (txt, col) = self.mode.badge();
+            badge(ui, txt, col);
+            if !self.basis.is_empty() {
+                ui.add_space(4.0);
+                ui.label(RichText::new(&self.basis).small().color(theme::TEXT_MUTED));
+            }
+        });
+        ui.add_space(6.0);
+
+        // ── Stacked proportion bar (full width = gross) ───────────
+        self.render_bar(ui);
+        ui.add_space(8.0);
+
+        // ── Labelled breakdown ────────────────────────────────────
+        self.render_breakdown(ui);
+    }
+
+    /// The colour a deduction / party segment paints in. Parties cycle a
+    /// palette; the highlighted party stays vivid while the rest dim.
+    fn party_color(&self, idx: usize, name: &str) -> Color32 {
+        const PALETTE: [Color32; 5] = [
+            theme::ACCENT_BLUE,
+            theme::ACCENT_MAGENTA,
+            theme::ACCENT_CYAN,
+            theme::ACCENT_GREEN,
+            theme::ACCENT_ORANGE,
+        ];
+        let c = PALETTE[idx % PALETTE.len()];
+        match &self.highlight {
+            Some(h) if h != name => dim(c),
+            _ => c,
+        }
+    }
+
+    fn render_bar(&self, ui: &mut Ui) {
+        let gross = self.gross_lovelace.max(1);
+        let h = 18.0;
+        let width = ui.available_width().max(40.0);
+        let (rect, _) = ui.allocate_exact_size(Vec2::new(width, h), Sense::hover());
+        let painter = ui.painter_at(rect);
+        painter.rect_filled(rect, 3.0, theme::BG_HIGHLIGHT);
+
+        // Segments, in waterfall order. Deductions are muted; the platform
+        // fee amber; parties take the palette.
+        let mut segs: Vec<(u64, Color32)> = Vec::new();
+        if self.delivery_lovelace > 0 {
+            segs.push((self.delivery_lovelace, theme::TEXT_MUTED));
+        }
+        if self.refund_lovelace > 0 {
+            segs.push((self.refund_lovelace, theme::TEXT_SECONDARY));
+        }
+        if self.network_fee_lovelace > 0 {
+            segs.push((self.network_fee_lovelace, theme::TEXT_MUTED));
+        }
+        if self.platform_fee_lovelace > 0 {
+            segs.push((self.platform_fee_lovelace, theme::ACCENT_YELLOW));
+        }
+        for (i, p) in self.parties.iter().enumerate() {
+            segs.push((p.lovelace, self.party_color(i, &p.name)));
+        }
+
+        let mut x = rect.left();
+        for (lov, color) in segs {
+            let w = (lov as f32 / gross as f32) * width;
+            if w <= 0.0 {
+                continue;
+            }
+            let seg = Rect::from_min_size(Pos2::new(x, rect.top()), Vec2::new(w, h));
+            painter.rect_filled(seg, 0.0, color);
+            x += w;
+        }
+        // Thin outline so a near-empty bar still reads as a bar.
+        painter.rect_stroke(
+            rect,
+            3.0,
+            Stroke::new(0.5, theme::BG_HIGHLIGHT),
+            StrokeKind::Inside,
+        );
+    }
+
+    fn render_breakdown(&self, ui: &mut Ui) {
+        // Top line — total received (works across all modes: a single sale
+        // projected, or the aggregate so far / final).
+        line(
+            ui,
+            "Inbound",
+            self.gross_lovelace,
+            theme::TEXT_PRIMARY,
+            true,
+            0.0,
+        );
+
+        // Deductions off the top (skip zero rows).
+        deduction(
+            ui,
+            "NFT min-ADA",
+            "to buyer, rides the NFT",
+            self.delivery_lovelace,
+        );
+        deduction(ui, "Refunds", "back to buyer", self.refund_lovelace);
+        deduction(ui, "Network fee", "", self.network_fee_lovelace);
+        if self.platform_fee_lovelace > 0 {
+            let note = self.platform_fee_label.as_deref().unwrap_or("");
+            deduction(ui, "Platform fee", note, self.platform_fee_lovelace);
+        }
+
+        ui.add_space(2.0);
+        ui.separator();
+        line(
+            ui,
+            "Distributable",
+            self.distributable_lovelace,
+            theme::TEXT_PRIMARY,
+            true,
+            0.0,
+        );
+
+        // Party split — each indented, with their share %, highlighted one
+        // emphasised + a "you" marker.
+        for (i, p) in self.parties.iter().enumerate() {
+            let is_you = self.highlight.as_deref() == Some(p.name.as_str());
+            let color = self.party_color(i, &p.name);
+            ui.horizontal(|ui| {
+                ui.add_space(12.0);
+                let mut name = RichText::new(format!("{}  {}%", p.name, p.share_bps / 100))
+                    .small()
+                    .color(color);
+                if is_you {
+                    name = name.strong();
+                }
+                ui.label(name);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if is_you {
+                        ui.label(RichText::new("you").small().strong().color(theme::ACCENT));
+                        ui.add_space(6.0);
+                    }
+                    let mut amt = RichText::new(format!("{} ADA", ada(p.lovelace)))
+                        .monospace()
+                        .small()
+                        .color(if is_you { theme::TEXT_PRIMARY } else { color });
+                    if is_you {
+                        amt = amt.strong();
+                    }
+                    ui.label(amt);
+                });
+            });
+        }
+    }
+}
+
+// ── Render helpers ──────────────────────────────────────────────────
+
+/// A small filled mode badge.
+fn badge(ui: &mut Ui, text: &str, color: Color32) {
+    egui::Frame::new()
+        .fill(Color32::from_rgba_unmultiplied(
+            color.r(),
+            color.g(),
+            color.b(),
+            36,
+        ))
+        .stroke(Stroke::new(1.0, color))
+        .corner_radius(egui::CornerRadius::same(3))
+        .inner_margin(egui::Margin::symmetric(5, 1))
+        .show(ui, |ui| {
+            ui.label(RichText::new(text).small().strong().color(color));
+        });
+}
+
+/// A `label … amount ADA` row (indented `indent` px, optionally strong).
+fn line(ui: &mut Ui, label: &str, lovelace: u64, color: Color32, strong: bool, indent: f32) {
+    ui.horizontal(|ui| {
+        if indent > 0.0 {
+            ui.add_space(indent);
+        }
+        let mut l = RichText::new(label).small().color(color);
+        if strong {
+            l = l.strong();
+        }
+        ui.label(l);
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let mut a = RichText::new(format!("{} ADA", ada(lovelace)))
+                .monospace()
+                .small()
+                .color(color);
+            if strong {
+                a = a.strong();
+            }
+            ui.label(a);
+        });
+    });
+}
+
+/// An indented `− label (note) … amount` deduction row; skipped when zero.
+fn deduction(ui: &mut Ui, label: &str, note: &str, lovelace: u64) {
+    if lovelace == 0 {
+        return;
+    }
+    ui.horizontal(|ui| {
+        ui.add_space(12.0);
+        let text = if note.is_empty() {
+            format!("- {label}")
+        } else {
+            format!("- {label}  ({note})")
+        };
+        ui.label(RichText::new(text).small().color(theme::TEXT_SECONDARY));
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(
+                RichText::new(format!("{} ADA", ada(lovelace)))
+                    .monospace()
+                    .small()
+                    .color(theme::TEXT_SECONDARY),
+            );
+        });
+    });
+}
+
+/// Lovelace → ADA, 3 decimals (millilovelace precision — plenty for a
+/// distribution report, and tidier than 6 dp on aggregate totals).
+fn ada(lovelace: u64) -> String {
+    format!("{:.3}", lovelace as f64 / 1_000_000.0)
+}
+
+/// Dim a colour for the non-highlighted parties.
+fn dim(c: Color32) -> Color32 {
+    Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), 90)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ada_formats_three_dp() {
+        assert_eq!(ada(32_300_000), "32.300");
+        assert_eq!(ada(0), "0.000");
+    }
+}

--- a/ui/egui-widgets/src/id_pill.rs
+++ b/ui/egui-widgets/src/id_pill.rs
@@ -24,6 +24,8 @@
 //!     .show(ui);
 //! ```
 
+use std::borrow::Cow;
+
 use egui::{Align, Color32, Layout, RichText, Ui};
 
 use crate::icons::{install_phosphor_font, PhosphorIcon};
@@ -50,7 +52,7 @@ pub enum IdPillLayout {
 /// Builder.
 pub struct IdPill<'a> {
     label: Option<&'a str>,
-    value_full: &'a str,
+    value_full: Cow<'a, str>,
     value_short: Option<String>,
     widths: (usize, usize),
     label_min_width: Option<f32>,
@@ -77,7 +79,7 @@ impl<'a> IdPill<'a> {
     pub fn new(label: &'a str, value_full: &'a str) -> Self {
         Self {
             label: Some(label).filter(|s| !s.is_empty()),
-            value_full,
+            value_full: Cow::Borrowed(value_full),
             value_short: None,
             // (10, 8) → 19-char middle-elision: `8532f316dd…45d87a1b`.
             // Reads as a consistent total length across policy_id (56 chars),
@@ -90,6 +92,31 @@ impl<'a> IdPill<'a> {
             layout: IdPillLayout::Stacked,
             label_color: Color32::from_gray(140),
             value_color: Color32::from_gray(220),
+        }
+    }
+
+    /// A pill for a **UTxO reference** — `tx_hash#index`, label-less, in the
+    /// compact [`IdPillLayout::Inline`] shape (suited to a dense UTxO list).
+    /// The copy button writes the canonical `tx_hash#index` (paste into an
+    /// explorer — trim the `#index` — or straight into `cardano-cli`); the
+    /// display middle-elides the hash but keeps the index: `739df5ec…6df854#2`.
+    /// Returns `IdPill<'static>` (it owns the formatted value), so the caller
+    /// can chain builders + `show(ui)` without holding the strings.
+    pub fn utxo_ref(tx_hash: &str, index: u32) -> IdPill<'static> {
+        let full = format!("{tx_hash}#{index}");
+        let short = format!("{}#{index}", truncate_middle(tx_hash, 8, 6));
+        IdPill {
+            label: None,
+            value_full: Cow::Owned(full),
+            value_short: Some(short),
+            widths: (8, 6),
+            label_min_width: None,
+            value_min_width: None,
+            min_width: None,
+            copyable: true,
+            layout: IdPillLayout::Inline,
+            label_color: Color32::from_gray(140),
+            value_color: Color32::from_gray(160),
         }
     }
 
@@ -202,11 +229,9 @@ impl<'a> IdPill<'a> {
         // `allocate_ui_with_layout(vec2(w, 0), …)` carves out exactly
         // `w` of horizontal space for the frame to occupy.
         if let Some(w) = self.min_width {
-            ui.allocate_ui_with_layout(
-                egui::vec2(w, 0.0),
-                Layout::top_down(Align::Min),
-                |ui| self.render_stacked_frame(ui, &mut response, true),
-            );
+            ui.allocate_ui_with_layout(egui::vec2(w, 0.0), Layout::top_down(Align::Min), |ui| {
+                self.render_stacked_frame(ui, &mut response, true)
+            });
         } else {
             self.render_stacked_frame(ui, &mut response, false);
         }
@@ -245,12 +270,8 @@ impl<'a> IdPill<'a> {
                     let copy_budget = if self.copyable { 22.0 } else { 0.0 };
                     let display =
                         self.choose_display_with_budget(ui, ui.available_width() - copy_budget);
-                    ui.label(
-                        RichText::new(display)
-                            .monospace()
-                            .color(self.value_color),
-                    )
-                    .on_hover_text(self.value_full);
+                    ui.label(RichText::new(display).monospace().color(self.value_color))
+                        .on_hover_text(self.value_full.as_ref());
                     if !self.copyable {
                         return;
                     }
@@ -289,9 +310,9 @@ impl<'a> IdPill<'a> {
                     ui.add(label_widget);
                 }
             }
-            let short = self
-                .value_short
-                .unwrap_or_else(|| truncate_middle(self.value_full, self.widths.0, self.widths.1));
+            let short = self.value_short.unwrap_or_else(|| {
+                truncate_middle(self.value_full.as_ref(), self.widths.0, self.widths.1)
+            });
             let value_widget = egui::Label::new(
                 RichText::new(short)
                     .monospace()
@@ -303,7 +324,7 @@ impl<'a> IdPill<'a> {
             } else {
                 ui.add(value_widget)
             };
-            value_resp.on_hover_text(self.value_full);
+            value_resp.on_hover_text(self.value_full.as_ref());
             if self.copyable {
                 install_phosphor_font(ui.ctx());
                 if ui
@@ -344,7 +365,7 @@ impl<'a> IdPill<'a> {
         if full_width <= budget {
             self.value_full.to_string()
         } else {
-            truncate_middle(self.value_full, self.widths.0, self.widths.1)
+            truncate_middle(self.value_full.as_ref(), self.widths.0, self.widths.1)
         }
     }
 }

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -70,6 +70,8 @@ pub mod coverage_delta_bar;
 #[cfg(feature = "cardano")]
 pub mod fee_report;
 #[cfg(feature = "cardano")]
+pub mod managed_wallet_utxos;
+#[cfg(feature = "cardano")]
 pub mod offer_slot;
 #[cfg(feature = "cardano")]
 pub mod signing_status;
@@ -106,7 +108,9 @@ pub use file_upload::{FileUploadButton, UploadedFile};
 pub use flip_counter::FlipCounter;
 pub use fungibles_row::{FungiblesRow, FungiblesRowConfig};
 pub use icons::{install_phosphor_font, PhosphorIcon};
-pub use id_pill::{stacked_width_for as id_pill_stacked_width_for, IdPill, IdPillLayout, IdPillResponse};
+pub use id_pill::{
+    stacked_width_for as id_pill_stacked_width_for, IdPill, IdPillLayout, IdPillResponse,
+};
 pub use image_loader::{iiif_asset_url, AssetImageSize};
 #[cfg(feature = "image-editor")]
 pub use image_text_editor::{
@@ -178,6 +182,8 @@ pub use asset_strip::{AssetStripConfig, AssetStripItem, AssetStripResponse};
 pub use coverage_delta_bar::CoverageDeltaConfig;
 #[cfg(feature = "cardano")]
 pub use fee_report::{FeeReportConfig, FeeReportData, SideFeeData};
+#[cfg(feature = "cardano")]
+pub use managed_wallet_utxos::{ManagedWalletUtxos, UtxoBreakdown, WalletShape};
 #[cfg(feature = "cardano")]
 pub use offer_slot::{OfferSlotAction, OfferSlotConfig, OfferSlotData, OfferSlotResponse};
 #[cfg(feature = "cardano")]

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -7,6 +7,7 @@ pub mod buttons;
 pub mod card_browser;
 pub mod chip;
 pub mod collection_list;
+pub mod distribution_waterfall;
 pub mod donut_chart;
 #[cfg(target_arch = "wasm32")]
 pub mod file_upload;
@@ -100,6 +101,7 @@ pub use collection_list::{
     CollectionList, CollectionListAction, CollectionListLayout, CollectionListResponse,
     CollectionRow,
 };
+pub use distribution_waterfall::{DistributionWaterfall, WaterfallMode, WaterfallParty};
 pub use donut_chart::{
     format_value as format_chart_value, legend_row, DistBand, DistributionChart,
 };

--- a/ui/egui-widgets/src/managed_wallet_utxos.rs
+++ b/ui/egui-widgets/src/managed_wallet_utxos.rs
@@ -1,0 +1,447 @@
+//! Managed-wallet UTxO breakdown — a structured, role-aware view of a
+//! custodial wallet's on-chain UTxOs.
+//!
+//! The unified mint+payments wallet (settle-as-you-mint) should hold **only
+//! ADA**: buyer payments waiting to mint + a small operating float, plus the
+//! change those txs return. It must never hold native assets — an NFT sitting
+//! here means the wallet minted to *itself* (a self-payment bug) or a token
+//! was sent in by mistake. The plain "tx#idx · N ADA · +2 assets" list buried
+//! that distinction (and coloured the assets a cheerful green), so this widget
+//! groups UTxOs by role and flags asset-bearing ones loudly.
+//!
+//! ```ignore
+//! ManagedWalletUtxos::new(&snapshot.utxos)
+//!     .assets_unexpected(true) // a custodial mint+payments wallet
+//!     .show(ui);
+//! ```
+
+use cardano_assets::utxo::UtxoApi;
+use egui::{RichText, Ui};
+
+use crate::theme;
+
+/// Role-aware UTxO breakdown for a managed wallet.
+pub struct ManagedWalletUtxos<'a> {
+    utxos: &'a [UtxoApi],
+    assets_unexpected: bool,
+}
+
+/// An ADA-only UTxO below this reads as "small" — close enough to min-UTxO
+/// that a pile of them just bloats mint-tx inputs without adding useful
+/// spendable balance.
+const SMALL_UTXO_LOVELACE: u64 = 3_000_000;
+/// Spendable-UTxO count at/above which the wallet reads as fragmented.
+const FRAGMENT_COUNT: usize = 12;
+/// Small-UTxO count at/above which the wallet reads as fragmented even with a
+/// modest total count.
+const FRAGMENT_SMALL_COUNT: usize = 5;
+
+/// How consolidated the spendable side of the wallet is. A fragmented mint
+/// wallet matters under settle-as-you-mint: a mint tx must spend several
+/// inputs, and with large on-chain-art metadata (up to ~15 KB) the extra
+/// input bytes can crowd the 16 KB tx-size limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalletShape {
+    /// A handful of UTxOs / ADA concentrated — comfortable to build txs from.
+    Healthy,
+    /// Many UTxOs and/or lots of small ones — consolidation candidate.
+    Fragmented,
+}
+
+/// The pure-vs-asset split + totals — the testable core behind the widget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UtxoBreakdown {
+    /// UTxOs holding only ADA (the spendable mint-funding pool).
+    pub ada_only_count: usize,
+    /// ADA-only UTxOs below [`SMALL_UTXO_LOVELACE`] (dust-ish fragments).
+    pub ada_only_small_count: usize,
+    /// Σ lovelace across the ADA-only UTxOs.
+    pub ada_only_lovelace: u64,
+    /// UTxOs that carry one or more native assets.
+    pub asset_bearing_count: usize,
+    /// Σ lovelace locked in asset-bearing UTxOs (min-UTxO riding the tokens).
+    pub asset_bearing_lovelace: u64,
+    /// Total native tokens across all asset-bearing UTxOs.
+    pub token_count: usize,
+    /// Σ lovelace across every UTxO.
+    pub total_lovelace: u64,
+}
+
+impl UtxoBreakdown {
+    /// Split a wallet's UTxOs into the ADA-only vs asset-bearing buckets.
+    pub fn of(utxos: &[UtxoApi]) -> Self {
+        let mut b = UtxoBreakdown {
+            ada_only_count: 0,
+            ada_only_small_count: 0,
+            ada_only_lovelace: 0,
+            asset_bearing_count: 0,
+            asset_bearing_lovelace: 0,
+            token_count: 0,
+            total_lovelace: 0,
+        };
+        for u in utxos {
+            b.total_lovelace = b.total_lovelace.saturating_add(u.lovelace);
+            if u.assets.is_empty() {
+                b.ada_only_count += 1;
+                if u.lovelace < SMALL_UTXO_LOVELACE {
+                    b.ada_only_small_count += 1;
+                }
+                b.ada_only_lovelace = b.ada_only_lovelace.saturating_add(u.lovelace);
+            } else {
+                b.asset_bearing_count += 1;
+                b.asset_bearing_lovelace = b.asset_bearing_lovelace.saturating_add(u.lovelace);
+                b.token_count += u.assets.len();
+            }
+        }
+        b
+    }
+
+    /// `true` when the wallet holds any native asset.
+    pub fn has_assets(&self) -> bool {
+        self.asset_bearing_count > 0
+    }
+
+    /// Consolidation read on the spendable (ADA-only) side. Heuristic: many
+    /// spendable UTxOs OR several small ones ⇒ [`WalletShape::Fragmented`].
+    pub fn shape(&self) -> WalletShape {
+        if self.ada_only_count >= FRAGMENT_COUNT
+            || self.ada_only_small_count >= FRAGMENT_SMALL_COUNT
+        {
+            WalletShape::Fragmented
+        } else {
+            WalletShape::Healthy
+        }
+    }
+}
+
+impl<'a> ManagedWalletUtxos<'a> {
+    /// New breakdown view. Defaults to treating assets as **unexpected** (the
+    /// custodial mint+payments wallet case); call [`assets_unexpected`] with
+    /// `false` for a generic wallet where holding tokens is normal.
+    ///
+    /// [`assets_unexpected`]: Self::assets_unexpected
+    pub fn new(utxos: &'a [UtxoApi]) -> Self {
+        Self {
+            utxos,
+            assets_unexpected: true,
+        }
+    }
+
+    /// Whether asset-bearing UTxOs should be flagged as an anomaly.
+    pub fn assets_unexpected(mut self, unexpected: bool) -> Self {
+        self.assets_unexpected = unexpected;
+        self
+    }
+
+    /// Render the breakdown into `ui`.
+    pub fn show(self, ui: &mut Ui) {
+        if self.utxos.is_empty() {
+            ui.colored_label(theme::TEXT_MUTED, "No UTxOs at this address.");
+            return;
+        }
+        let b = UtxoBreakdown::of(self.utxos);
+
+        // ── Summary line ──────────────────────────────────────────
+        ui.label(
+            RichText::new(format!(
+                "{} UTxO{} · {} ADA total",
+                self.utxos.len(),
+                plural(self.utxos.len()),
+                ada(b.total_lovelace),
+            ))
+            .color(theme::TEXT_SECONDARY)
+            .small(),
+        );
+        ui.add_space(6.0);
+
+        // ── Visual UTxO strip ─────────────────────────────────────
+        // One block per UTxO, width ∝ lovelace (clamped so tiny ones stay
+        // visible): a glance tells you whether the wallet is a couple of fat
+        // blocks (healthy) or a scatter of thin ones (fragmented). Spendable
+        // = green, asset-bearing = flagged.
+        render_block_strip(ui, self.utxos, self.assets_unexpected);
+
+        // Fragmentation read — only framed as a problem for a custodial mint
+        // wallet, where input bloat fights the on-chain-art tx-size budget.
+        if self.assets_unexpected && b.shape() == WalletShape::Fragmented {
+            let small = if b.ada_only_small_count > 0 {
+                format!(
+                    " ({} under {} ADA)",
+                    b.ada_only_small_count,
+                    SMALL_UTXO_LOVELACE / 1_000_000
+                )
+            } else {
+                String::new()
+            };
+            ui.label(
+                RichText::new(format!(
+                    "⚠ Fragmented — {} spendable UTxOs{small}. A mint tx must spend several as \
+                     inputs; with large on-chain-art metadata that can crowd the 16 KB tx limit. \
+                     Consider consolidating (a Fund/no-op self-send merges them).",
+                    b.ada_only_count,
+                ))
+                .color(theme::ACCENT_YELLOW)
+                .small(),
+            );
+        }
+        ui.add_space(6.0);
+
+        // ── Spendable ADA (the expected contents) ─────────────────
+        ui.label(
+            RichText::new(format!(
+                "Spendable ADA — {} across {} UTxO{}",
+                ada(b.ada_only_lovelace),
+                b.ada_only_count,
+                plural(b.ada_only_count),
+            ))
+            .color(theme::ACCENT_GREEN)
+            .small()
+            .strong(),
+        );
+        if self.assets_unexpected {
+            ui.label(
+                RichText::new(
+                    "Buyer payments + operating float — what funds minting and the inline payouts.",
+                )
+                .color(theme::TEXT_MUTED)
+                .small(),
+            );
+        }
+        ui.add_space(2.0);
+        for u in self.utxos.iter().filter(|u| u.assets.is_empty()) {
+            utxo_ref_row(ui, u);
+        }
+
+        // ── Asset-bearing UTxOs (flagged when unexpected) ─────────
+        if b.has_assets() {
+            ui.add_space(8.0);
+            if self.assets_unexpected {
+                ui.label(
+                    RichText::new(format!(
+                        "⚠ Holds assets — {} UTxO{} carrying {} token{}",
+                        b.asset_bearing_count,
+                        plural(b.asset_bearing_count),
+                        b.token_count,
+                        plural(b.token_count),
+                    ))
+                    .color(theme::ACCENT_RED)
+                    .small()
+                    .strong(),
+                );
+                ui.label(
+                    RichText::new(
+                        "A mint + payments wallet should hold only ADA. Tokens here were most \
+                         likely minted to the wallet itself or sent in by mistake — move or burn \
+                         them so they don't get spent as fee/change.",
+                    )
+                    .color(theme::ACCENT_YELLOW)
+                    .small(),
+                );
+            } else {
+                ui.label(
+                    RichText::new(format!(
+                        "Assets — {} UTxO{}",
+                        b.asset_bearing_count,
+                        plural(b.asset_bearing_count),
+                    ))
+                    .color(theme::TEXT_SECONDARY)
+                    .small()
+                    .strong(),
+                );
+            }
+            ui.add_space(2.0);
+            for u in self.utxos.iter().filter(|u| !u.assets.is_empty()) {
+                utxo_ref_row(ui, u);
+                for aq in &u.assets {
+                    let name = aq.asset_id.asset_name();
+                    let name = if name.trim().is_empty() {
+                        "(no name)".to_string()
+                    } else {
+                        name
+                    };
+                    let qty = if aq.quantity > 1 {
+                        format!(" ×{}", aq.quantity)
+                    } else {
+                        String::new()
+                    };
+                    let color = if self.assets_unexpected {
+                        theme::ACCENT_YELLOW
+                    } else {
+                        theme::TEXT_SECONDARY
+                    };
+                    ui.label(
+                        RichText::new(format!(
+                            "        {name}{qty} · {}",
+                            truncate(&aq.asset_id.policy_id, 10)
+                        ))
+                        .small()
+                        .color(color),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// One block per UTxO, width ∝ lovelace (clamped so tiny ones stay visible),
+/// wrapping across rows. Spendable (ADA-only) blocks first, big→small, in
+/// green; asset-bearing blocks after, flagged. Hover shows the ref + amount.
+fn render_block_strip(ui: &mut Ui, utxos: &[UtxoApi], assets_unexpected: bool) {
+    let max = utxos.iter().map(|u| u.lovelace).max().unwrap_or(1).max(1);
+    const H: f32 = 20.0;
+    const MIN_W: f32 = 6.0;
+    const MAX_W: f32 = 72.0;
+
+    let mut order: Vec<&UtxoApi> = utxos.iter().filter(|u| u.assets.is_empty()).collect();
+    order.sort_by(|a, b| b.lovelace.cmp(&a.lovelace));
+    let mut with_assets: Vec<&UtxoApi> = utxos.iter().filter(|u| !u.assets.is_empty()).collect();
+    with_assets.sort_by(|a, b| b.lovelace.cmp(&a.lovelace));
+    order.extend(with_assets);
+
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(3.0, 3.0);
+        for u in order {
+            let is_asset = !u.assets.is_empty();
+            let frac = u.lovelace as f32 / max as f32;
+            let w = (MIN_W + frac * (MAX_W - MIN_W)).clamp(MIN_W, MAX_W);
+            let (rect, resp) = ui.allocate_exact_size(egui::vec2(w, H), egui::Sense::hover());
+            let color = if is_asset && assets_unexpected {
+                theme::ACCENT_RED
+            } else if is_asset {
+                theme::ACCENT_YELLOW
+            } else {
+                theme::ACCENT_GREEN
+            };
+            ui.painter().rect_filled(rect, 2.0, color);
+            let head = &u.tx_hash[..u.tx_hash.len().min(8)];
+            let mut tip = format!("{head}…#{} · {} ADA", u.output_index, ada(u.lovelace));
+            if is_asset {
+                tip.push_str(&format!(
+                    " · {} asset{}",
+                    u.assets.len(),
+                    plural(u.assets.len())
+                ));
+            }
+            resp.on_hover_text(tip);
+        }
+    });
+}
+
+/// One `tx_hash#index [copy] · N ADA` row. The ref is a copyable `IdPill`
+/// (operators paste it into an explorer / `cardano-cli`).
+fn utxo_ref_row(ui: &mut Ui, u: &UtxoApi) {
+    ui.horizontal(|ui| {
+        crate::IdPill::utxo_ref(&u.tx_hash, u.output_index).show(ui);
+        ui.label(
+            RichText::new(format!("{} ADA", ada(u.lovelace)))
+                .monospace()
+                .small()
+                .color(theme::TEXT_PRIMARY),
+        );
+    });
+}
+
+/// Lovelace → ADA with 6 decimals.
+fn ada(lovelace: u64) -> String {
+    format!("{:.6}", lovelace as f64 / 1_000_000.0)
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Head-truncate a long id (policy_id) to `keep` chars + ellipsis.
+fn truncate(s: &str, keep: usize) -> String {
+    if s.len() <= keep {
+        return s.to_string();
+    }
+    format!("{}…", &s[..keep])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cardano_assets::utxo::AssetQuantity;
+    use cardano_assets::AssetId;
+
+    fn pure(lovelace: u64) -> UtxoApi {
+        UtxoApi {
+            tx_hash: format!("tx{lovelace}"),
+            output_index: 0,
+            lovelace,
+            assets: vec![],
+            tags: vec![],
+        }
+    }
+
+    fn with_assets(lovelace: u64, n: usize) -> UtxoApi {
+        let assets = (0..n)
+            .map(|i| AssetQuantity {
+                asset_id: AssetId::new_unchecked("policy".to_string(), format!("{i:02x}")),
+                quantity: 1,
+            })
+            .collect();
+        UtxoApi {
+            tx_hash: format!("txa{lovelace}"),
+            output_index: 1,
+            lovelace,
+            assets,
+            tags: vec![],
+        }
+    }
+
+    #[test]
+    fn breakdown_splits_pure_and_asset_bearing() {
+        let utxos = vec![
+            pure(117_667_750),
+            with_assets(1_206_800, 2),
+            pure(68_125_678),
+        ];
+        let b = UtxoBreakdown::of(&utxos);
+        assert_eq!(b.ada_only_count, 2);
+        assert_eq!(b.ada_only_lovelace, 117_667_750 + 68_125_678);
+        assert_eq!(b.asset_bearing_count, 1);
+        assert_eq!(b.asset_bearing_lovelace, 1_206_800);
+        assert_eq!(b.token_count, 2);
+        assert_eq!(b.total_lovelace, 117_667_750 + 1_206_800 + 68_125_678);
+        assert!(b.has_assets());
+    }
+
+    #[test]
+    fn breakdown_pure_wallet_has_no_assets() {
+        let b = UtxoBreakdown::of(&[pure(10_000_000), pure(5_000_000)]);
+        assert!(!b.has_assets());
+        assert_eq!(b.asset_bearing_count, 0);
+        assert_eq!(b.token_count, 0);
+    }
+
+    #[test]
+    fn shape_healthy_for_a_few_fat_utxos() {
+        let b = UtxoBreakdown::of(&[pure(140_000_000), pure(117_667_750), pure(68_000_000)]);
+        assert_eq!(b.ada_only_small_count, 0);
+        assert_eq!(b.shape(), WalletShape::Healthy);
+    }
+
+    #[test]
+    fn shape_fragmented_on_high_count() {
+        // 12 spendable UTxOs trips the count threshold even though none are small.
+        let utxos: Vec<UtxoApi> = (0..12).map(|_| pure(10_000_000)).collect();
+        let b = UtxoBreakdown::of(&utxos);
+        assert_eq!(b.shape(), WalletShape::Fragmented);
+    }
+
+    #[test]
+    fn shape_fragmented_on_small_pile() {
+        // A couple of big UTxOs but five dust-ish ones → fragmented.
+        let mut utxos = vec![pure(120_000_000), pure(40_000_000)];
+        utxos.extend((0..5).map(|_| pure(1_200_000)));
+        let b = UtxoBreakdown::of(&utxos);
+        assert_eq!(b.ada_only_small_count, 5);
+        assert!(b.ada_only_count < FRAGMENT_COUNT);
+        assert_eq!(b.shape(), WalletShape::Fragmented);
+    }
+}

--- a/ui/egui-widgets/src/managed_wallet_utxos.rs
+++ b/ui/egui-widgets/src/managed_wallet_utxos.rs
@@ -309,9 +309,9 @@ fn render_block_strip(ui: &mut Ui, utxos: &[UtxoApi], assets_unexpected: bool) {
     const MAX_W: f32 = 72.0;
 
     let mut order: Vec<&UtxoApi> = utxos.iter().filter(|u| u.assets.is_empty()).collect();
-    order.sort_by(|a, b| b.lovelace.cmp(&a.lovelace));
+    order.sort_by_key(|u| std::cmp::Reverse(u.lovelace));
     let mut with_assets: Vec<&UtxoApi> = utxos.iter().filter(|u| !u.assets.is_empty()).collect();
-    with_assets.sort_by(|a, b| b.lovelace.cmp(&a.lovelace));
+    with_assets.sort_by_key(|u| std::cmp::Reverse(u.lovelace));
     order.extend(with_assets);
 
     ui.horizontal_wrapped(|ui| {

--- a/ui/egui-widgets/src/managed_wallet_utxos.rs
+++ b/ui/egui-widgets/src/managed_wallet_utxos.rs
@@ -173,14 +173,26 @@ impl<'a> ManagedWalletUtxos<'a> {
             } else {
                 String::new()
             };
+            ui.horizontal(|ui| {
+                crate::icons::install_phosphor_font(ui.ctx());
+                ui.label(crate::PhosphorIcon::Warning.rich_text(12.0, theme::ACCENT_YELLOW));
+                ui.label(
+                    RichText::new(format!(
+                        "Fragmented — {} spendable UTxOs{small}",
+                        b.ada_only_count
+                    ))
+                    .color(theme::ACCENT_YELLOW)
+                    .small()
+                    .strong(),
+                );
+            });
             ui.label(
-                RichText::new(format!(
-                    "⚠ Fragmented — {} spendable UTxOs{small}. A mint tx must spend several as \
-                     inputs; with large on-chain-art metadata that can crowd the 16 KB tx limit. \
-                     Consider consolidating (a Fund/no-op self-send merges them).",
-                    b.ada_only_count,
-                ))
-                .color(theme::ACCENT_YELLOW)
+                RichText::new(
+                    "A mint tx must spend several as inputs; with large on-chain-art metadata \
+                     that can crowd the 16 KB tx limit. Consider consolidating (a Fund/no-op \
+                     self-send merges them).",
+                )
+                .color(theme::TEXT_SECONDARY)
                 .small(),
             );
         }
@@ -216,18 +228,22 @@ impl<'a> ManagedWalletUtxos<'a> {
         if b.has_assets() {
             ui.add_space(8.0);
             if self.assets_unexpected {
-                ui.label(
-                    RichText::new(format!(
-                        "⚠ Holds assets — {} UTxO{} carrying {} token{}",
-                        b.asset_bearing_count,
-                        plural(b.asset_bearing_count),
-                        b.token_count,
-                        plural(b.token_count),
-                    ))
-                    .color(theme::ACCENT_RED)
-                    .small()
-                    .strong(),
-                );
+                ui.horizontal(|ui| {
+                    crate::icons::install_phosphor_font(ui.ctx());
+                    ui.label(crate::PhosphorIcon::Warning.rich_text(12.0, theme::ACCENT_RED));
+                    ui.label(
+                        RichText::new(format!(
+                            "Holds assets — {} UTxO{} carrying {} token{}",
+                            b.asset_bearing_count,
+                            plural(b.asset_bearing_count),
+                            b.token_count,
+                            plural(b.token_count),
+                        ))
+                        .color(theme::ACCENT_RED)
+                        .small()
+                        .strong(),
+                    );
+                });
                 ui.label(
                     RichText::new(
                         "A mint + payments wallet should hold only ADA. Tokens here were most \

--- a/ui/egui-widgets/src/mnemonic_display.rs
+++ b/ui/egui-widgets/src/mnemonic_display.rs
@@ -102,11 +102,16 @@ impl<'a> MnemonicDisplay<'a> {
                 .corner_radius(CornerRadius::same(4))
                 .inner_margin(Margin::symmetric(12, 8))
                 .show(ui, |ui| {
-                    ui.label(
-                        RichText::new("⚠  This phrase is shown ONCE. Write it down.")
-                            .color(Color32::from_rgb(240, 210, 140))
-                            .strong(),
-                    );
+                    ui.horizontal(|ui| {
+                        crate::icons::install_phosphor_font(ui.ctx());
+                        let warn = Color32::from_rgb(240, 210, 140);
+                        ui.label(crate::PhosphorIcon::Warning.rich_text(13.0, warn));
+                        ui.label(
+                            RichText::new("This phrase is shown ONCE. Write it down.")
+                                .color(warn)
+                                .strong(),
+                        );
+                    });
                     ui.label(
                         RichText::new(
                             "Anyone with these words controls the wallet. Store offline; \

--- a/ui/egui-widgets/src/toast.rs
+++ b/ui/egui-widgets/src/toast.rs
@@ -340,9 +340,15 @@ mod tests {
 
     #[test]
     fn default_icons_match_kind() {
-        assert_eq!(ToastKind::Success.default_icon(), Some(PhosphorIcon::CheckCircle));
+        assert_eq!(
+            ToastKind::Success.default_icon(),
+            Some(PhosphorIcon::CheckCircle)
+        );
         assert_eq!(ToastKind::Error.default_icon(), Some(PhosphorIcon::X));
-        assert_eq!(ToastKind::Warning.default_icon(), Some(PhosphorIcon::Warning));
+        assert_eq!(
+            ToastKind::Warning.default_icon(),
+            Some(PhosphorIcon::Warning)
+        );
         assert_eq!(ToastKind::Info.default_icon(), None);
     }
 

--- a/ui/egui-widgets/tests/no_broken_glyphs.rs
+++ b/ui/egui-widgets/tests/no_broken_glyphs.rs
@@ -1,0 +1,105 @@
+//! Guardrail: no known-broken Unicode glyphs in rendered strings.
+//!
+//! egui's default font (Ubuntu) does NOT cover many symbol glyphs — arrows,
+//! the warning sign, ballot/check marks, the math minus — and renders them as
+//! a "tofu" box. We keep hitting this (the broken `✕`, a broken `←`, …). The
+//! rule: in `egui-widgets`, never put those glyphs in rendered text — use a
+//! [`PhosphorIcon`](egui_widgets::PhosphorIcon) (the installed icon font) for
+//! iconography, or plain ASCII (e.g. `-` not the math minus).
+//!
+//! This test scans every `src/**/*.rs`, strips trailing `//` comments (which
+//! don't render), and fails if any denylisted codepoint appears in the code —
+//! i.e. inside a string/char literal. The denylist is spelled with `\u{}`
+//! escapes so this file doesn't trip its own check. To add an icon, extend
+//! `PhosphorIcon`; don't reach for a bare Unicode symbol.
+
+use std::path::Path;
+
+/// Codepoints egui's default font won't render — keep them out of rendered
+/// strings. (Safe glyphs deliberately omitted: middle dot `·`, em dash `—`,
+/// ellipsis `…`, `×` — all render fine.)
+const DENY: &[(char, &str)] = &[
+    ('\u{2190}', "left arrow"),
+    ('\u{2191}', "up arrow"),
+    ('\u{2192}', "right arrow"),
+    ('\u{2193}', "down arrow"),
+    ('\u{2194}', "left-right arrow"),
+    ('\u{2195}', "up-down arrow"),
+    ('\u{26A0}', "warning sign"),
+    ('\u{2713}', "check mark"),
+    ('\u{2714}', "heavy check mark"),
+    ('\u{2715}', "multiplication x"),
+    ('\u{2716}', "heavy multiplication x"),
+    ('\u{2717}', "ballot x"),
+    ('\u{2718}', "heavy ballot x"),
+    ('\u{2212}', "minus sign (use ASCII '-')"),
+];
+
+/// Truncate a line at the first `//` that is NOT inside a string literal, so
+/// trailing comments (which don't render) are ignored. Byte-indexed, but only
+/// matches ASCII `"`/`/`, so multibyte glyphs are never split.
+fn code_portion(line: &str) -> &str {
+    let b = line.as_bytes();
+    let mut in_str = false;
+    let mut i = 0;
+    while i < b.len() {
+        match b[i] {
+            b'"' => {
+                // Toggle unless this quote is escaped (odd run of backslashes).
+                let mut bs = 0;
+                let mut j = i;
+                while j > 0 && b[j - 1] == b'\\' {
+                    bs += 1;
+                    j -= 1;
+                }
+                if bs % 2 == 0 {
+                    in_str = !in_str;
+                }
+            }
+            b'/' if !in_str && b.get(i + 1) == Some(&b'/') => return &line[..i],
+            _ => {}
+        }
+        i += 1;
+    }
+    line
+}
+
+fn scan(dir: &Path, failures: &mut Vec<String>) {
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let path = entry.expect("entry").path();
+        if path.is_dir() {
+            scan(&path, failures);
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        let src = std::fs::read_to_string(&path).expect("read file");
+        for (n, line) in src.lines().enumerate() {
+            let code = code_portion(line);
+            for (glyph, name) in DENY {
+                if code.contains(*glyph) {
+                    failures.push(format!(
+                        "{}:{} — broken glyph U+{:04X} ({name}); use PhosphorIcon or ASCII",
+                        path.display(),
+                        n + 1,
+                        *glyph as u32,
+                    ));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn no_broken_glyphs_in_rendered_strings() {
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut failures = Vec::new();
+    scan(&src, &mut failures);
+    assert!(
+        failures.is_empty(),
+        "found {} broken-glyph use(s) in rendered strings:\n{}",
+        failures.len(),
+        failures.join("\n"),
+    );
+}


### PR DESCRIPTION
### New egui widgets

- **`ManagedWalletUtxos`** — role-aware UTxO breakdown for a custodial wallet.
  Splits ADA-only (the spendable mint-funding pool) from asset-bearing UTxOs and
  flags the latter as an anomaly (a mint+payments wallet should never hold NFTs —
  minted-to-self / stray). Includes a proportional block strip and a
  fragmentation read (`UtxoBreakdown::shape()` → `WalletShape`) that warns when
  the wallet is fragmented enough to crowd the on-chain-art tx-size budget.
  Pure `UtxoBreakdown` core is unit-tested.
- **`DistributionWaterfall`** — how a buyer payment flows to each party
  (gross → −delivery/network/platform → distributable → split), across three
  lifecycle modes (`Projected` / `Live` / `Final`) and two audiences (manager =
  all parties; party = their slice highlighted). Pure view-model in; the
  consumer feeds it a projection or recorded actuals.
- **`IdPill::utxo_ref(tx, idx)`** — a copyable, label-less pill for a `tx#idx`
  UTxO reference (copies the canonical ref for explorer / cardano-cli). Backed by
  switching `IdPill`'s value to `Cow<str>` so a constructor can own its string;
  `IdPill::new` and all builders are unchanged.

### Collection card (`collection_list`)

Extends `CollectionRow` + the card for the managed-mint workflow: the wallet pill
now reads **"mint + payments #N"** for unified wallets (legacy two-wallet shows
"mint wallet"), a separate inspectable deposit pill (`deposit_address(_short)` +
`deposit_account_index`), and `with_fund` / `with_settlement` opt-in action
buttons. Stacked policy/wallet/deposit pills.

### Quality / guardrails

- **`tests/no_broken_glyphs.rs`** — fails the build if a known-broken Unicode
  glyph (arrows, ⚠, ✕/✗/✓, math-minus) appears in a rendered string. egui's
  default font tofu-boxes these; the rule is "use `PhosphorIcon` or ASCII." The
  scan is comment-aware and the denylist is `\u{}`-escaped so it can't trip
  itself.
- `mnemonic_display` warning glyph swapped for `PhosphorIcon::Warning`.

### cardano-tx

- Inline-distribution **tx-size spike tests** (`spike_inline_distribution_15kb_…`,
  `spike_max_metadata_single_payout_fee_waived`) — prove a ~15 KB on-chain-art
  mint plus inline payout outputs fits the 16,384-byte limit (~760 B / ~19
  payouts of headroom; max single-payout metadata ≈ 15,904 B). Tests only.

### Storybook

Stories for the two new widgets (Wallet category) + the toggles that exercise
their states (fragmentation, anomaly, lifecycle modes, party highlight,
thin-price floor); plus a fix to the `collection_list` story for the new
`CollectionRow` field / action variants.

### Testing

`egui-widgets` clippy-clean (`-D warnings`) native + wasm32; all unit + guardrail
tests pass; `storybook-egui` builds on wasm32 (trunk's target).
