### PR TITLE
feature(s): fal.ai client + datum tagging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fal-client"
+version = "0.1.0"
+dependencies = [
+ "http-client",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "mint-manifest",
     "cnft-tools",
     "discord-client",
+    "fal-client",
     "filebase",
     "http-client",
     "openai-client",

--- a/cardano-assets/Cargo.toml
+++ b/cardano-assets/Cargo.toml
@@ -29,6 +29,9 @@ cip14 = ["dep:bech32", "dep:blake2"]
 cip68 = ["dep:pallas-codec", "dep:pallas-primitives"]
 # CIP-25 mint-tx metadata (label 721) decode — same pallas deps as cip68.
 cip25 = ["dep:pallas-codec", "dep:pallas-primitives"]
+# Generic UTxO tag datum (namespace + version + app-defined u32 role bitflags)
+# encode/decode — a reusable inline-datum facility; same pallas deps as cip68.
+tag-datum = ["dep:pallas-codec", "dep:pallas-primitives"]
 utxorpc = ["dep:utxorpc-spec", "dep:tracing"]
 openapi = ["dep:utoipa"]
 cnft_tools = ["dep:cnft_tools"]

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -28,9 +28,9 @@ pub mod traits;
 pub mod tx_hash;
 pub mod utxo;
 
-pub use token_type::TokenType;
 #[cfg(feature = "tag-datum")]
 pub use tag_datum::UtxoTagDatum;
+pub use token_type::TokenType;
 
 #[cfg(feature = "utxorpc")]
 pub mod utxorpc;

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -21,12 +21,16 @@ pub mod fingerprint;
 pub mod policy_id;
 pub mod resolver;
 pub mod supply;
+#[cfg(feature = "tag-datum")]
+pub mod tag_datum;
 pub mod token_type;
 pub mod traits;
 pub mod tx_hash;
 pub mod utxo;
 
 pub use token_type::TokenType;
+#[cfg(feature = "tag-datum")]
+pub use tag_datum::UtxoTagDatum;
 
 #[cfg(feature = "utxorpc")]
 pub mod utxorpc;

--- a/cardano-assets/src/supply.rs
+++ b/cardano-assets/src/supply.rs
@@ -106,7 +106,10 @@ mod tests {
     #[test]
     fn serialize_mirrors_db() {
         assert_eq!(serde_json::to_string(&MintSupply::Quota(50)).unwrap(), "50");
-        assert_eq!(serde_json::to_string(&MintSupply::Uncapped).unwrap(), "null");
+        assert_eq!(
+            serde_json::to_string(&MintSupply::Uncapped).unwrap(),
+            "null"
+        );
     }
 
     #[test]

--- a/cardano-assets/src/tag_datum.rs
+++ b/cardano-assets/src/tag_datum.rs
@@ -1,0 +1,124 @@
+//! Generic UTxO **tag datum** — a small, versioned inline datum that classifies
+//! a UTxO's role for an application, so coin-selection can distinguish purposes
+//! (e.g. delivery fuel vs operator float vs an inbound payment) without amount
+//! heuristics or a second address.
+//!
+//! The mechanism is app-agnostic; the *meaning* of `flags` is owned by the
+//! reader. A `namespace` byte string scopes the tag to one purpose, so an
+//! unrelated `Constr 0 [..]` datum never decodes as a foreign app's tag.
+//!
+//! Datum: `Constr 0 [ Bytes(namespace), Int(version), Int(flags: u32) ]`.
+//!
+//! Inline datums are not script-only — a normal key/enterprise address output
+//! can carry one (CIP-32) and is spent with just the key witness.
+
+use pallas_primitives::alonzo::{BigInt, Constr, PlutusData};
+use pallas_primitives::{Fragment, MaybeIndefArray};
+
+/// A decoded UTxO tag datum. `flags` is an application-defined `u32` bitfield —
+/// the reader interprets it (after filtering by its expected `namespace`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UtxoTagDatum {
+    pub namespace: Vec<u8>,
+    pub version: u16,
+    pub flags: u32,
+}
+
+impl UtxoTagDatum {
+    pub fn new(namespace: impl Into<Vec<u8>>, version: u16, flags: u32) -> Self {
+        Self {
+            namespace: namespace.into(),
+            version,
+            flags,
+        }
+    }
+
+    /// Encode to inline-datum CBOR for `Output::set_inline_datum`.
+    pub fn encode(&self) -> Result<Vec<u8>, String> {
+        let data = PlutusData::Constr(Constr {
+            tag: 121, // Constr 0
+            any_constructor: None,
+            fields: MaybeIndefArray::Def(vec![
+                PlutusData::BoundedBytes(self.namespace.clone().into()),
+                PlutusData::BigInt(BigInt::Int((self.version as i64).into())),
+                PlutusData::BigInt(BigInt::Int((self.flags as i64).into())),
+            ]),
+        });
+        data.encode_fragment()
+            .map_err(|e| format!("encode tag datum: {e}"))
+    }
+
+    /// Decode a UTxO's inline-datum CBOR. Returns `None` when it isn't a tag
+    /// datum of this shape (a foreign datum is simply "untagged").
+    pub fn decode(cbor: &[u8]) -> Option<Self> {
+        let data = PlutusData::decode_fragment(cbor).ok()?;
+        let PlutusData::Constr(constr) = data else {
+            return None;
+        };
+        if constr.tag != 121 || constr.fields.len() != 3 {
+            return None;
+        }
+        let namespace = as_bytes(&constr.fields[0])?;
+        let version = u16::try_from(as_u64(&constr.fields[1])?).ok()?;
+        let flags = u32::try_from(as_u64(&constr.fields[2])?).ok()?;
+        Some(Self {
+            namespace,
+            version,
+            flags,
+        })
+    }
+
+    /// True when this tag is in `namespace` — the per-app scope guard a reader
+    /// applies before trusting `flags`.
+    pub fn in_namespace(&self, namespace: &[u8]) -> bool {
+        self.namespace == namespace
+    }
+}
+
+fn as_u64(d: &PlutusData) -> Option<u64> {
+    match d {
+        PlutusData::BigInt(BigInt::Int(int)) => {
+            let v: i128 = (*int).into();
+            (0..=u64::MAX as i128).contains(&v).then_some(v as u64)
+        }
+        _ => None,
+    }
+}
+
+fn as_bytes(d: &PlutusData) -> Option<Vec<u8>> {
+    match d {
+        PlutusData::BoundedBytes(b) => Some(b.to_vec()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips() {
+        let tag = UtxoTagDatum::new(b"fuel".to_vec(), 1, 0b1011);
+        let cbor = tag.encode().unwrap();
+        let back = UtxoTagDatum::decode(&cbor).unwrap();
+        assert_eq!(tag, back);
+        assert!(back.in_namespace(b"fuel"));
+        assert!(!back.in_namespace(b"float"));
+    }
+
+    #[test]
+    fn rejects_foreign_datum() {
+        // A 2-field Constr 0 (the old fuel-only shape / a Splash-ish datum) is
+        // NOT a tag datum — must not false-positive.
+        let foreign = PlutusData::Constr(Constr {
+            tag: 121,
+            any_constructor: None,
+            fields: MaybeIndefArray::Def(vec![
+                PlutusData::BigInt(BigInt::Int(1i64.into())),
+                PlutusData::BigInt(BigInt::Int(2i64.into())),
+            ]),
+        });
+        let cbor = foreign.encode_fragment().unwrap();
+        assert!(UtxoTagDatum::decode(&cbor).is_none());
+    }
+}

--- a/cardano-tx/src/builder/send.rs
+++ b/cardano-tx/src/builder/send.rs
@@ -382,6 +382,7 @@ pub fn build_fan_out(
     deps: &TxDeps,
     slot_size: u64,
     slot_count: u32,
+    slot_datum: Option<Vec<u8>>,
 ) -> Result<UnsignedTx, TxBuildError> {
     if slot_count == 0 {
         return Err(TxBuildError::BuildFailed(
@@ -453,9 +454,15 @@ pub fn build_fan_out(
             let refs: Vec<&UtxoApi> = selected_cloned.iter().collect();
             let mut tx = add_utxo_inputs(StagingTransaction::new(), &refs)?;
 
-            // N equal fuel-slot outputs back to self.
+            // N equal fuel-slot outputs back to self, each optionally carrying an
+            // inline datum tag (e.g. the engine's FUEL role marker) so the outputs
+            // are self-describing on chain — distinguishable from inbound payments.
             for _ in 0..slot_count {
-                tx = tx.output(create_ada_output(from_address.clone(), slot_size));
+                let mut out = create_ada_output(from_address.clone(), slot_size);
+                if let Some(datum) = &slot_datum {
+                    out = out.set_inline_datum(datum.clone());
+                }
+                tx = tx.output(out);
             }
 
             // Change output for the remainder — fee converges around
@@ -906,7 +913,7 @@ mod tests {
             from_address: test_address(),
             network_id: 0,
         };
-        let result = build_fan_out(&deps, 10_000_000, 5);
+        let result = build_fan_out(&deps, 10_000_000, 5, None);
         assert!(result.is_ok(), "build_fan_out failed: {result:?}");
         let unsigned = result.unwrap();
         assert!(unsigned.fee > 0);
@@ -928,7 +935,7 @@ mod tests {
             from_address: test_address(),
             network_id: 0,
         };
-        let result = build_fan_out(&deps, 10_000_000, 5);
+        let result = build_fan_out(&deps, 10_000_000, 5, None);
         assert!(result.is_ok(), "multi-input fan_out failed: {result:?}");
         let unsigned = result.unwrap();
         assert!(
@@ -958,7 +965,7 @@ mod tests {
             from_address: test_address(),
             network_id: 0,
         };
-        let result = build_fan_out(&deps, 10_000_000, 5);
+        let result = build_fan_out(&deps, 10_000_000, 5, None);
         assert!(
             matches!(result, Err(TxBuildError::InsufficientFunds { .. })),
             "expected InsufficientFunds (script-ref + asset UTxOs excluded), got {result:?}"
@@ -973,7 +980,7 @@ mod tests {
             from_address: test_address(),
             network_id: 0,
         };
-        assert!(build_fan_out(&deps, 10_000_000, 0).is_err());
+        assert!(build_fan_out(&deps, 10_000_000, 0, None).is_err());
     }
 
     // ── build_send_many (refund / settlement payout txs) ──────────────

--- a/fal-client/Cargo.toml
+++ b/fal-client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fal-client"
+version.workspace = true
+authors.workspace = true
+edition = "2021"
+description = "fal.ai image generation/editing client (Qwen inpaint, Flux Fill) using http-client for platform-agnostic HTTP"
+
+[dependencies]
+http-client = { path = "../http-client" }
+serde = { workspace = true, features = ["derive"] }
+thiserror = "2.0"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/fal-client/examples/qwen_inpaint.rs
+++ b/fal-client/examples/qwen_inpaint.rs
@@ -1,0 +1,38 @@
+//! Fire a real Qwen inpaint against fal.
+//!
+//! Requires `FAL_API_KEY` in the environment.
+//!
+//! ```sh
+//! FAL_API_KEY=... cargo run -p fal-client --example qwen_inpaint -- \
+//!     base.png mask.png "a backwards snapback cap, flat vector"
+//! ```
+//! Writes the result to `fal-out.png`.
+
+use fal_client::{png_data_uri, FalClient, InpaintRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let base = args.next().expect("usage: <base.png> <mask.png> <prompt>");
+    let mask = args.next().expect("missing mask.png");
+    let prompt = args.next().expect("missing prompt");
+    let key = std::env::var("FAL_API_KEY").expect("FAL_API_KEY not set");
+
+    let image = png_data_uri(&std::fs::read(&base)?);
+    let mask = png_data_uri(&std::fs::read(&mask)?);
+
+    let client = FalClient::new(&key);
+    let out = client
+        .qwen_inpaint(&InpaintRequest {
+            prompt: &prompt,
+            image: &image,
+            mask: &mask,
+            ..Default::default()
+        })
+        .await?;
+
+    let bytes = out.first_bytes()?;
+    std::fs::write("fal-out.png", &bytes)?;
+    println!("wrote fal-out.png ({} bytes), seed={:?}", bytes.len(), out.seed);
+    Ok(())
+}

--- a/fal-client/src/base64.rs
+++ b/fal-client/src/base64.rs
@@ -1,0 +1,87 @@
+//! Minimal dependency-free base64 (standard alphabet), matching the WASM-safe
+//! approach used elsewhere in the workspace. Used to pass images to fal as data
+//! URIs and to decode `sync_mode` results.
+
+const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+pub fn encode(input: &[u8]) -> String {
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    let mut i = 0;
+    while i + 2 < input.len() {
+        let triple = ((input[i] as u32) << 16) | ((input[i + 1] as u32) << 8) | input[i + 2] as u32;
+        out.push(CHARS[((triple >> 18) & 0x3F) as usize] as char);
+        out.push(CHARS[((triple >> 12) & 0x3F) as usize] as char);
+        out.push(CHARS[((triple >> 6) & 0x3F) as usize] as char);
+        out.push(CHARS[(triple & 0x3F) as usize] as char);
+        i += 3;
+    }
+    match input.len() - i {
+        1 => {
+            let b0 = input[i] as u32;
+            out.push(CHARS[((b0 >> 2) & 0x3F) as usize] as char);
+            out.push(CHARS[((b0 << 4) & 0x3F) as usize] as char);
+            out.push('=');
+            out.push('=');
+        }
+        2 => {
+            let pair = ((input[i] as u32) << 8) | input[i + 1] as u32;
+            out.push(CHARS[((pair >> 10) & 0x3F) as usize] as char);
+            out.push(CHARS[((pair >> 4) & 0x3F) as usize] as char);
+            out.push(CHARS[((pair << 2) & 0x3F) as usize] as char);
+            out.push('=');
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Decode standard base64; returns `None` on any invalid character. Whitespace
+/// and `=` padding are ignored.
+pub fn decode(input: &str) -> Option<Vec<u8>> {
+    let mut table = [255u8; 256];
+    for (i, &c) in CHARS.iter().enumerate() {
+        table[c as usize] = i as u8;
+    }
+
+    let mut vals = Vec::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'=' | b'\n' | b'\r' | b' ' => continue,
+            _ => {
+                let v = table[b as usize];
+                if v == 255 {
+                    return None;
+                }
+                vals.push(v);
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(vals.len() * 3 / 4);
+    let mut i = 0;
+    while i + 4 <= vals.len() {
+        let n = ((vals[i] as u32) << 18)
+            | ((vals[i + 1] as u32) << 12)
+            | ((vals[i + 2] as u32) << 6)
+            | vals[i + 3] as u32;
+        out.push((n >> 16) as u8);
+        out.push((n >> 8) as u8);
+        out.push(n as u8);
+        i += 4;
+    }
+    match vals.len() - i {
+        2 => {
+            let n = ((vals[i] as u32) << 18) | ((vals[i + 1] as u32) << 12);
+            out.push((n >> 16) as u8);
+        }
+        3 => {
+            let n = ((vals[i] as u32) << 18)
+                | ((vals[i + 1] as u32) << 12)
+                | ((vals[i + 2] as u32) << 6);
+            out.push((n >> 16) as u8);
+            out.push((n >> 8) as u8);
+        }
+        _ => {}
+    }
+    Some(out)
+}

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -31,6 +31,9 @@ pub const FLUX_CANNY: &str = "fal-ai/flux-control-lora-canny/image-to-image";
 /// `fal-ai/flux-control-lora-canny` — FLUX canny **text-to-image**: generates
 /// from the control image's edges, so colour comes from the prompt (recolour).
 pub const FLUX_CANNY_GEN: &str = "fal-ai/flux-control-lora-canny";
+/// `fal-ai/birefnet/v2` — semantic background removal / matting (handles soft
+/// fur/hair edges far better than colour-keying).
+pub const BIREFNET: &str = "fal-ai/birefnet/v2";
 
 #[derive(Debug, thiserror::Error)]
 pub enum FalError {
@@ -180,6 +183,21 @@ impl FalClient {
             seed: req.seed,
         };
         self.finish(self.run(FLUX_CANNY_GEN, &body).await?)
+    }
+
+    /// Semantic background removal / matting via BiRefNet. `model` selects the
+    /// variant (e.g. "Matting" for soft fur/hair edges, "General Use (Light)").
+    /// Returns an RGBA image (data URI under `sync_mode`).
+    pub async fn birefnet(&self, image: &str, model: &str) -> Result<MatteOutput, FalError> {
+        let body = BirefnetInput {
+            image_url: image,
+            model,
+            operating_resolution: "1024x1024",
+            output_format: "png",
+            refine_foreground: true,
+            sync_mode: true,
+        };
+        self.run(BIREFNET, &body).await
     }
 
     fn finish(&self, out: ImageOutput) -> Result<ImageOutput, FalError> {
@@ -339,6 +357,21 @@ impl ImageOutput {
     }
 }
 
+/// Result of a [`FalClient::birefnet`] matte: an RGBA image and optional mask.
+#[derive(Debug, Deserialize)]
+pub struct MatteOutput {
+    pub image: FalImage,
+    #[serde(default)]
+    pub mask_image: Option<FalImage>,
+}
+
+impl MatteOutput {
+    /// Decode the matted RGBA image bytes (expects a `sync_mode` data URI).
+    pub fn image_bytes(&self) -> Result<Vec<u8>, FalError> {
+        decode_data_uri(&self.image.url)
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct FalImage {
     /// Data URI when `sync_mode` is set, otherwise a hosted fal.media URL.
@@ -426,6 +459,16 @@ struct FluxCannyInput<'a> {
     enable_safety_checker: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct BirefnetInput<'a> {
+    image_url: &'a str,
+    model: &'a str,
+    operating_resolution: &'a str,
+    output_format: &'a str,
+    refine_foreground: bool,
+    sync_mode: bool,
 }
 
 #[derive(Serialize)]

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -1,0 +1,350 @@
+//! fal.ai image generation/editing client.
+//!
+//! Platform-agnostic — uses `http-client` which selects reqwest (native) or
+//! gloo-net (WASM) automatically. Targets fal's synchronous endpoint
+//! (`https://fal.run/{model_id}`) and requests `sync_mode` so results come back
+//! inline as data URIs (no second download).
+//!
+//! Primary use here is mask-based inpainting (Qwen / Flux Fill): the mask
+//! defines exactly which pixels change, so the masked region *is* the extracted
+//! layer's alpha.
+
+mod base64;
+
+use http_client::HttpClient;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+const BASE_URL: &str = "https://fal.run";
+
+/// `fal-ai/qwen-image-edit/inpaint` — Apache-licensed, ControlNet-capable.
+pub const QWEN_INPAINT: &str = "fal-ai/qwen-image-edit/inpaint";
+/// `fal-ai/flux-pro/v1/fill` — true composite-back masked inpaint.
+pub const FLUX_FILL: &str = "fal-ai/flux-pro/v1/fill";
+/// `fal-ai/qwen-image-edit` — full-frame instruction edit (no mask).
+pub const QWEN_EDIT: &str = "fal-ai/qwen-image-edit";
+/// `fal-ai/fast-sdxl-controlnet-canny/inpainting` — structure-locked colorize:
+/// canny control keeps the linework in place, mask scopes the region.
+pub const SDXL_CONTROLNET_CANNY_INPAINT: &str = "fal-ai/fast-sdxl-controlnet-canny/inpainting";
+
+#[derive(Debug, thiserror::Error)]
+pub enum FalError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] http_client::HttpError),
+    #[error("fal returned no images")]
+    NoImages,
+    #[error("{0}")]
+    Other(String),
+}
+
+/// fal.ai client. Auth header is `Authorization: Key <FAL_API_KEY>`.
+pub struct FalClient {
+    client: HttpClient,
+}
+
+impl FalClient {
+    pub fn new(api_key: &str) -> Self {
+        Self {
+            client: HttpClient::new().with_header("Authorization", &format!("Key {api_key}")),
+        }
+    }
+
+    /// Run any fal model synchronously: `POST https://fal.run/{model_id}`.
+    /// Escape hatch for models without a typed wrapper here.
+    pub async fn run<I: Serialize, O: DeserializeOwned>(
+        &self,
+        model_id: &str,
+        input: &I,
+    ) -> Result<O, FalError> {
+        let url = format!("{BASE_URL}/{model_id}");
+        Ok(self.client.post(&url, input).await?)
+    }
+
+    /// Qwen image-edit inpaint: paint `prompt` into the white region of `mask`.
+    pub async fn qwen_inpaint(&self, req: &InpaintRequest<'_>) -> Result<ImageOutput, FalError> {
+        let body = QwenInpaintInput {
+            prompt: req.prompt,
+            image_url: req.image,
+            mask_url: req.mask,
+            negative_prompt: req.negative_prompt,
+            num_images: 1,
+            output_format: "png",
+            sync_mode: true,
+            strength: req.strength,
+            seed: req.seed,
+        };
+        self.finish(self.run(QWEN_INPAINT, &body).await?)
+    }
+
+    /// Flux Fill (pro): mask-based fill where outside-mask pixels are composited
+    /// back unchanged — the byte-frozen registration path.
+    pub async fn flux_fill(&self, req: &InpaintRequest<'_>) -> Result<ImageOutput, FalError> {
+        let body = FluxFillInput {
+            prompt: req.prompt,
+            image_url: req.image,
+            mask_url: req.mask,
+            num_images: 1,
+            output_format: "png",
+            sync_mode: true,
+            seed: req.seed,
+        };
+        self.finish(self.run(FLUX_FILL, &body).await?)
+    }
+
+    /// Qwen image-edit with no mask: a full-frame instruction edit driven by
+    /// `prompt` — e.g. colorizing monotone linework while preserving shape.
+    /// The result is opaque; reapply the source alpha afterward to re-register.
+    pub async fn qwen_edit(&self, req: &EditRequest<'_>) -> Result<ImageOutput, FalError> {
+        let body = QwenEditInput {
+            prompt: req.prompt,
+            image_url: req.image,
+            negative_prompt: req.negative_prompt,
+            num_images: 1,
+            output_format: "png",
+            sync_mode: true,
+            guidance_scale: req.guidance_scale,
+            seed: req.seed,
+        };
+        self.finish(self.run(QWEN_EDIT, &body).await?)
+    }
+
+    /// Structure-locked colorize via SDXL canny ControlNet inpaint. The canny
+    /// edges of `control_image` (clean linework) pin the composition in place,
+    /// `mask` scopes the colorized region, and `strength` controls how far the
+    /// init image is reworked. Registration is preserved, so the source alpha
+    /// stays valid.
+    pub async fn controlnet_lineart(
+        &self,
+        req: &LineartColorizeRequest<'_>,
+    ) -> Result<ImageOutput, FalError> {
+        let body = SdxlControlnetInpaintInput {
+            prompt: req.prompt,
+            negative_prompt: req.negative_prompt,
+            image_url: req.image,
+            control_image_url: req.control_image,
+            mask_url: req.mask,
+            strength: req.strength,
+            controlnet_conditioning_scale: req.controlnet_conditioning_scale,
+            num_images: 1,
+            format: "png",
+            sync_mode: true,
+            // Off by default: the checker false-positives on plain garment art.
+            enable_safety_checker: false,
+            seed: req.seed,
+        };
+        self.finish(self.run(SDXL_CONTROLNET_CANNY_INPAINT, &body).await?)
+    }
+
+    fn finish(&self, out: ImageOutput) -> Result<ImageOutput, FalError> {
+        if out.images.is_empty() {
+            return Err(FalError::NoImages);
+        }
+        Ok(out)
+    }
+}
+
+/// Shared parameters for the masked-inpaint wrappers. `image` and `mask` are
+/// data URIs (see [`png_data_uri`]); the mask's white pixels are the edit region.
+pub struct InpaintRequest<'a> {
+    pub prompt: &'a str,
+    pub negative_prompt: &'a str,
+    pub image: &'a str,
+    pub mask: &'a str,
+    pub seed: Option<u64>,
+    /// Qwen denoise strength in the masked region (fal default 0.93).
+    pub strength: f32,
+}
+
+impl Default for InpaintRequest<'_> {
+    fn default() -> Self {
+        Self {
+            prompt: "",
+            negative_prompt: " ",
+            image: "",
+            mask: "",
+            seed: None,
+            strength: 0.93,
+        }
+    }
+}
+
+/// Parameters for a no-mask full-frame edit ([`FalClient::qwen_edit`]).
+/// `image` is a data URI (see [`png_data_uri`]).
+pub struct EditRequest<'a> {
+    pub prompt: &'a str,
+    pub negative_prompt: &'a str,
+    pub image: &'a str,
+    pub seed: Option<u64>,
+    /// CFG scale — prompt adherence (fal default 4.0).
+    pub guidance_scale: f32,
+}
+
+impl Default for EditRequest<'_> {
+    fn default() -> Self {
+        Self {
+            prompt: "",
+            negative_prompt: " ",
+            image: "",
+            seed: None,
+            guidance_scale: 4.0,
+        }
+    }
+}
+
+/// Parameters for structure-locked colorize ([`FalClient::controlnet_lineart`]).
+/// `image`/`control_image`/`mask` are data URIs (see [`png_data_uri`]); typically
+/// `image` and `control_image` are the same flattened linework, and `mask` is the
+/// source asset's alpha silhouette (white = colorize).
+pub struct LineartColorizeRequest<'a> {
+    pub prompt: &'a str,
+    pub negative_prompt: &'a str,
+    pub image: &'a str,
+    pub control_image: &'a str,
+    pub mask: &'a str,
+    /// Resemblance to the init image (fal default 0.95; higher = more recolour).
+    pub strength: f32,
+    /// How strongly the canny edges pin structure (fal default 0.5; raise to lock harder).
+    pub controlnet_conditioning_scale: f32,
+    pub seed: Option<u64>,
+}
+
+impl Default for LineartColorizeRequest<'_> {
+    fn default() -> Self {
+        Self {
+            prompt: "",
+            negative_prompt: " ",
+            image: "",
+            control_image: "",
+            mask: "",
+            strength: 0.95,
+            controlnet_conditioning_scale: 0.8,
+            seed: None,
+        }
+    }
+}
+
+/// fal image result. With `sync_mode = true`, `images[].url` is a data URI.
+#[derive(Debug, Deserialize)]
+pub struct ImageOutput {
+    pub images: Vec<FalImage>,
+    #[serde(default)]
+    pub seed: Option<u64>,
+}
+
+impl ImageOutput {
+    /// Decode the first image to raw bytes (expects a `sync_mode` data URI).
+    pub fn first_bytes(&self) -> Result<Vec<u8>, FalError> {
+        let img = self.images.first().ok_or(FalError::NoImages)?;
+        decode_data_uri(&img.url)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FalImage {
+    /// Data URI when `sync_mode` is set, otherwise a hosted fal.media URL.
+    pub url: String,
+    #[serde(default)]
+    pub width: Option<u32>,
+    #[serde(default)]
+    pub height: Option<u32>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+}
+
+/// Wrap PNG bytes as a `data:image/png;base64,...` URI for fal `image_url`/`mask_url`.
+pub fn png_data_uri(bytes: &[u8]) -> String {
+    format!("data:image/png;base64,{}", base64::encode(bytes))
+}
+
+/// Decode a `data:...;base64,...` URI to raw bytes.
+pub fn decode_data_uri(uri: &str) -> Result<Vec<u8>, FalError> {
+    let b64 = uri
+        .split_once("base64,")
+        .map(|(_, rest)| rest)
+        .ok_or_else(|| FalError::Other("expected a base64 data URI (is sync_mode set?)".into()))?;
+    base64::decode(b64).ok_or_else(|| FalError::Other("invalid base64 in data URI".into()))
+}
+
+// ─── Request body types ──────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct QwenInpaintInput<'a> {
+    prompt: &'a str,
+    image_url: &'a str,
+    mask_url: &'a str,
+    negative_prompt: &'a str,
+    num_images: u32,
+    output_format: &'a str,
+    sync_mode: bool,
+    strength: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct QwenEditInput<'a> {
+    prompt: &'a str,
+    image_url: &'a str,
+    negative_prompt: &'a str,
+    num_images: u32,
+    output_format: &'a str,
+    sync_mode: bool,
+    guidance_scale: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct SdxlControlnetInpaintInput<'a> {
+    prompt: &'a str,
+    negative_prompt: &'a str,
+    image_url: &'a str,
+    control_image_url: &'a str,
+    mask_url: &'a str,
+    strength: f32,
+    controlnet_conditioning_scale: f32,
+    num_images: u32,
+    // Note: this endpoint uses `format`, not `output_format`.
+    format: &'a str,
+    sync_mode: bool,
+    enable_safety_checker: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct FluxFillInput<'a> {
+    prompt: &'a str,
+    image_url: &'a str,
+    mask_url: &'a str,
+    num_images: u32,
+    output_format: &'a str,
+    sync_mode: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_roundtrips_all_lengths() {
+        for n in 0..32usize {
+            let data: Vec<u8> = (0..n).map(|i| (i * 7 + 1) as u8).collect();
+            let enc = base64::encode(&data);
+            assert_eq!(base64::decode(&enc).as_deref(), Some(data.as_slice()), "n={n}");
+        }
+    }
+
+    #[test]
+    fn data_uri_roundtrips() {
+        let uri = png_data_uri(&[0, 1, 2, 253, 254, 255]);
+        assert!(uri.starts_with("data:image/png;base64,"));
+        assert_eq!(decode_data_uri(&uri).unwrap(), vec![0, 1, 2, 253, 254, 255]);
+    }
+
+    #[test]
+    fn decode_rejects_non_data_uri() {
+        assert!(decode_data_uri("https://fal.media/files/abc.png").is_err());
+    }
+}

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -26,8 +26,11 @@ pub const QWEN_EDIT: &str = "fal-ai/qwen-image-edit";
 /// canny control keeps the linework in place, mask scopes the region.
 pub const SDXL_CONTROLNET_CANNY_INPAINT: &str = "fal-ai/fast-sdxl-controlnet-canny/inpainting";
 /// `fal-ai/flux-control-lora-canny/image-to-image` — FLUX-quality canny-locked
-/// img2img (no mask). Higher fidelity than the SDXL path.
+/// img2img (no mask). A *refiner*: preserves the init image's colour.
 pub const FLUX_CANNY: &str = "fal-ai/flux-control-lora-canny/image-to-image";
+/// `fal-ai/flux-control-lora-canny` — FLUX canny **text-to-image**: generates
+/// from the control image's edges, so colour comes from the prompt (recolour).
+pub const FLUX_CANNY_GEN: &str = "fal-ai/flux-control-lora-canny";
 
 #[derive(Debug, thiserror::Error)]
 pub enum FalError {
@@ -157,6 +160,28 @@ impl FalClient {
         self.finish(self.run(FLUX_CANNY, &body).await?)
     }
 
+    /// FLUX canny **text-to-image**: generate fresh from the canny edges of
+    /// `control` with colour driven by `prompt`. Unlike [`Self::flux_canny`]
+    /// (a refiner), this actually recolours. Output is square (`square_hd`).
+    pub async fn flux_canny_generate(
+        &self,
+        req: &FluxCannyGenRequest<'_>,
+    ) -> Result<ImageOutput, FalError> {
+        let body = FluxCannyGenInput {
+            prompt: req.prompt,
+            control_lora_image_url: req.control,
+            control_lora_strength: req.control_strength,
+            guidance_scale: req.guidance_scale,
+            image_size: "square_hd",
+            num_images: 1,
+            output_format: "png",
+            sync_mode: true,
+            enable_safety_checker: false,
+            seed: req.seed,
+        };
+        self.finish(self.run(FLUX_CANNY_GEN, &body).await?)
+    }
+
     fn finish(&self, out: ImageOutput) -> Result<ImageOutput, FalError> {
         if out.images.is_empty() {
             return Err(FalError::NoImages);
@@ -274,6 +299,30 @@ impl Default for FluxCannyRequest<'_> {
     }
 }
 
+/// Parameters for FLUX canny generate-mode recolor ([`FalClient::flux_canny_generate`]).
+pub struct FluxCannyGenRequest<'a> {
+    pub prompt: &'a str,
+    /// Control image (canny auto-extracted); typically the flattened linework.
+    pub control: &'a str,
+    /// Canny control strength (fal default 1.0).
+    pub control_strength: f32,
+    /// CFG (fal default 3.5; raise for stronger prompt-colour adherence).
+    pub guidance_scale: f32,
+    pub seed: Option<u64>,
+}
+
+impl Default for FluxCannyGenRequest<'_> {
+    fn default() -> Self {
+        Self {
+            prompt: "",
+            control: "",
+            control_strength: 0.85,
+            guidance_scale: 3.5,
+            seed: None,
+        }
+    }
+}
+
 /// fal image result. With `sync_mode = true`, `images[].url` is a data URI.
 #[derive(Debug, Deserialize)]
 pub struct ImageOutput {
@@ -371,6 +420,21 @@ struct FluxCannyInput<'a> {
     strength: f32,
     control_lora_strength: f32,
     guidance_scale: f32,
+    num_images: u32,
+    output_format: &'a str,
+    sync_mode: bool,
+    enable_safety_checker: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct FluxCannyGenInput<'a> {
+    prompt: &'a str,
+    control_lora_image_url: &'a str,
+    control_lora_strength: f32,
+    guidance_scale: f32,
+    image_size: &'a str,
     num_images: u32,
     output_format: &'a str,
     sync_mode: bool,

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -25,6 +25,9 @@ pub const QWEN_EDIT: &str = "fal-ai/qwen-image-edit";
 /// `fal-ai/fast-sdxl-controlnet-canny/inpainting` — structure-locked colorize:
 /// canny control keeps the linework in place, mask scopes the region.
 pub const SDXL_CONTROLNET_CANNY_INPAINT: &str = "fal-ai/fast-sdxl-controlnet-canny/inpainting";
+/// `fal-ai/flux-control-lora-canny/image-to-image` — FLUX-quality canny-locked
+/// img2img (no mask). Higher fidelity than the SDXL path.
+pub const FLUX_CANNY: &str = "fal-ai/flux-control-lora-canny/image-to-image";
 
 #[derive(Debug, thiserror::Error)]
 pub enum FalError {
@@ -134,6 +137,26 @@ impl FalClient {
         self.finish(self.run(SDXL_CONTROLNET_CANNY_INPAINT, &body).await?)
     }
 
+    /// FLUX.1 [dev] canny-locked img2img colorize — higher fidelity than the
+    /// SDXL path. `image` is the img2img init and `control` the canny source
+    /// (typically the same flattened linework). No mask; reapply source alpha.
+    pub async fn flux_canny(&self, req: &FluxCannyRequest<'_>) -> Result<ImageOutput, FalError> {
+        let body = FluxCannyInput {
+            prompt: req.prompt,
+            image_url: req.image,
+            control_lora_image_url: req.control,
+            strength: req.strength,
+            control_lora_strength: req.control_strength,
+            guidance_scale: req.guidance_scale,
+            num_images: 1,
+            output_format: "png",
+            sync_mode: true,
+            enable_safety_checker: false,
+            seed: req.seed,
+        };
+        self.finish(self.run(FLUX_CANNY, &body).await?)
+    }
+
     fn finish(&self, out: ImageOutput) -> Result<ImageOutput, FalError> {
         if out.images.is_empty() {
             return Err(FalError::NoImages);
@@ -222,6 +245,35 @@ impl Default for LineartColorizeRequest<'_> {
     }
 }
 
+/// Parameters for FLUX canny-locked colorize ([`FalClient::flux_canny`]).
+/// `image`/`control` are data URIs (typically the same flattened linework).
+pub struct FluxCannyRequest<'a> {
+    pub prompt: &'a str,
+    pub image: &'a str,
+    pub control: &'a str,
+    /// img2img strength 0..1 (fal default 0.85).
+    pub strength: f32,
+    /// Canny control-LoRA strength (fal default 1.0; lower loosens the lock).
+    pub control_strength: f32,
+    /// CFG (fal default 3.5).
+    pub guidance_scale: f32,
+    pub seed: Option<u64>,
+}
+
+impl Default for FluxCannyRequest<'_> {
+    fn default() -> Self {
+        Self {
+            prompt: "",
+            image: "",
+            control: "",
+            strength: 0.85,
+            control_strength: 1.0,
+            guidance_scale: 3.5,
+            seed: None,
+        }
+    }
+}
+
 /// fal image result. With `sync_mode = true`, `images[].url` is a data URI.
 #[derive(Debug, Deserialize)]
 pub struct ImageOutput {
@@ -305,6 +357,22 @@ struct SdxlControlnetInpaintInput<'a> {
     num_images: u32,
     // Note: this endpoint uses `format`, not `output_format`.
     format: &'a str,
+    sync_mode: bool,
+    enable_safety_checker: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct FluxCannyInput<'a> {
+    prompt: &'a str,
+    image_url: &'a str,
+    control_lora_image_url: &'a str,
+    strength: f32,
+    control_lora_strength: f32,
+    guidance_scale: f32,
+    num_images: u32,
+    output_format: &'a str,
     sync_mode: bool,
     enable_safety_checker: bool,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -34,6 +34,9 @@ pub const FLUX_CANNY_GEN: &str = "fal-ai/flux-control-lora-canny";
 /// `fal-ai/birefnet/v2` — semantic background removal / matting (handles soft
 /// fur/hair edges far better than colour-keying).
 pub const BIREFNET: &str = "fal-ai/birefnet/v2";
+/// `fal-ai/flux-2-pro/edit` — frontier instruction-based editing (no mask),
+/// up to 9 reference images. Commercial use included.
+pub const FLUX2_EDIT: &str = "fal-ai/flux-2-pro/edit";
 
 #[derive(Debug, thiserror::Error)]
 pub enum FalError {
@@ -183,6 +186,17 @@ impl FalClient {
             seed: req.seed,
         };
         self.finish(self.run(FLUX_CANNY_GEN, &body).await?)
+    }
+
+    /// FLUX.2 [pro] instruction edit (no mask): transform `images` (1-9 data
+    /// URIs/URLs) per `prompt`. Frontier quality, flattened output.
+    pub async fn flux2_edit(&self, images: &[&str], prompt: &str) -> Result<ImageOutput, FalError> {
+        let body = Flux2EditInput {
+            prompt,
+            image_urls: images,
+            sync_mode: true,
+        };
+        self.finish(self.run(FLUX2_EDIT, &body).await?)
     }
 
     /// Semantic background removal / matting via BiRefNet. `model` selects the
@@ -459,6 +473,13 @@ struct FluxCannyInput<'a> {
     enable_safety_checker: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     seed: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct Flux2EditInput<'a> {
+    prompt: &'a str,
+    image_urls: &'a [&'a str],
+    sync_mode: bool,
 }
 
 #[derive(Serialize)]

--- a/fal-client/src/lib.rs
+++ b/fal-client/src/lib.rs
@@ -37,6 +37,17 @@ pub const BIREFNET: &str = "fal-ai/birefnet/v2";
 /// `fal-ai/flux-2-pro/edit` — frontier instruction-based editing (no mask),
 /// up to 9 reference images. Commercial use included.
 pub const FLUX2_EDIT: &str = "fal-ai/flux-2-pro/edit";
+/// `fal-ai/qwen-image-layered` — decompose an image into 1-10 semantic RGBA layers.
+pub const QWEN_LAYERED: &str = "fal-ai/qwen-image-layered";
+/// `fal-ai/nano-banana-2` — Google Nano Banana 2 text-to-image (Gemini-based;
+/// strong prompt/pose adherence). No native transparency — matte for alpha.
+pub const NANO_BANANA: &str = "fal-ai/nano-banana-2";
+/// `fal-ai/nano-banana-2/edit` — Nano Banana 2 instruction edit; best multi-frame
+/// character consistency, up to 14 reference images. Ideal for variation sets.
+pub const NANO_BANANA_EDIT: &str = "fal-ai/nano-banana-2/edit";
+/// `fal-ai/ideogram/v3/generate-transparent` — text-to-image with a native
+/// transparent background (no matte step needed).
+pub const IDEOGRAM_TRANSPARENT: &str = "fal-ai/ideogram/v3/generate-transparent";
 
 #[derive(Debug, thiserror::Error)]
 pub enum FalError {
@@ -197,6 +208,78 @@ impl FalClient {
             sync_mode: true,
         };
         self.finish(self.run(FLUX2_EDIT, &body).await?)
+    }
+
+    /// Decompose an image into `num_layers` (1-10) semantic RGBA layers.
+    /// Returns the layers as images (data URIs under `sync_mode`).
+    pub async fn qwen_layered(&self, image: &str, num_layers: u32) -> Result<ImageOutput, FalError> {
+        let body = QwenLayeredInput {
+            image_url: image,
+            num_layers,
+            output_format: "png",
+            sync_mode: true,
+        };
+        self.finish(self.run(QWEN_LAYERED, &body).await?)
+    }
+
+    /// Nano Banana 2 text-to-image. `aspect_ratio` e.g. "1:1"/"auto";
+    /// `resolution` is "1K"/"2K"/"4K".
+    pub async fn nano_banana(
+        &self,
+        prompt: &str,
+        num_images: u32,
+        aspect_ratio: &str,
+        resolution: &str,
+    ) -> Result<ImageOutput, FalError> {
+        let body = NanoBananaInput {
+            prompt,
+            num_images,
+            aspect_ratio,
+            resolution,
+            output_format: "png",
+            sync_mode: true,
+        };
+        self.finish(self.run(NANO_BANANA, &body).await?)
+    }
+
+    /// Nano Banana 2 instruction edit: transform `images` (1-14 data URIs/URLs)
+    /// per `prompt`, holding character identity across frames. `aspect_ratio`
+    /// "auto" preserves the input framing; `resolution` is "1K"/"2K"/"4K".
+    pub async fn nano_banana_edit(
+        &self,
+        images: &[&str],
+        prompt: &str,
+        num_images: u32,
+        aspect_ratio: &str,
+        resolution: &str,
+    ) -> Result<ImageOutput, FalError> {
+        let body = NanoBananaEditInput {
+            prompt,
+            image_urls: images,
+            num_images,
+            aspect_ratio,
+            resolution,
+            output_format: "png",
+            sync_mode: true,
+        };
+        self.finish(self.run(NANO_BANANA_EDIT, &body).await?)
+    }
+
+    /// Ideogram v3 text-to-image with a native transparent background.
+    /// `aspect_ratio` e.g. "1:1". Output is RGBA (no matte needed).
+    pub async fn ideogram_transparent(
+        &self,
+        prompt: &str,
+        num_images: u32,
+        aspect_ratio: &str,
+    ) -> Result<ImageOutput, FalError> {
+        let body = IdeogramTransparentInput {
+            prompt,
+            num_images,
+            aspect_ratio,
+            sync_mode: true,
+        };
+        self.finish(self.run(IDEOGRAM_TRANSPARENT, &body).await?)
     }
 
     /// Semantic background removal / matting via BiRefNet. `model` selects the
@@ -479,6 +562,43 @@ struct FluxCannyInput<'a> {
 struct Flux2EditInput<'a> {
     prompt: &'a str,
     image_urls: &'a [&'a str],
+    sync_mode: bool,
+}
+
+#[derive(Serialize)]
+struct QwenLayeredInput<'a> {
+    image_url: &'a str,
+    num_layers: u32,
+    output_format: &'a str,
+    sync_mode: bool,
+}
+
+#[derive(Serialize)]
+struct NanoBananaInput<'a> {
+    prompt: &'a str,
+    num_images: u32,
+    aspect_ratio: &'a str,
+    resolution: &'a str,
+    output_format: &'a str,
+    sync_mode: bool,
+}
+
+#[derive(Serialize)]
+struct NanoBananaEditInput<'a> {
+    prompt: &'a str,
+    image_urls: &'a [&'a str],
+    num_images: u32,
+    aspect_ratio: &'a str,
+    resolution: &'a str,
+    output_format: &'a str,
+    sync_mode: bool,
+}
+
+#[derive(Serialize)]
+struct IdeogramTransparentInput<'a> {
+    prompt: &'a str,
+    num_images: u32,
+    aspect_ratio: &'a str,
     sync_mode: bool,
 }
 

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -559,12 +559,24 @@ impl From<AddressUtxo> for cardano_assets::UtxoApi {
             }
         }
 
+        // Surface the structural tags the consumer (the UTxO shelf) needs to
+        // tell a datum-stamped UTxO from plain ADA. At a mint wallet a datum
+        // means our inline FUEL tag, so `HasDatum` is what the shelf colours
+        // "fuel" against the untagged liquid float.
+        let mut tags = Vec::new();
+        if utxo.datum.is_some() {
+            tags.push(cardano_assets::utxo::UtxoTag::HasDatum);
+        }
+        if utxo.script_ref.is_some() {
+            tags.push(cardano_assets::utxo::UtxoTag::HasScriptRef);
+        }
+
         Self {
             tx_hash: utxo.tx_hash,
             output_index: utxo.index,
             lovelace,
             assets: native_assets,
-            tags: vec![],
+            tags,
         }
     }
 }

--- a/ui/egui-widgets/src/managed_wallet_utxos.rs
+++ b/ui/egui-widgets/src/managed_wallet_utxos.rs
@@ -15,10 +15,62 @@
 //!     .show(ui);
 //! ```
 
-use cardano_assets::utxo::UtxoApi;
-use egui::{RichText, Ui};
+use cardano_assets::utxo::{UtxoApi, UtxoTag};
+use egui::{Color32, RichText, Ui};
 
 use crate::theme;
+
+/// The purpose a UTxO serves in a mint + payments wallet — what the block
+/// strip colours by. Derived purely from the UTxO's own shape: a datum means
+/// our inline FUEL tag (the engine stamps it on fan-out outputs), native
+/// assets are an anomaly here, and everything else is uncommitted liquid ADA
+/// (buyer payments awaiting mint + raw operating float — the two can't be told
+/// apart from the chain alone, so they share a colour).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BlockRole {
+    /// Carries our inline FUEL datum — committed fuel, ready to mint with.
+    Fuel,
+    /// Plain ADA, no datum — buyer payments awaiting mint + operating float.
+    Liquid,
+    /// Holds native assets where they're unexpected (a self-mint / stray send).
+    AssetAnomaly,
+    /// Holds native assets where that's normal (generic wallet).
+    Asset,
+}
+
+impl BlockRole {
+    fn of(u: &UtxoApi, assets_unexpected: bool) -> Self {
+        if !u.assets.is_empty() {
+            if assets_unexpected {
+                BlockRole::AssetAnomaly
+            } else {
+                BlockRole::Asset
+            }
+        } else if u.has_tag(UtxoTag::HasDatum) {
+            BlockRole::Fuel
+        } else {
+            BlockRole::Liquid
+        }
+    }
+
+    fn color(self) -> Color32 {
+        match self {
+            BlockRole::Fuel => theme::ACCENT_GREEN,
+            BlockRole::Liquid => theme::ACCENT_BLUE,
+            BlockRole::AssetAnomaly => theme::ACCENT_RED,
+            BlockRole::Asset => theme::ACCENT_YELLOW,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            BlockRole::Fuel => "Fuel",
+            BlockRole::Liquid => "Liquid ADA",
+            BlockRole::AssetAnomaly => "Holds assets",
+            BlockRole::Asset => "Assets",
+        }
+    }
+}
 
 /// Role-aware UTxO breakdown for a managed wallet.
 pub struct ManagedWalletUtxos<'a> {
@@ -300,8 +352,11 @@ impl<'a> ManagedWalletUtxos<'a> {
 }
 
 /// One block per UTxO, width ∝ lovelace (clamped so tiny ones stay visible),
-/// wrapping across rows. Spendable (ADA-only) blocks first, big→small, in
-/// green; asset-bearing blocks after, flagged. Hover shows the ref + amount.
+/// wrapping across rows. Coloured by [`BlockRole`] — tagged fuel (green),
+/// liquid ADA (blue), asset-bearing (flagged) — so a glance reads the wallet's
+/// composition by *purpose*, not just size. Fuel + liquid first (big→small),
+/// asset-bearing after. Hover shows the ref, amount, and role. A legend with
+/// per-role counts follows the strip.
 fn render_block_strip(ui: &mut Ui, utxos: &[UtxoApi], assets_unexpected: bool) {
     let max = utxos.iter().map(|u| u.lovelace).max().unwrap_or(1).max(1);
     const H: f32 = 20.0;
@@ -316,22 +371,20 @@ fn render_block_strip(ui: &mut Ui, utxos: &[UtxoApi], assets_unexpected: bool) {
 
     ui.horizontal_wrapped(|ui| {
         ui.spacing_mut().item_spacing = egui::vec2(3.0, 3.0);
-        for u in order {
-            let is_asset = !u.assets.is_empty();
+        for u in &order {
+            let role = BlockRole::of(u, assets_unexpected);
             let frac = u.lovelace as f32 / max as f32;
             let w = (MIN_W + frac * (MAX_W - MIN_W)).clamp(MIN_W, MAX_W);
             let (rect, resp) = ui.allocate_exact_size(egui::vec2(w, H), egui::Sense::hover());
-            let color = if is_asset && assets_unexpected {
-                theme::ACCENT_RED
-            } else if is_asset {
-                theme::ACCENT_YELLOW
-            } else {
-                theme::ACCENT_GREEN
-            };
-            ui.painter().rect_filled(rect, 2.0, color);
+            ui.painter().rect_filled(rect, 2.0, role.color());
             let head = &u.tx_hash[..u.tx_hash.len().min(8)];
-            let mut tip = format!("{head}…#{} · {} ADA", u.output_index, ada(u.lovelace));
-            if is_asset {
+            let mut tip = format!(
+                "{head}…#{} · {} ADA · {}",
+                u.output_index,
+                ada(u.lovelace),
+                role.label()
+            );
+            if !u.assets.is_empty() {
                 tip.push_str(&format!(
                     " · {} asset{}",
                     u.assets.len(),
@@ -339,6 +392,42 @@ fn render_block_strip(ui: &mut Ui, utxos: &[UtxoApi], assets_unexpected: bool) {
                 ));
             }
             resp.on_hover_text(tip);
+        }
+    });
+
+    render_role_legend(ui, &order, assets_unexpected);
+}
+
+/// A compact swatch + label + count for each role present in the strip, so the
+/// colour coding is self-explanatory without a hover. Order follows the strip
+/// (fuel, liquid, then asset roles); roles with no UTxOs are omitted.
+fn render_role_legend(ui: &mut Ui, utxos: &[&UtxoApi], assets_unexpected: bool) {
+    use std::collections::BTreeMap;
+    // BTreeMap keyed by a stable discriminant keeps a deterministic order.
+    let mut counts: BTreeMap<u8, (BlockRole, usize)> = BTreeMap::new();
+    for u in utxos {
+        let role = BlockRole::of(u, assets_unexpected);
+        let key = match role {
+            BlockRole::Fuel => 0,
+            BlockRole::Liquid => 1,
+            BlockRole::AssetAnomaly | BlockRole::Asset => 2,
+        };
+        counts.entry(key).or_insert((role, 0)).1 += 1;
+    }
+    if counts.is_empty() {
+        return;
+    }
+    ui.add_space(4.0);
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing = egui::vec2(10.0, 2.0);
+        for (role, n) in counts.values() {
+            let (rect, _) = ui.allocate_exact_size(egui::vec2(10.0, 10.0), egui::Sense::hover());
+            ui.painter().rect_filled(rect, 2.0, role.color());
+            ui.label(
+                RichText::new(format!("{} ({n})", role.label()))
+                    .color(theme::TEXT_SECONDARY)
+                    .small(),
+            );
         }
     });
 }
@@ -408,6 +497,28 @@ mod tests {
             assets,
             tags: vec![],
         }
+    }
+
+    #[test]
+    fn block_role_classifies_by_purpose() {
+        // Plain ADA, no datum → uncommitted liquid (payments + float).
+        assert_eq!(BlockRole::of(&pure(5_000_000), true), BlockRole::Liquid);
+
+        // Same UTxO carrying our inline FUEL datum → committed fuel.
+        let mut fuel = pure(5_000_000);
+        fuel.tags.push(UtxoTag::HasDatum);
+        assert_eq!(BlockRole::of(&fuel, true), BlockRole::Fuel);
+
+        // Native assets at a mint+payments wallet are an anomaly...
+        assert_eq!(
+            BlockRole::of(&with_assets(2_000_000, 1), true),
+            BlockRole::AssetAnomaly
+        );
+        // ...but plain `Asset` where assets are expected.
+        assert_eq!(
+            BlockRole::of(&with_assets(2_000_000, 1), false),
+            BlockRole::Asset
+        );
     }
 
     #[test]


### PR DESCRIPTION
Summary

Two independent additions to `shared-crates`, plus the supporting plumbing they need:

1. **`fal-client`** — a new platform-agnostic crate wrapping the [fal.ai](https://fal.run) image generation/editing API, for the on-chain art generator pipeline.
2. **UTxO tag datums** — a generic, versioned inline-datum facility (`cardano-assets::tag_datum`) plus the builder/indexer/UI plumbing to stamp, surface, and visualise role-tagged UTxOs (the minting engine's "FUEL" marker being the first consumer).

These are unrelated features that landed on the same branch; reviewers can read them independently.

---

## 1. New crate: `fal-client`

A thin, typed client for fal.ai's synchronous endpoint (`https://fal.run/{model_id}`).

- **Platform-agnostic** — built on the workspace `http-client` (reqwest on native, gloo-net on WASM), so it works inside workers too.
- Requests `sync_mode` so results come back inline as data URIs — no second download round-trip.
- Typed wrappers for the models we use, plus a generic `run<I, O>()` escape hatch for any model: Qwen inpaint/edit/layered, Flux Fill / Canny (refine + text-to-image), SDXL ControlNet canny, BiRefNet matting, Flux 2 edit, Nano Banana 2 (+ edit), and Ideogram transparent.
- `Authorization: Key <FAL_API_KEY>` auth; `InpaintRequest`/`EditRequest`/etc. request structs; `ImageOutput`/`MatteOutput` with `first_bytes()`/`image_bytes()` decode helpers.
- Self-contained, dependency-free base64 (matching the WASM-safe approach used elsewhere) for data-URI encode/decode.
- Runnable example: `cargo run -p fal-client --example qwen_inpaint -- base.png mask.png "<prompt>"`.

Added to the workspace members in the root `Cargo.toml`.

## 2. Generic UTxO tag datums

A small, reusable inline-datum facility that classifies a UTxO's role for an application, so coin-selection can tell purposes apart (e.g. delivery fuel vs operating float vs inbound payment) **without amount heuristics or a second address**.

- **`cardano-assets::tag_datum::UtxoTagDatum`** (behind a new `tag-datum` feature, same pallas deps as `cip68`): `Constr 0 [ Bytes(namespace), Int(version), Int(flags: u32) ]`. App-agnostic — `flags` meaning is owned by the reader, and a `namespace` scope guard (`in_namespace`) means a foreign `Constr 0 [..]` datum never false-positives as another app's tag. Round-trip + foreign-datum-rejection tests included.
- **`cardano-tx` `build_fan_out`** gains a `slot_datum: Option<Vec<u8>>` param — fan-out fuel-slot outputs can now carry an inline datum tag, making them self-describing on chain (CIP-32; spent with just the key witness, no script). Call sites pass `None` for the untagged behaviour.
- **`indexers/maestro`** now surfaces structural `UtxoTag::HasDatum` / `HasScriptRef` on `UtxoApi` conversion (previously always empty `tags`), so consumers can colour a datum-stamped UTxO apart from plain ADA.
- **`egui-widgets::ManagedWalletUtxos`** block strip is now coloured by a derived `BlockRole` (Fuel / Liquid ADA / asset-bearing-anomaly / Asset) instead of just ADA-only-vs-asset, with a per-role count legend and role in the hover tip. Classification + tests added.

## Misc

- `cardano-assets/src/supply.rs`: rustfmt-only reflow in a test.

## Testing

- `cargo test` across the touched crates (tag-datum round-trip/rejection, `build_fan_out` signature updates, `BlockRole` classification).
- `fal-client` example exercises a real inpaint when `FAL_API_KEY` is set.