### PR TITLE
feature: alternative trait extract strategy

### DIFF
--- a/cardano-assets/resources/test/funplastic.json
+++ b/cardano-assets/resources/test/funplastic.json
@@ -1,0 +1,49 @@
+{
+  "Artist": "zigor",
+  "Artist Website": "https://lynkfire.com/zigor",
+  "Id": "1 of 10000",
+  "Rarity": "Eggcellent",
+  "attributes": {
+    "Body Color": "B",
+    "Ears": "Bush",
+    "Ears Color": "C",
+    "Faces": "Ummm",
+    "Faces Color": "A",
+    "Horns": "Dead Cat",
+    "Horns Color": "C",
+    "Items": "None",
+    "Material": "BubbleGum",
+    "Medallion": "Cuadrado",
+    "Medallion Color": "C",
+    "Name-Size": "7",
+    "On Top": "Dino",
+    "On Top Color": "C",
+    "Scene": "Plantibolas",
+    "Scene Color": "Cold Winter",
+    "Tails": "Mono",
+    "Tails Color": "A",
+    "Used Slots": "6"
+  },
+  "description": [
+    "Funplastic is the generative collection of 10k exclusive",
+    "figurines created by Zigor for Benjamin Group. Half of the",
+    "artist's royalties go towards cleaning plastics from the ocean."
+  ],
+  "files": [
+    {
+      "mediaType": "image/png",
+      "name": "Quitepe",
+      "src": "ipfs://QmWJ4dS1PAHaPCJ3otKBT35FeRwsvLRuha5rWqJk22wYUc"
+    },
+    {
+      "mediaType": "image/jpg",
+      "name": "Instructions",
+      "src": "ipfs://QmZeWT5FYsaV7vY13idqaDLE2wmnvVJLk1Jkfm8djoGbkt"
+    }
+  ],
+  "image": "ipfs://QmWJ4dS1PAHaPCJ3otKBT35FeRwsvLRuha5rWqJk22wYUc",
+  "mediaType": "image/png",
+  "name": "Quitepe",
+  "royalties": "12%",
+  "twitter": "https://twitter.com/BenjaminsGroup"
+}

--- a/cardano-assets/resources/test/traits-chadano.json
+++ b/cardano-assets/resources/test/traits-chadano.json
@@ -1,0 +1,29 @@
+{
+  "assetKind": "citizen",
+  "collection": "Chadano Citizens",
+  "description": "Chadano Citizen #1396 from the Chadano Citizens collection.",
+  "files": [
+    {
+      "mediaType": "image/jpeg",
+      "name": "Chadano Citizens Citizen",
+      "src": "ipfs://QmQY9xUyfSKYfYybDP9226MEJ4fnLpzS6Z8HYv1SXyv7Xv"
+    }
+  ],
+  "image": "ipfs://QmZJVVpJvsLcaERfhrXEPyWV8MGBTWWoYoUtYZ3TFmeozx",
+  "mediaType": "image/jpeg",
+  "name": "Chadano Citizen #1396",
+  "phaseSupply": 1500,
+  "serialNumber": 1396,
+  "totalSupply": 1500,
+  "traits": [
+    { "trait_type": "Skin Tone", "value": "Light Skin" },
+    { "trait_type": "Background", "value": "Crimson" },
+    { "trait_type": "Body", "value": "Base Body" },
+    { "trait_type": "Outfit", "value": "Blue Blazer" },
+    { "trait_type": "Facial Hair", "value": "Clean Shaven Smile" },
+    { "trait_type": "Eyes", "value": "Black Stern Eyes" },
+    { "trait_type": "Hair", "value": "Black Mop Top" },
+    { "trait_type": "Sunglasses", "value": "Red Cool Shades" },
+    { "trait_type": "Hand Accessories", "value": "Commercial Here Tumbler" }
+  ]
+}

--- a/cardano-assets/src/extract.rs
+++ b/cardano-assets/src/extract.rs
@@ -1,0 +1,299 @@
+//! v2 trait extraction: envelope + composable trait patterns.
+//!
+//! The original [`crate::AssetMetadata`] models metadata as ~8
+//! whole-document `#[serde(untagged)]` variants, each re-declaring the
+//! common envelope (name/image/mediaType/files/…) alongside one trait
+//! encoding. Matching is therefore by *whole-document deserialization
+//! success* and by *variant order* — which is fragile: a document that
+//! doesn't fit its intended variant silently falls through to whichever
+//! other variant happens to deserialize, often producing wrong traits
+//! (e.g. an OpenSea `{trait_type,value}` array collapsing into bogus
+//! `trait_type`/`value` keys, or a single numeric attribute knocking a
+//! whole nested map into a fallback that drops every real trait).
+//!
+//! This module separates the two concerns:
+//!   1. A single [`AssetEnvelope`] captures the common fields once.
+//!   2. [`extract_traits`] dispatches on the JSON *shape* of the trait
+//!      data, so the same small set of orthogonal patterns compose
+//!      regardless of which collection produced them.
+//!
+//! It is deliberately built alongside the existing enum (not wired into
+//! the live path yet) so its output can be diffed against v1 over the
+//! whole fixture corpus before any cutover. See
+//! `tests/extract_corpus.rs`.
+
+use crate::{Asset, AssetFile, PrimitiveOrList, Traits};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Metadata keys that form the common envelope of an NFT and must never
+/// be surfaced as traits in flat-extraction mode. Compared lowercased,
+/// so this is the single source of truth shared by the typed envelope
+/// fields and the flat-trait filter (v1 had two lists that could drift).
+pub const ENVELOPE_KEYS: &[&str] = &[
+    "name",
+    "image",
+    "mediatype",
+    "files",
+    "description",
+    "project",
+    "collection",
+    "collection name",
+    "twitter",
+    "website",
+    "discord",
+    "github",
+    "medium",
+    "minter",
+    "publisher",
+    "sha256",
+    "url",
+];
+
+/// Keys whose value, when structured, holds the asset's traits.
+const SLOT_KEYS: &[&str] = &["traits", "attributes", "properties"];
+
+/// Universal trait keys that are kept even when they sit as a *sibling*
+/// of a structured slot (where siblings are otherwise ignored as
+/// metadata noise). These are cross-collection trait concepts, not
+/// per-collection fields — the curated inverse of [`ENVELOPE_KEYS`].
+/// Compared lowercased. Example: Funplastic nests its visual traits in
+/// an `attributes` map but puts `Rarity` at the top level.
+const PROMOTE_KEYS: &[&str] = &["rarity", "tier"];
+
+/// The common metadata envelope. Typed fields are parsed once; every
+/// other field lands in `rest` for trait extraction.
+#[derive(Deserialize, Debug, Clone)]
+pub struct AssetEnvelope {
+    #[serde(default, alias = "Name")]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub image: Option<PrimitiveOrList<String>>,
+    #[serde(default, alias = "mediaType", alias = "mediatype")]
+    pub media_type: Option<String>,
+    #[serde(default)]
+    pub files: Option<Vec<AssetFile>>,
+    #[serde(flatten)]
+    pub rest: HashMap<String, serde_json::Value>,
+}
+
+impl AssetEnvelope {
+    /// Project the envelope into an [`Asset`], extracting traits from
+    /// `rest` by shape. Mirrors the v1 `From<AssetMetadata>` output
+    /// (name/image/media_type/traits) but via the composable extractor.
+    pub fn into_asset(self) -> Asset {
+        let image = self
+            .image
+            .as_ref()
+            .map(PrimitiveOrList::dechunked)
+            .unwrap_or_default();
+        let media_type = self.resolve_media_type(&image);
+        let traits = extract_traits(&self.rest);
+        Asset {
+            name: self.name.unwrap_or_default(),
+            image,
+            media_type,
+            traits,
+            rarity_rank: None,
+            tags: vec![],
+        }
+    }
+
+    /// Top-level `mediaType` if present, else the media type of the file
+    /// whose `src` matches the (dechunked) image URL — matching v1's
+    /// `extract_media_type` fallback.
+    fn resolve_media_type(&self, image: &str) -> Option<String> {
+        if self.media_type.is_some() {
+            return self.media_type.clone();
+        }
+        if let Some(files) = &self.files {
+            for file in files {
+                if file.get_src() == image {
+                    return Some(file.media_type().to_string());
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Parse raw asset metadata JSON into an [`Asset`] via the v2 path.
+pub fn asset_from_metadata_json(json: &str) -> Result<Asset, serde_json::Error> {
+    let envelope: AssetEnvelope = serde_json::from_str(json)?;
+    Ok(envelope.into_asset())
+}
+
+/// The structured shapes a trait slot can take. A value-only string
+/// array (`["A","B"]`) is deliberately NOT a structured slot — it is
+/// treated as a flat multi-value field, matching how v1 surfaced
+/// SpaceBudz-style `traits` arrays (the array under its own key, with
+/// sibling scalars still becoming traits).
+enum SlotShape {
+    /// `{ "Background": "Crimson", ... }`
+    Map,
+    /// `[ { "trait_type"|"name": K, "value": V }, ... ]` (OpenSea / gophers)
+    Codified,
+    /// `[ { "K": "V" }, ... ]` (one or more single-key objects per element)
+    ObjectArray,
+    /// `[ "State: Delusional", ... ]`
+    ColonDelimited,
+}
+
+/// Classify a candidate slot value. Returns `None` when the value is not
+/// a *structured* trait container (e.g. a value-only string array, a
+/// scalar, or an empty array), in which case flat extraction applies.
+fn classify_slot(value: &serde_json::Value) -> Option<SlotShape> {
+    match value {
+        serde_json::Value::Object(_) => Some(SlotShape::Map),
+        serde_json::Value::Array(items) if !items.is_empty() => {
+            if items.iter().all(serde_json::Value::is_object) {
+                let codified = items.iter().all(|item| {
+                    let obj = item.as_object().expect("checked is_object");
+                    obj.contains_key("value")
+                        && (obj.contains_key("trait_type") || obj.contains_key("name"))
+                });
+                Some(if codified {
+                    SlotShape::Codified
+                } else {
+                    SlotShape::ObjectArray
+                })
+            } else if items.iter().all(serde_json::Value::is_string) {
+                let any_colon = items
+                    .iter()
+                    .any(|v| v.as_str().is_some_and(|s| s.contains(':')));
+                any_colon.then_some(SlotShape::ColonDelimited)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Extract traits from `rest`. If a structured trait slot
+/// (`traits`/`attributes`/`properties`) is present, traits come solely
+/// from it (sibling scalars are envelope/metadata noise). Otherwise all
+/// non-envelope scalar/array fields are treated as flat traits.
+pub fn extract_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
+    for slot in SLOT_KEYS {
+        if let Some((_, value)) = rest.iter().find(|(k, _)| k.to_lowercase() == *slot) {
+            if let Some(shape) = classify_slot(value) {
+                let mut traits = extract_slot(shape, value);
+                promote_siblings(&mut traits, rest);
+                return traits;
+            }
+        }
+    }
+    flat_extract(rest)
+}
+
+/// Fold any [`PROMOTE_KEYS`] siblings of a structured slot into the
+/// trait set — the few universal trait concepts (e.g. `rarity`) that are
+/// worth keeping even though the slot rule otherwise drops siblings.
+fn promote_siblings(traits: &mut Traits, rest: &HashMap<String, serde_json::Value>) {
+    for (key, value) in rest {
+        if PROMOTE_KEYS.contains(&key.to_lowercase().as_str()) {
+            insert_if_present(traits, key.clone(), value);
+        }
+    }
+}
+
+fn extract_slot(shape: SlotShape, value: &serde_json::Value) -> Traits {
+    let mut traits = Traits::new();
+    match shape {
+        SlotShape::Map => {
+            if let Some(map) = value.as_object() {
+                for (key, val) in map {
+                    insert_if_present(&mut traits, key.clone(), val);
+                }
+            }
+        }
+        SlotShape::Codified => {
+            for item in value.as_array().into_iter().flatten() {
+                let Some(obj) = item.as_object() else {
+                    continue;
+                };
+                let key = obj
+                    .get("trait_type")
+                    .or_else(|| obj.get("name"))
+                    .and_then(|v| v.as_str());
+                if let (Some(key), Some(val)) = (key, obj.get("value")) {
+                    insert_if_present(&mut traits, key.to_string(), val);
+                }
+            }
+        }
+        SlotShape::ObjectArray => {
+            for item in value.as_array().into_iter().flatten() {
+                if let Some(obj) = item.as_object() {
+                    for (key, val) in obj {
+                        insert_if_present(&mut traits, key.clone(), val);
+                    }
+                }
+            }
+        }
+        SlotShape::ColonDelimited => {
+            for item in value.as_array().into_iter().flatten() {
+                if let Some((key, val)) = item.as_str().and_then(|s| s.split_once(':')) {
+                    let key = key.trim();
+                    let val = val.trim();
+                    if !key.is_empty() && !val.is_empty() {
+                        traits.insert_single(key.to_string(), val.to_string());
+                    }
+                }
+            }
+        }
+    }
+    traits
+}
+
+fn flat_extract(rest: &HashMap<String, serde_json::Value>) -> Traits {
+    let mut traits = Traits::new();
+    for (key, val) in rest {
+        if ENVELOPE_KEYS.contains(&key.to_lowercase().as_str()) {
+            continue;
+        }
+        insert_if_present(&mut traits, key.clone(), val);
+    }
+    traits
+}
+
+/// Insert a trait under `key`, coercing the JSON value to one or more
+/// strings. Numbers/bools stringify; string arrays stay multi-valued;
+/// objects, nulls and empty results are skipped.
+fn insert_if_present(traits: &mut Traits, key: String, value: &serde_json::Value) {
+    let values = json_to_strings(value);
+    if !values.is_empty() {
+        traits.insert_vec(key, values);
+    }
+}
+
+/// Coerce a JSON value to trait string(s): scalars to a single trimmed
+/// string, arrays to their scalar elements (one level, trimmed,
+/// non-empty), objects/nulls to nothing.
+fn json_to_strings(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::String(s) => {
+            let s = s.trim();
+            if s.is_empty() {
+                vec![]
+            } else {
+                vec![s.to_string()]
+            }
+        }
+        serde_json::Value::Number(n) => vec![n.to_string()],
+        serde_json::Value::Bool(b) => vec![b.to_string()],
+        serde_json::Value::Array(arr) => arr
+            .iter()
+            .flat_map(|v| match v {
+                serde_json::Value::String(s) => {
+                    let s = s.trim();
+                    (!s.is_empty()).then(|| s.to_string())
+                }
+                serde_json::Value::Number(n) => Some(n.to_string()),
+                serde_json::Value::Bool(b) => Some(b.to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => vec![],
+    }
+}

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -352,6 +352,9 @@ pub struct UnsigData {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct CodifiedTrait {
+    // `trait_type` is the OpenSea-standard key (used by e.g. Chadano Citizens);
+    // `name` is the original gophers-style key. Both normalise to the same trait.
+    #[serde(alias = "trait_type")]
     pub name: String,
     pub value: String,
     #[serde(default)]
@@ -1631,6 +1634,59 @@ mod tests {
                 panic!("failed decoding: {err:?}");
             }
         }
+    }
+
+    #[test]
+    fn test_chadano_trait_type_codified() {
+        // Chadano Citizens use the OpenSea-standard `trait_type`/`value` array
+        // shape. This must match the CodifiedTraits variant (via the `trait_type`
+        // alias) and NOT fall through to AttributeArray, which would otherwise
+        // collapse every object into bogus `trait_type`/`value` keys.
+        match serde_json::from_str::<AssetMetadata>(test_case!("traits-chadano.json")) {
+            Ok(metadata) => match metadata {
+                AssetMetadata::CodifiedTraits {
+                    name,
+                    media_type,
+                    traits,
+                    ..
+                } => {
+                    assert_eq!(name, "Chadano Citizen #1396");
+                    assert_eq!(media_type, Some("image/jpeg".to_string()));
+                    assert_eq!(
+                        traits,
+                        vec![
+                            CodifiedTrait::new("Skin Tone", "Light Skin"),
+                            CodifiedTrait::new("Background", "Crimson"),
+                            CodifiedTrait::new("Body", "Base Body"),
+                            CodifiedTrait::new("Outfit", "Blue Blazer"),
+                            CodifiedTrait::new("Facial Hair", "Clean Shaven Smile"),
+                            CodifiedTrait::new("Eyes", "Black Stern Eyes"),
+                            CodifiedTrait::new("Hair", "Black Mop Top"),
+                            CodifiedTrait::new("Sunglasses", "Red Cool Shades"),
+                            CodifiedTrait::new("Hand Accessories", "Commercial Here Tumbler"),
+                        ]
+                    );
+                }
+                other => panic!("expected CodifiedTraits, got {other:?}"),
+            },
+            Err(err) => {
+                panic!("failed decoding: {err:?}");
+            }
+        }
+
+        // And verify the end-to-end Asset projection exposes the traits as a map.
+        let asset: Asset = serde_json::from_str::<AssetMetadata>(test_case!("traits-chadano.json"))
+            .unwrap()
+            .into();
+        assert_eq!(asset.name, "Chadano Citizen #1396");
+        assert_eq!(
+            asset.traits.get("Background"),
+            Some(&vec!["Crimson".to_string()])
+        );
+        assert_eq!(
+            asset.traits.get("Hand Accessories"),
+            Some(&vec!["Commercial Here Tumbler".to_string()])
+        );
     }
 
     #[test]

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cip25;
 #[cfg(feature = "cip68")]
 pub mod cip68;
 pub mod collection;
+pub mod extract;
 #[cfg(feature = "cip14")]
 pub mod fingerprint;
 pub mod policy_id;
@@ -42,6 +43,7 @@ pub use cip25::{cip25_metadata_json, cip25_metadata_value, decode_cip25_metadata
 #[cfg(feature = "cip68")]
 pub use cip68::{decode_cip68_datum, Cip68Error};
 pub use collection::*;
+pub use extract::{asset_from_metadata_json, extract_traits, AssetEnvelope, ENVELOPE_KEYS};
 #[cfg(feature = "cip14")]
 pub use fingerprint::{Fingerprint, FingerprintError};
 pub use policy_id::{PolicyId, PolicyIdError};

--- a/cardano-assets/tests/extract_corpus.rs
+++ b/cardano-assets/tests/extract_corpus.rs
@@ -8,21 +8,22 @@
 //! known v1 bugs, each spelled out so any future drift is caught and
 //! every behavioural difference is reviewed rather than silent.
 //!
-//! This is the safety net for the incremental refactor: as long as the
-//! `SameAsV1` set stays green, v2 is behaviour-preserving for every
-//! shape we have a real on-chain sample of; the correction set documents
-//! exactly where (and why) v2 deviates.
+//! **Exhaustiveness is enforced.** `corpus_is_exhaustive` walks
+//! `resources/test/` and fails if any fixture is neither in the corpus
+//! below nor in `NON_METADATA_FIXTURES` (with a reason). So a new
+//! fixture can't silently go unverified under v2 — you must classify it.
 
 use cardano_assets::{asset_from_metadata_json, Asset, AssetMetadata, Traits};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
 
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/test")
+}
+
 fn fixture(name: &str) -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("resources/test")
-        .join(name);
-    fs::read_to_string(path).unwrap_or_else(|e| panic!("read {name}: {e}"))
+    fs::read_to_string(fixtures_dir().join(name)).unwrap_or_else(|e| panic!("read {name}: {e}"))
 }
 
 fn sorted(t: &Traits) -> BTreeMap<String, Vec<String>> {
@@ -61,10 +62,11 @@ enum Expect {
     },
 }
 
-#[test]
-fn extractor_corpus() {
+/// Every per-asset metadata fixture and its v2 expectation. The single
+/// source of truth for what the v2 extractor must produce.
+fn corpus_cases() -> Vec<(&'static str, Expect)> {
     use Expect::*;
-    let cases: &[(&str, Expect)] = &[
+    vec![
         // ---- behaviour-preserving: identical to v1 -------------------
         ("traits-chadano.json", SameAsV1), // codified {trait_type,value}
         ("traits-gopher.json", SameAsV1),  // codified {name,value,display}
@@ -80,6 +82,12 @@ fn extractor_corpus() {
         // `series` is a sibling of the `attributes` slot — metadata, not
         // a visual trait. v1 folded it in via merge_extra_fields.
         ("derpbird07490.json", V1Minus(&["series"])),
+        // Asset-shaped fixtures (carry an `id`): a flat `traits` map with
+        // `id` as a sibling. v1 flattened `id` in as a trait; v2 reads
+        // the map slot and drops the `id` sibling. Same content in both
+        // (https_image is the Pirate #84 record with an https image).
+        ("5069726174653834.json", V1Minus(&["id"])),
+        ("https_image.json", V1Minus(&["id"])),
         // The big one: a numeric `Rank: 1` inside `attributes` made the
         // v1 `Attributed` variant fail to deserialize, so it fell through
         // to `FlattenedMixed`, which DROPPED the whole attributes object
@@ -102,9 +110,7 @@ fn extractor_corpus() {
         // BlockGen authority tokens have no `name` (v1 -> `Untitled` ->
         // empty traits) but DO carry `properties: {type: master}`, a
         // structured slot. v2 surfaces it and ignores the envelope
-        // siblings (artist/medium/vendor/projectPolicyId). This is the
-        // only case where v2 yields traits v1 did not — review before
-        // cutover if authority tokens should stay trait-less.
+        // siblings (artist/medium/vendor/projectPolicyId).
         (
             "blockgen-auth-master.json",
             Exact {
@@ -176,9 +182,32 @@ fn extractor_corpus() {
                 note: "attributes slot + promoted Rarity sibling, metadata siblings dropped",
             },
         ),
-    ];
+    ]
+}
 
-    for (name, expect) in cases {
+/// Fixtures in `resources/test/` that are deliberately NOT per-asset
+/// metadata, so they're out of scope for the v2 extractor. Listed here
+/// (with a reason) so `corpus_is_exhaustive` can prove the corpus covers
+/// everything else — nothing is silently skipped.
+const NON_METADATA_FIXTURES: &[(&str, &str)] = &[
+    (
+        "blackflag-traits.json",
+        "collection trait-summary (parsed as TraitSummarySorted), not per-asset metadata",
+    ),
+    (
+        "swatch_tagged_union.json",
+        "empty/invalid fixture (decode error expected)",
+    ),
+    (
+        "ug_mint.json",
+        "CIP-25 mint-tx CBOR aux-data (decode_cip25 test input), not asset-metadata JSON",
+    ),
+];
+
+#[test]
+fn extractor_corpus() {
+    use Expect::*;
+    for (name, expect) in corpus_cases() {
         let raw = fixture(name);
         let v2 = v2_traits(&raw);
         match expect {
@@ -187,7 +216,7 @@ fn extractor_corpus() {
             }
             V1Minus(removed) => {
                 let mut want = v1_traits(&raw);
-                for k in *removed {
+                for k in removed {
                     assert!(want.remove(*k).is_some(), "{name}: v1 lacked key {k:?}");
                 }
                 assert_eq!(v2, want, "{name}: v2 must equal v1 minus {removed:?}");
@@ -197,6 +226,34 @@ fn extractor_corpus() {
             }
         }
     }
+}
+
+/// Guard: every `*.json` fixture on disk must be accounted for — either
+/// pinned in `corpus_cases()` or listed in `NON_METADATA_FIXTURES`. A
+/// fixture added without classifying it fails here, so the v2 corpus
+/// can never silently fall behind the fixture set.
+#[test]
+fn corpus_is_exhaustive() {
+    let covered: std::collections::HashSet<&str> = corpus_cases().iter().map(|(n, _)| *n).collect();
+    let skipped: std::collections::HashSet<&str> =
+        NON_METADATA_FIXTURES.iter().map(|(n, _)| *n).collect();
+
+    let mut unclassified = Vec::new();
+    for entry in fs::read_dir(fixtures_dir()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().map(|x| x == "json").unwrap_or(false) {
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            if !covered.contains(name.as_str()) && !skipped.contains(name.as_str()) {
+                unclassified.push(name);
+            }
+        }
+    }
+    unclassified.sort();
+    assert!(
+        unclassified.is_empty(),
+        "fixtures not covered by the v2 corpus (add to corpus_cases() or \
+         NON_METADATA_FIXTURES): {unclassified:?}"
+    );
 }
 
 /// SpaceBudz-style CIP-68: `traits` is a value-only string array (kept

--- a/cardano-assets/tests/extract_corpus.rs
+++ b/cardano-assets/tests/extract_corpus.rs
@@ -1,0 +1,242 @@
+//! Golden corpus for the v2 envelope+pattern extractor
+//! (`cardano_assets::extract`).
+//!
+//! For every per-asset metadata fixture this pins the v2 output and
+//! states its relationship to the legacy v1 (`AssetMetadata` -> `Asset`)
+//! output. Most fixtures must be byte-for-byte identical to v1
+//! (`Expect::SameAsV1`); the rest are *intentional corrections* of
+//! known v1 bugs, each spelled out so any future drift is caught and
+//! every behavioural difference is reviewed rather than silent.
+//!
+//! This is the safety net for the incremental refactor: as long as the
+//! `SameAsV1` set stays green, v2 is behaviour-preserving for every
+//! shape we have a real on-chain sample of; the correction set documents
+//! exactly where (and why) v2 deviates.
+
+use cardano_assets::{asset_from_metadata_json, Asset, AssetMetadata, Traits};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+
+fn fixture(name: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("resources/test")
+        .join(name);
+    fs::read_to_string(path).unwrap_or_else(|e| panic!("read {name}: {e}"))
+}
+
+fn sorted(t: &Traits) -> BTreeMap<String, Vec<String>> {
+    t.inner().clone().into_iter().collect()
+}
+
+fn v1_traits(raw: &str) -> BTreeMap<String, Vec<String>> {
+    match serde_json::from_str::<AssetMetadata>(raw) {
+        Ok(meta) => sorted(&Asset::from(meta).traits),
+        Err(_) => BTreeMap::new(),
+    }
+}
+
+fn v2_traits(raw: &str) -> BTreeMap<String, Vec<String>> {
+    sorted(&asset_from_metadata_json(raw).expect("v2 decode").traits)
+}
+
+fn map(pairs: &[(&str, &[&str])]) -> BTreeMap<String, Vec<String>> {
+    pairs
+        .iter()
+        .map(|(k, vs)| (k.to_string(), vs.iter().map(|s| s.to_string()).collect()))
+        .collect()
+}
+
+enum Expect {
+    /// v2 reproduces v1 exactly (behaviour-preserving).
+    SameAsV1,
+    /// v2 == v1 with these keys removed — v1 leaked an envelope field
+    /// into traits, or folded a sibling of a structured trait slot.
+    V1Minus(&'static [&'static str]),
+    /// v2 produces this exact trait map, where v1 was wrong enough that
+    /// "v1 minus keys" doesn't describe it. `note` says why.
+    Exact {
+        traits: &'static [(&'static str, &'static [&'static str])],
+        note: &'static str,
+    },
+}
+
+#[test]
+fn extractor_corpus() {
+    use Expect::*;
+    let cases: &[(&str, Expect)] = &[
+        // ---- behaviour-preserving: identical to v1 -------------------
+        ("traits-chadano.json", SameAsV1), // codified {trait_type,value}
+        ("traits-gopher.json", SameAsV1),  // codified {name,value,display}
+        ("traits-mallards.json", SameAsV1), // array of single-key objects
+        ("traits-anscestors.json", SameAsV1), // flat top-level keys
+        ("traits-toolhead.json", SameAsV1), // nested attributes map (single+multi)
+        ("traits-wiseowl.json", SameAsV1), // flat, chunked image
+        // ---- intentional corrections of v1 bugs ----------------------
+        // v1 `Flattened` doesn't declare `collection`, so the collection
+        // name leaked in as a per-asset trait.
+        ("bankcard2500.json", V1Minus(&["collection"])),
+        ("traits-oldmoney.json", V1Minus(&["Collection"])),
+        // `series` is a sibling of the `attributes` slot — metadata, not
+        // a visual trait. v1 folded it in via merge_extra_fields.
+        ("derpbird07490.json", V1Minus(&["series"])),
+        // The big one: a numeric `Rank: 1` inside `attributes` made the
+        // v1 `Attributed` variant fail to deserialize, so it fell through
+        // to `FlattenedMixed`, which DROPPED the whole attributes object
+        // and emitted the metadata siblings instead. v2 reads the map
+        // (coercing the number) and ignores the siblings.
+        (
+            "pred09193.json",
+            Exact {
+                traits: &[
+                    ("Background", &["Infiltration"]),
+                    ("Body", &["Farmer's Body"]),
+                    ("Face", &["Trooper's Face"]),
+                    ("Head", &["Marksman's ???"]),
+                    ("Rank", &["1"]),
+                    ("Skin Color", &["Gray"]),
+                ],
+                note: "numeric attribute no longer discards the trait set",
+            },
+        ),
+        // BlockGen authority tokens have no `name` (v1 -> `Untitled` ->
+        // empty traits) but DO carry `properties: {type: master}`, a
+        // structured slot. v2 surfaces it and ignores the envelope
+        // siblings (artist/medium/vendor/projectPolicyId). This is the
+        // only case where v2 yields traits v1 did not — review before
+        // cutover if authority tokens should stay trait-less.
+        (
+            "blockgen-auth-master.json",
+            Exact {
+                traits: &[("type", &["master"])],
+                note: "properties slot on a nameless authority token",
+            },
+        ),
+        (
+            "blockgen-auth-playground.json",
+            Exact {
+                traits: &[("type", &["master"])],
+                note: "properties slot on a nameless authority token",
+            },
+        ),
+        (
+            "blockgen-artist-hookman.json",
+            Exact {
+                traits: &[("type", &["master"])],
+                note: "properties slot on a nameless authority token",
+            },
+        ),
+        (
+            "blockgen-artist-autrecoeur.json",
+            Exact {
+                traits: &[("type", &["master"])],
+                note: "properties slot on a nameless authority token",
+            },
+        ),
+        (
+            "blockgen-artist-charlesmachin.json",
+            Exact {
+                traits: &[("type", &["master"])],
+                note: "properties slot on a nameless authority token",
+            },
+        ),
+        // Funplastic: visual traits nested in an `attributes` map, with
+        // `Rarity` as a top-level sibling. v1 surfaced only the flat
+        // siblings (Artist/royalties/Rarity/…) and dropped the whole
+        // attributes block. v2 reads the slot AND promotes `Rarity` (a
+        // PROMOTE_KEY) while ignoring the metadata siblings (Artist,
+        // Artist Website, Id, royalties). Name-Size/Used Slots are kept
+        // here (the worker's all-numeric cardinality filter drops them
+        // downstream, not the extractor).
+        (
+            "funplastic.json",
+            Exact {
+                traits: &[
+                    ("Body Color", &["B"]),
+                    ("Ears", &["Bush"]),
+                    ("Ears Color", &["C"]),
+                    ("Faces", &["Ummm"]),
+                    ("Faces Color", &["A"]),
+                    ("Horns", &["Dead Cat"]),
+                    ("Horns Color", &["C"]),
+                    ("Items", &["None"]),
+                    ("Material", &["BubbleGum"]),
+                    ("Medallion", &["Cuadrado"]),
+                    ("Medallion Color", &["C"]),
+                    ("Name-Size", &["7"]),
+                    ("On Top", &["Dino"]),
+                    ("On Top Color", &["C"]),
+                    ("Scene", &["Plantibolas"]),
+                    ("Scene Color", &["Cold Winter"]),
+                    ("Tails", &["Mono"]),
+                    ("Tails Color", &["A"]),
+                    ("Used Slots", &["6"]),
+                    ("Rarity", &["Eggcellent"]),
+                ],
+                note: "attributes slot + promoted Rarity sibling, metadata siblings dropped",
+            },
+        ),
+    ];
+
+    for (name, expect) in cases {
+        let raw = fixture(name);
+        let v2 = v2_traits(&raw);
+        match expect {
+            SameAsV1 => {
+                assert_eq!(v2, v1_traits(&raw), "{name}: v2 must match v1");
+            }
+            V1Minus(removed) => {
+                let mut want = v1_traits(&raw);
+                for k in *removed {
+                    assert!(want.remove(*k).is_some(), "{name}: v1 lacked key {k:?}");
+                }
+                assert_eq!(v2, want, "{name}: v2 must equal v1 minus {removed:?}");
+            }
+            Exact { traits, note } => {
+                assert_eq!(v2, map(traits), "{name}: {note}");
+            }
+        }
+    }
+}
+
+/// SpaceBudz-style CIP-68: `traits` is a value-only string array (kept
+/// as a multi-value flat field, NOT a structured slot) and `type` is a
+/// flat sibling that should still surface; `image`/`sha256` must not.
+/// (No fixture file — locked here to match the existing v1 inline test.)
+#[test]
+fn value_only_traits_array_is_flat() {
+    let json = r#"{
+        "name": "SpaceBud #0",
+        "traits": ["Star Suit", "Chestplate", "Belt", "Covered Helmet"],
+        "type": "Frog",
+        "image": "ipfs://bafkreicbn7uu2wyfpzjgterlumqk2pxisww7hszdfupwy2lydtsq3prufq",
+        "sha256": "416fe94d5b057e5269922ba320ad3ee895adf3cb232d1f6c69781ce50dbe342c"
+    }"#;
+    let asset = asset_from_metadata_json(json).expect("decode");
+    assert_eq!(asset.name, "SpaceBud #0");
+    assert_eq!(asset.traits.get("type"), Some(&vec!["Frog".to_string()]));
+    let mut gadgets = asset.traits.get("traits").cloned().unwrap_or_default();
+    gadgets.sort();
+    assert_eq!(
+        gadgets,
+        vec!["Belt", "Chestplate", "Covered Helmet", "Star Suit"]
+    );
+    assert!(!asset.traits.contains_key("sha256"));
+    assert!(!asset.traits.contains_key("image"));
+}
+
+/// Colon-delimited attribute arrays (BlockOwls-style) parse into pairs.
+#[test]
+fn colon_delimited_attributes() {
+    let json = r#"{
+        "name": "BlockOwl #1",
+        "image": "ipfs://abc",
+        "attributes": ["State: Delusional", "Mood: Gloomy"]
+    }"#;
+    let asset = asset_from_metadata_json(json).expect("decode");
+    assert_eq!(
+        asset.traits.get("State"),
+        Some(&vec!["Delusional".to_string()])
+    );
+    assert_eq!(asset.traits.get("Mood"), Some(&vec!["Gloomy".to_string()]));
+}


### PR DESCRIPTION
Adds a new trait-extraction path to `cardano-assets` that parses NFT metadata via a **common envelope + composable trait-shape dispatch**, replacing the fragile `#[serde(untagged)] AssetMetadata` enum for trait derivation. New public entry point `asset_from_metadata_json(&str) -> Result<Asset>`. Fully additive: the v1 enum and its consumers are untouched, so this can be adopted incrementally.

### Why

The untagged enum matched on *whole-document deserialization success* and *variant order*, so any document that didn't fit its intended variant silently fell through to whichever other variant happened to deserialize — producing wrong or empty traits. Two real collections exposed this:

- **Chadano Citizens** — OpenSea-standard `[{trait_type, value}]` arrays mis-matched `AttributeArray` and produced garbage keys.
- **Funplastic** — a numeric attribute knocked the whole nested `attributes` map into a fallback that dropped every real trait.

### What changed

- **`src/extract.rs`** (new) — `AssetEnvelope` (typed `name`/`image`/`mediaType`/`files` + `#[serde(flatten)] rest`) and `extract_traits()`, which dispatches on the JSON **shape** of the trait data:
  - structured slot (`traits`/`attributes`/`properties`) as a map, `{trait_type|name, value}` array, single-key-object array, or colon-delimited array → traits come from the slot; siblings ignored;
  - otherwise flat top-level scalars/arrays become traits.
  - One `ENVELOPE_KEYS` set is the single source of truth for "not a trait" (v1 had two lists that drifted), and a small `PROMOTE_KEYS` (`rarity`, `tier`) keeps universal trait concepts even when they sit beside a structured slot.
- **`src/lib.rs`** — `CodifiedTrait.name` gains `#[serde(alias = "trait_type")]` (the minimal Chadano fix for the v1 path too); `pub mod extract` + re-exports.
- **`tests/extract_corpus.rs`** (new) — golden corpus over every fixture plus a `corpus_is_exhaustive` guard that fails if any fixture isn't classified.
- **`resources/test/{traits-chadano,funplastic}.json`** (new) — real on-chain fixtures for the OpenSea-array and reveal-collection shapes.

### Behavioural deltas vs v1

6 fixtures are byte-for-byte identical to v1; the rest are **intentional corrections of v1 bugs**, each pinned in the corpus:

| Fixture(s) | Change |
|---|---|
| chadano, gopher, mallards, anscestors, toolhead, wiseowl | identical to v1 |
| `bankcard2500`, `oldmoney` | drop leaked `collection`/`Collection` |
| `5069…`, `https_image` | drop leaked `id` |
| `derpbird07490` | drop `series` (metadata sibling of the `attributes` slot) |
| `pred09193` | **+6 real traits, −3 junk** — a numeric attribute no longer discards the trait set |
| `blockgen-*` (×5) | gain `type=master` from the `properties` slot (v1 → empty) |
| `funplastic` | full `attributes` slot + promoted `Rarity`, metadata siblings dropped |

### Backward compatibility

Additive only — `AssetMetadata` and its `From<…> for Asset` impl, `has_fungible_signals`, and `cid::extract_cids` are unchanged. Consumers opt in by calling `asset_from_metadata_json`.

### Testing

- `extractor_corpus` — 18 metadata fixtures pinned (`SameAsV1` / `V1Minus(keys)` / `Exact{…}`).
- `corpus_is_exhaustive` — walks `resources/test/`; every `*.json` must be in the corpus or in `NON_METADATA_FIXTURES` (with a reason), so a new fixture can't silently go unverified.
- Inline tests for SpaceBudz value-only arrays and BlockOwls colon-delimited attributes.
- Full crate suite (88 lib + corpus + doc) and `clippy --all-targets -- -D warnings` green.

### Rollout notes

The `collection-ownership` worker (cnft.dev-workers) is the first consumer (`parse_asset_metadata` → `asset_from_metadata_json`); it needs a rev-bump to this commit. The mitos-side reveal handling (resolving `metadata_tx` so reveal collections like Funplastic surface their post-reveal traits) is a **separate change in the `mitos` repo** — this PR is just the extractor.

🤖 Generated with [Claude Code