### PR TITLE
feature(cardano-assets, maestro): field-classification registry + maestro v2 cutover

### DIFF
--- a/cardano-assets/src/extract.rs
+++ b/cardano-assets/src/extract.rs
@@ -26,40 +26,123 @@ use crate::{Asset, AssetFile, PrimitiveOrList, Traits, UnsigData};
 use serde::Deserialize;
 use std::collections::HashMap;
 
-/// Metadata keys that form the common envelope of an NFT and must never
-/// be surfaced as traits in flat-extraction mode. Compared lowercased,
-/// so this is the single source of truth shared by the typed envelope
-/// fields and the flat-trait filter (v1 had two lists that could drift).
+// =========================================================================
+// Field registry — the single classification of known metadata field
+// names, applied UNIFORMLY regardless of JSON layout (slot contents,
+// slot siblings, or flat top-level). Replaces the old envelope/promote
+// lists + the accidental flat-vs-slot behaviour. See
+// `cnft.dev-workers/docs/design/STRUCTURED_METADATA_CAPTURE.md`.
+//
+// Four categories:
+//   - Envelope    : asset core / display — never a trait, never a facet.
+//   - Facet       : low-cardinality semantic; `surface` = also a
+//                   filterable collection-ownership trait (rarity/tier);
+//                   else capture-only (artist/series/…).
+//   - Provenance  : per-asset identifier / economics — captured, never a
+//                   trait.
+//   - (unknown)   : not in the registry → a visual trait, decided
+//                   structurally (slot contents / flat top-level).
+//
+// Only the trait output is wired today (a field is a collection-ownership
+// trait iff it's unknown OR a surfaced facet); the envelope/facet/
+// provenance split feeds the future structured-metadata capture.
+// All comparisons are trimmed + lowercased.
+
+/// Envelope (asset core / display). Kept `pub` — was the crate's public
+/// "not a trait" list; now the registry's envelope arm.
 pub const ENVELOPE_KEYS: &[&str] = &[
     "name",
+    "title",
     "image",
     "mediatype",
     "files",
     "description",
-    "project",
-    "collection",
-    "collection name",
+    "url",
+    "sha256",
     "twitter",
     "website",
     "discord",
     "github",
+];
+
+/// Facets that ALSO surface as filterable collection-ownership traits.
+const FACET_SURFACE: &[&str] = &["rarity", "tier"];
+
+/// Facets captured for data collection but NOT surfaced as traits.
+const FACET_CAPTURE: &[&str] = &[
+    "artist",
+    "series",
     "medium",
-    "minter",
+    "vendor",
     "publisher",
-    "sha256",
-    "url",
+    "project",
+    "collection",
+    "collection name",
+];
+
+/// Per-asset identifiers / economics — captured, never a trait.
+const PROVENANCE_FIELDS: &[&str] = &[
+    "id",
+    "tokenid",
+    "edition",
+    "number",
+    "index",
+    "serialnumber",
+    "note number",
+    "plate number",
+    "serial number",
+    "seed",
+    "piece",
+    "authnft",
+    "royalties",
+    "copyright",
+    "minter",
+    "assetkind",
+    "phasesupply",
+    "totalsupply",
+    "source_key",
+    "source_tx_id",
 ];
 
 /// Keys whose value, when structured, holds the asset's traits.
 const SLOT_KEYS: &[&str] = &["traits", "attributes", "properties"];
 
-/// Universal trait keys that are kept even when they sit as a *sibling*
-/// of a structured slot (where siblings are otherwise ignored as
-/// metadata noise). These are cross-collection trait concepts, not
-/// per-collection fields — the curated inverse of [`ENVELOPE_KEYS`].
-/// Compared lowercased. Example: Funplastic nests its visual traits in
-/// an `attributes` map but puts `Rarity` at the top level.
-const PROMOTE_KEYS: &[&str] = &["rarity", "tier"];
+/// Registry category for a known field name. See module-level table.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum FieldClass {
+    Envelope,
+    Facet { surface: bool },
+    Provenance,
+}
+
+/// Classify a known field name (trimmed, lowercased). `None` = unknown,
+/// so the structural rule decides (slot contents / flat top-level → a
+/// visual trait; slot sibling → not a trait).
+pub fn classify_field(name: &str) -> Option<FieldClass> {
+    let key = name.trim().to_lowercase();
+    let key = key.as_str();
+    if ENVELOPE_KEYS.contains(&key) {
+        Some(FieldClass::Envelope)
+    } else if FACET_SURFACE.contains(&key) {
+        Some(FieldClass::Facet { surface: true })
+    } else if FACET_CAPTURE.contains(&key) {
+        Some(FieldClass::Facet { surface: false })
+    } else if PROVENANCE_FIELDS.contains(&key) {
+        Some(FieldClass::Provenance)
+    } else {
+        None
+    }
+}
+
+/// Whether a field should appear in the collection-ownership trait set:
+/// unknown fields (visual traits) and surfaced facets (rarity/tier) only.
+fn trait_eligible(name: &str) -> bool {
+    match classify_field(name) {
+        None => true,
+        Some(FieldClass::Facet { surface }) => surface,
+        Some(FieldClass::Envelope | FieldClass::Provenance) => false,
+    }
+}
 
 /// The common metadata envelope. Typed fields are parsed once; every
 /// other field lands in `rest` for trait extraction.
@@ -180,17 +263,43 @@ fn classify_slot(value: &serde_json::Value) -> Option<SlotShape> {
     }
 }
 
-/// Extract traits from `rest`. If a structured trait slot
-/// (`traits`/`attributes`/`properties`) is present, traits come solely
-/// from it (sibling scalars are envelope/metadata noise). Otherwise all
-/// non-envelope scalar/array fields are treated as flat traits.
+/// Extract the collection-ownership trait set from `rest`.
+///
+/// Structural extraction produces candidate traits (a slot's contents,
+/// or all flat top-level fields, or the unsig bespoke set); the field
+/// **registry** then filters them UNIFORMLY — a candidate survives only
+/// if it's unknown (a visual trait) or a surfaced facet (rarity/tier).
+/// Envelope / capture-only facets / provenance are dropped wherever they
+/// appear (slot contents, flat fields, or the unsig set), so the same
+/// field is treated identically regardless of JSON layout.
 pub fn extract_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
-    // Bespoke: unsigned_algorithms. Its traits are *algorithmic*
-    // (index, num_props, and the per-pixel colors/distributions under
-    // `unsigs.properties`) rather than plain key/values, so the generic
-    // shape-dispatch can't recover them. Detect the `unsigs` structure
-    // and delegate to the shared builder — identical to the v1 path, so
-    // both the maestro fallback and the mitos/v2 path yield the rich set.
+    let mut traits = candidate_traits(rest);
+    traits.inner_mut().retain(|key, _| trait_eligible(key));
+
+    // Surface facets (rarity/tier) carried as slot siblings — not already
+    // captured by the structural pass above.
+    for (key, value) in rest {
+        if matches!(
+            classify_field(key),
+            Some(FieldClass::Facet { surface: true })
+        ) && !traits.contains_key(key)
+        {
+            insert_if_present(&mut traits, key.clone(), value);
+        }
+    }
+    traits
+}
+
+/// Structural trait extraction, BEFORE the registry filter: the
+/// unsigned_algorithms bespoke set, else a structured slot's contents,
+/// else all flat top-level fields.
+fn candidate_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
+    // Bespoke: unsigned_algorithms — algorithmic traits (index,
+    // num_props, per-pixel colors/distributions under `unsigs.properties`)
+    // the generic shape-dispatch can't recover. Shared with the v1 path
+    // via `unsig_traits`; the caller's registry filter then drops the
+    // provenance/facet members (index, series, source_*), keeping
+    // num_props + colors + distributions.
     if let Some(unsigs) = rest
         .get("unsigs")
         .and_then(|v| serde_json::from_value::<UnsigData>(v.clone()).ok())
@@ -213,13 +322,11 @@ pub fn extract_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
     for slot in SLOT_KEYS {
         if let Some((_, value)) = rest.iter().find(|(k, _)| k.to_lowercase() == *slot) {
             if let Some(shape) = classify_slot(value) {
-                let mut traits = extract_slot(shape, value);
-                promote_siblings(&mut traits, rest);
-                return traits;
+                return extract_slot(shape, value);
             }
         }
     }
-    flat_extract(rest)
+    flat_all(rest)
 }
 
 /// Build the trait set for an unsigned_algorithms asset from its
@@ -246,17 +353,6 @@ pub(crate) fn unsig_traits(
         traits.insert_multi(key.clone(), values.clone());
     }
     traits
-}
-
-/// Fold any [`PROMOTE_KEYS`] siblings of a structured slot into the
-/// trait set — the few universal trait concepts (e.g. `rarity`) that are
-/// worth keeping even though the slot rule otherwise drops siblings.
-fn promote_siblings(traits: &mut Traits, rest: &HashMap<String, serde_json::Value>) {
-    for (key, value) in rest {
-        if PROMOTE_KEYS.contains(&key.to_lowercase().as_str()) {
-            insert_if_present(traits, key.clone(), value);
-        }
-    }
 }
 
 fn extract_slot(shape: SlotShape, value: &serde_json::Value) -> Traits {
@@ -307,15 +403,13 @@ fn extract_slot(shape: SlotShape, value: &serde_json::Value) -> Traits {
     traits
 }
 
-fn flat_extract(rest: &HashMap<String, serde_json::Value>) -> Traits {
+/// Every flat top-level field as a candidate trait. The registry filter
+/// in `extract_traits` then removes the envelope / facet / provenance
+/// ones (including data-quality warts like a leading-space key — the
+/// registry trims before matching).
+fn flat_all(rest: &HashMap<String, serde_json::Value>) -> Traits {
     let mut traits = Traits::new();
     for (key, val) in rest {
-        // Trim before the envelope check so data-quality warts like a
-        // leading-space key (" Project") still match an envelope key and
-        // get excluded rather than leaking in as a trait.
-        if ENVELOPE_KEYS.contains(&key.trim().to_lowercase().as_str()) {
-            continue;
-        }
         insert_if_present(&mut traits, key.clone(), val);
     }
     traits

--- a/cardano-assets/src/extract.rs
+++ b/cardano-assets/src/extract.rs
@@ -22,7 +22,7 @@
 //! whole fixture corpus before any cutover. See
 //! `tests/extract_corpus.rs`.
 
-use crate::{Asset, AssetFile, PrimitiveOrList, Traits};
+use crate::{Asset, AssetFile, PrimitiveOrList, Traits, UnsigData};
 use serde::Deserialize;
 use std::collections::HashMap;
 
@@ -65,7 +65,7 @@ const PROMOTE_KEYS: &[&str] = &["rarity", "tier"];
 /// other field lands in `rest` for trait extraction.
 #[derive(Deserialize, Debug, Clone)]
 pub struct AssetEnvelope {
-    #[serde(default, alias = "Name")]
+    #[serde(default, alias = "Name", alias = "title")]
     pub name: Option<String>,
     #[serde(default)]
     pub image: Option<PrimitiveOrList<String>>,
@@ -123,6 +123,16 @@ pub fn asset_from_metadata_json(json: &str) -> Result<Asset, serde_json::Error> 
     Ok(envelope.into_asset())
 }
 
+/// As [`asset_from_metadata_json`], but from an already-parsed
+/// `serde_json::Value`. For callers that hold the raw metadata as a
+/// `Value` (e.g. an indexer response) — avoids a re-serialize round-trip
+/// and, critically, lets them feed the *original* document to v2 rather
+/// than laundering it through the v1 `AssetMetadata` enum first.
+pub fn asset_from_metadata_value(value: serde_json::Value) -> Result<Asset, serde_json::Error> {
+    let envelope: AssetEnvelope = serde_json::from_value(value)?;
+    Ok(envelope.into_asset())
+}
+
 /// The structured shapes a trait slot can take. A value-only string
 /// array (`["A","B"]`) is deliberately NOT a structured slot — it is
 /// treated as a flat multi-value field, matching how v1 surfaced
@@ -175,6 +185,31 @@ fn classify_slot(value: &serde_json::Value) -> Option<SlotShape> {
 /// from it (sibling scalars are envelope/metadata noise). Otherwise all
 /// non-envelope scalar/array fields are treated as flat traits.
 pub fn extract_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
+    // Bespoke: unsigned_algorithms. Its traits are *algorithmic*
+    // (index, num_props, and the per-pixel colors/distributions under
+    // `unsigs.properties`) rather than plain key/values, so the generic
+    // shape-dispatch can't recover them. Detect the `unsigs` structure
+    // and delegate to the shared builder — identical to the v1 path, so
+    // both the maestro fallback and the mitos/v2 path yield the rich set.
+    if let Some(unsigs) = rest
+        .get("unsigs")
+        .and_then(|v| serde_json::from_value::<UnsigData>(v.clone()).ok())
+    {
+        let series = rest
+            .get("series")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let source_key = rest
+            .get("source_key")
+            .map(json_to_strings)
+            .unwrap_or_default();
+        let source_tx_id = rest
+            .get("source_tx_id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        return unsig_traits(&unsigs, series, source_key, source_tx_id);
+    }
+
     for slot in SLOT_KEYS {
         if let Some((_, value)) = rest.iter().find(|(k, _)| k.to_lowercase() == *slot) {
             if let Some(shape) = classify_slot(value) {
@@ -185,6 +220,32 @@ pub fn extract_traits(rest: &HashMap<String, serde_json::Value>) -> Traits {
         }
     }
     flat_extract(rest)
+}
+
+/// Build the trait set for an unsigned_algorithms asset from its
+/// `unsigs` structure + the sibling provenance fields. Shared by the v1
+/// `From<AssetMetadata>` path and the v2 extractor so the two can't
+/// drift. Mirrors the original v1 logic exactly.
+pub(crate) fn unsig_traits(
+    unsigs: &UnsigData,
+    series: Option<String>,
+    source_key: Vec<String>,
+    source_tx_id: Option<String>,
+) -> Traits {
+    let mut traits = Traits::new();
+    if let Some(s) = series {
+        traits.insert_single("series".to_string(), s);
+    }
+    traits.insert_multi("source_key".to_string(), source_key);
+    if let Some(tx_id) = source_tx_id {
+        traits.insert_single("source_tx_id".to_string(), tx_id);
+    }
+    traits.insert_single("index".to_string(), unsigs.index.to_string());
+    traits.insert_single("num_props".to_string(), unsigs.num_props.to_string());
+    for (key, values) in unsigs.properties.inner() {
+        traits.insert_multi(key.clone(), values.clone());
+    }
+    traits
 }
 
 /// Fold any [`PROMOTE_KEYS`] siblings of a structured slot into the
@@ -249,7 +310,10 @@ fn extract_slot(shape: SlotShape, value: &serde_json::Value) -> Traits {
 fn flat_extract(rest: &HashMap<String, serde_json::Value>) -> Traits {
     let mut traits = Traits::new();
     for (key, val) in rest {
-        if ENVELOPE_KEYS.contains(&key.to_lowercase().as_str()) {
+        // Trim before the envelope check so data-quality warts like a
+        // leading-space key (" Project") still match an envelope key and
+        // get excluded rather than leaking in as a trait.
+        if ENVELOPE_KEYS.contains(&key.trim().to_lowercase().as_str()) {
             continue;
         }
         insert_if_present(&mut traits, key.clone(), val);

--- a/cardano-assets/src/lib.rs
+++ b/cardano-assets/src/lib.rs
@@ -43,7 +43,10 @@ pub use cip25::{cip25_metadata_json, cip25_metadata_value, decode_cip25_metadata
 #[cfg(feature = "cip68")]
 pub use cip68::{decode_cip68_datum, Cip68Error};
 pub use collection::*;
-pub use extract::{asset_from_metadata_json, extract_traits, AssetEnvelope, ENVELOPE_KEYS};
+pub use extract::{
+    asset_from_metadata_json, asset_from_metadata_value, extract_traits, AssetEnvelope,
+    ENVELOPE_KEYS,
+};
 #[cfg(feature = "cip14")]
 pub use fingerprint::{Fingerprint, FingerprintError};
 pub use policy_id::{PolicyId, PolicyIdError};
@@ -930,28 +933,10 @@ impl From<AssetMetadata> for Asset {
                 source_tx_id,
                 ..
             } => {
-                // Convert unsigs data to traits
-                let mut traits = Traits::new();
-
-                // Add series, source_key, source_tx_id as traits
-                if let Some(s) = series {
-                    traits.insert_single("series".to_string(), s);
-                }
-
-                traits.insert_multi("source_key".to_string(), source_key);
-                if let Some(tx_id) = source_tx_id {
-                    traits.insert_single("source_tx_id".to_string(), tx_id);
-                }
-
-                // Add unsigs index and num_props
-                traits.insert_single("index".to_string(), unsigs.index.to_string());
-                traits.insert_single("num_props".to_string(), unsigs.num_props.to_string());
-
-                // Merge properties traits into main traits
-                for (key, values) in unsigs.properties.inner() {
-                    traits.insert_multi(key.clone(), values.clone());
-                }
-
+                // Shared with the v2 extractor (`extract::unsig_traits`)
+                // so the two paths can't drift on this bespoke shape.
+                let traits =
+                    crate::extract::unsig_traits(&unsigs, series, source_key, source_tx_id);
                 Self {
                     name: title,
                     image: image.dechunked(),

--- a/cardano-assets/tests/extract_corpus.rs
+++ b/cardano-assets/tests/extract_corpus.rs
@@ -69,16 +69,35 @@ fn corpus_cases() -> Vec<(&'static str, Expect)> {
     vec![
         // ---- behaviour-preserving: identical to v1 -------------------
         ("traits-chadano.json", SameAsV1), // codified {trait_type,value}
-        ("traits-gopher.json", SameAsV1),  // codified {name,value,display}
         ("traits-mallards.json", SameAsV1), // array of single-key objects
-        ("traits-anscestors.json", SameAsV1), // flat top-level keys
+        ("traits-anscestors.json", SameAsV1), // flat top-level keys ("Type" is a visual trait)
         ("traits-toolhead.json", SameAsV1), // nested attributes map (single+multi)
-        ("traits-wiseowl.json", SameAsV1), // flat, chunked image
-        // ---- intentional corrections of v1 bugs ----------------------
-        // v1 `Flattened` doesn't declare `collection`, so the collection
-        // name leaked in as a per-asset trait.
+        ("traits-wiseowl.json", SameAsV1), // flat, chunked image ("type" visual)
+        // ---- registry-driven corrections (field classification) ------
+        // v1 leaked the collection name (`collection`/`Collection`) as a
+        // per-asset trait; the registry classifies it as a facet (dropped
+        // from the trait surface).
         ("bankcard2500.json", V1Minus(&["collection"])),
-        ("traits-oldmoney.json", V1Minus(&["Collection"])),
+        // oldmoney leaked a pile of facet/provenance fields as traits:
+        // `Collection`/`Series` (facets), `Number`/`Note Number`/`Plate
+        // Number`/`Serial Number` (provenance identifiers). Registry drops
+        // them from the trait surface; the visual traits (Base, Blood, …)
+        // stay.
+        (
+            "traits-oldmoney.json",
+            V1Minus(&[
+                "Collection",
+                "Number",
+                "Note Number",
+                "Plate Number",
+                "Serial Number",
+                "Series",
+            ]),
+        ),
+        // gopher's codified traits redundantly include `Name` (the display
+        // name); the registry classifies `name` as envelope → dropped from
+        // the trait surface even inside a slot.
+        ("traits-gopher.json", V1Minus(&["Name"])),
         // `series` is a sibling of the `attributes` slot — metadata, not
         // a visual trait. v1 folded it in via merge_extra_fields.
         ("derpbird07490.json", V1Minus(&["series"])),

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -2,7 +2,8 @@
 
 use async_stream::stream;
 use cardano_assets::{
-    Asset, AssetMetadata, AssetMetadata68, AssetWithId, ExtractedCid, MetadataKind, NftPurpose,
+    asset_from_metadata_value, Asset, AssetMetadata, AssetMetadata68, AssetWithId, ExtractedCid,
+    MetadataKind, NftPurpose,
 };
 use chrono::Utc;
 use futures_core::stream::Stream;
@@ -66,50 +67,74 @@ impl From<MaestroError> for worker::Error {
     }
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct AssetStandards {
     pub cip25_metadata: Option<AssetMetadata>,
     pub cip68_metadata: Option<AssetMetadata68>,
+    /// Raw JSON of each metadata field, retained alongside the typed
+    /// forms above. Trait extraction (`TryFrom<AssetStandards> for
+    /// Asset`) runs the v2 `cardano_assets::asset_from_metadata_value`
+    /// extractor over THIS original document — not the typed
+    /// `AssetMetadata`, which would re-introduce the v1 shape mis-matches
+    /// v2 exists to fix. The typed fields stay for CID / purpose / import
+    /// (which need the variant-matched enum). Typed parse is lenient
+    /// (`None` on failure) so a shape v1 can't match doesn't drop the
+    /// asset — v2 still extracts traits from the raw.
+    cip25_raw: Option<serde_json::Value>,
+    cip68_raw: Option<serde_json::Value>,
+}
+
+impl<'de> Deserialize<'de> for AssetStandards {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Raw {
+            #[serde(default)]
+            cip25_metadata: Option<Value>,
+            #[serde(default)]
+            cip68_metadata: Option<Value>,
+        }
+        let raw = Raw::deserialize(deserializer)?;
+        let cip25_metadata = raw
+            .cip25_metadata
+            .as_ref()
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        let cip68_metadata = raw
+            .cip68_metadata
+            .as_ref()
+            .and_then(|v| serde_json::from_value(v.clone()).ok());
+        Ok(AssetStandards {
+            cip25_metadata,
+            cip68_metadata,
+            cip25_raw: raw.cip25_metadata,
+            cip68_raw: raw.cip68_metadata,
+        })
+    }
 }
 
 impl TryFrom<AssetStandards> for Asset {
     type Error = MaestroError;
     fn try_from(value: AssetStandards) -> Result<Self, Self::Error> {
-        tracing::debug!("TryFrom<AssetStandards> for Asset:");
-        tracing::debug!(
-            "  cip68_metadata present: {}",
-            value.cip68_metadata.is_some()
-        );
-        tracing::debug!(
-            "  cip25_metadata present: {}",
-            value.cip25_metadata.is_some()
-        );
-
-        if let Some(ref cip25) = value.cip25_metadata {
-            tracing::debug!("  cip25_metadata content: {:#?}", cip25);
-        }
-
-        match (value.cip68_metadata, value.cip25_metadata) {
-            (Some(cip68), _) => {
-                tracing::debug!("  Using cip68 metadata");
-                Ok(Asset::from(cip68.metadata))
-            }
-            (_, Some(metadata)) => {
-                tracing::debug!("  Using cip25 metadata");
-                let asset = Asset::from(metadata);
-                tracing::debug!(
-                    "  Converted to asset: name='{}', image='{}', traits={:#?}",
-                    asset.name,
-                    asset.image,
-                    asset.traits
-                );
-                Ok(asset)
-            }
-            (_, _) => {
-                tracing::debug!("  No metadata found!");
-                Err(MaestroError::NoMetadata)
+        // Extract traits via the v2 `asset_from_metadata_value` extractor
+        // over the RAW metadata JSON, so results match the
+        // collection-ownership / mitos path (which also runs v2). Prefer
+        // CIP-68 (the ref-token datum metadata, nested under `metadata`)
+        // over CIP-25 mint metadata.
+        if let Some(cip68_raw) = &value.cip68_raw {
+            if let Some(meta) = cip68_raw.get("metadata") {
+                if let Ok(asset) = asset_from_metadata_value(meta.clone()) {
+                    tracing::debug!("Using cip68 metadata (v2): name='{}'", asset.name);
+                    return Ok(asset);
+                }
             }
         }
+        if let Some(cip25_raw) = value.cip25_raw {
+            if let Ok(asset) = asset_from_metadata_value(cip25_raw) {
+                tracing::debug!("Using cip25 metadata (v2): name='{}'", asset.name);
+                return Ok(asset);
+            }
+        }
+        tracing::debug!("No (parseable) metadata found");
+        Err(MaestroError::NoMetadata)
     }
 }
 
@@ -1842,4 +1867,72 @@ pub(crate) fn strip_control_chars(input: &str) -> String {
             !(c.is_control() && c != '\n' && c != '\r' && c != '\t')
         })
         .collect()
+}
+
+#[cfg(test)]
+mod trait_parity_tests {
+    use super::*;
+
+    // Maestro-derived traits must equal the v2 extractor run directly on
+    // the same metadata JSON — proving the get_all_assets bootstrap path
+    // can't drift from collection-ownership / the mitos path (both v2).
+
+    #[test]
+    fn cip25_traits_match_v2_extractor() {
+        // OpenSea-style `trait_type` array — a shape v1 mis-matched.
+        let meta = r#"{
+            "name": "X #1",
+            "image": "ipfs://img",
+            "traits": [
+                {"trait_type": "Background", "value": "Crimson"},
+                {"trait_type": "Body", "value": "Base"}
+            ]
+        }"#;
+        let standards: AssetStandards =
+            serde_json::from_str(&format!(r#"{{"cip25_metadata": {meta}}}"#)).unwrap();
+        let via_maestro = Asset::try_from(standards).expect("maestro asset");
+        let via_v2 = cardano_assets::asset_from_metadata_json(meta).expect("v2 asset");
+        assert_eq!(via_maestro.name, via_v2.name);
+        assert_eq!(via_maestro.traits, via_v2.traits);
+        assert!(via_maestro.traits.contains_key("Background"));
+    }
+
+    #[test]
+    fn cip68_traits_match_v2_extractor() {
+        // CIP-68: metadata nested under `metadata` (AssetMetadata68 shape);
+        // numeric `Rank` must be coerced, not drop the trait set.
+        let inner =
+            r#"{"name": "Y #2", "image": "ipfs://i", "attributes": {"Rank": 1, "Color": "Blue"}}"#;
+        let standards: AssetStandards = serde_json::from_str(&format!(
+            r#"{{"cip68_metadata": {{"purpose": "reference_nft", "version": 1, "metadata": {inner}}}}}"#
+        ))
+        .unwrap();
+        let via_maestro = Asset::try_from(standards).expect("maestro asset");
+        let via_v2 = cardano_assets::asset_from_metadata_json(inner).expect("v2 asset");
+        assert_eq!(via_maestro.traits, via_v2.traits);
+        assert!(via_maestro.traits.contains_key("Rank"));
+    }
+
+    #[test]
+    fn cip68_preferred_over_cip25() {
+        // Both present → CIP-68 wins (preserves prior precedence).
+        let cip25 = r#"{"name":"from25","image":"ipfs://a","traits":{"K":"v25"}}"#;
+        let cip68_inner = r#"{"name":"from68","image":"ipfs://b","attributes":{"K":"v68"}}"#;
+        let standards: AssetStandards = serde_json::from_str(&format!(
+            r#"{{"cip25_metadata": {cip25}, "cip68_metadata": {{"purpose":"reference_nft","version":1,"metadata": {cip68_inner}}}}}"#
+        )).unwrap();
+        let asset = Asset::try_from(standards).expect("asset");
+        assert_eq!(asset.name, "from68");
+        assert_eq!(asset.traits.get("K"), Some(&vec!["v68".to_string()]));
+    }
+
+    #[test]
+    fn typed_fields_survive_for_cid_and_purpose() {
+        // The typed AssetMetadata is still populated (CID / purpose paths
+        // depend on it) even though traits now come from the raw via v2.
+        let meta = r#"{"name":"Z","image":"ipfs://QmZ","traits":{"A":"b"}}"#;
+        let standards: AssetStandards =
+            serde_json::from_str(&format!(r#"{{"cip25_metadata": {meta}}}"#)).unwrap();
+        assert!(standards.cip25_metadata.is_some(), "typed cip25 retained");
+    }
 }

--- a/indexers/maestro/src/test.rs
+++ b/indexers/maestro/src/test.rs
@@ -656,7 +656,10 @@ mod tests {
                         "originalPolicy",
                         "33568ad11f93b3e79ae8dee5ad928ded72adcea719e92108caf1521b",
                     ),
-                    ("artist", "@netanelchn"),
+                    // v2: `artist` (@netanelchn) is a facet — captured for
+                    // data collection, not surfaced as a collection-
+                    // ownership trait. (`upgradedFrom`/`originalPolicy`
+                    // are unknown → visual traits, kept.)
                 ])
                 .into_traits();
                 let asset: Asset = deserialized.data.asset_standards.try_into().unwrap();
@@ -939,13 +942,13 @@ mod tests {
                     "ipfs://QmTeADGJVJSmzpa2AceMdZBDwzMf3w4BLAgqwx5ZZbw4cm"
                 );
 
-                // Check traits
+                // Check traits. The algorithmic properties
+                // (num_props/colors/distributions/…) are the unsig visual
+                // traits; `series` (facet) and `index` (provenance) are
+                // classified out of the trait surface by the registry.
                 let traits = asset.traits.inner();
-                assert_eq!(
-                    traits.get("series"),
-                    Some(&vec!["unsigned_algorithms".to_string()])
-                );
-                assert_eq!(traits.get("index"), Some(&vec!["12948".to_string()]));
+                assert_eq!(traits.get("series"), None);
+                assert_eq!(traits.get("index"), None);
                 assert_eq!(traits.get("num_props"), Some(&vec!["5".to_string()]));
                 assert_eq!(
                     traits.get("colors"),
@@ -1026,7 +1029,9 @@ mod tests {
                     Some(&vec!["PlainPlexi".to_string()])
                 );
                 assert_eq!(traits.get("Gender"), Some(&vec!["Female".to_string()]));
-                assert_eq!(traits.get("number"), Some(&vec!["78".to_string()]));
+                // v2: `number` (provenance) is dropped from the trait
+                // surface; `rarity` is a surfaced facet, kept.
+                assert_eq!(traits.get("number"), None);
                 assert_eq!(traits.get("rarity"), Some(&vec!["Common".to_string()]));
             }
             Err(err) => {

--- a/indexers/maestro/src/test.rs
+++ b/indexers/maestro/src/test.rs
@@ -164,7 +164,9 @@ mod tests {
                     ("Mouth", "Happy Mouth"),
                     ("Outfit", "Corpo Nepo Outfit"),
                     ("Skill", "None"),
-                    ("tokenId", "4471"), // Extra field included as trait
+                    // v2: `tokenId` dropped — a metadata sibling of the
+                    // attributes slot, not a visual trait (v1 leaked it
+                    // via merge_extra_fields).
                 ])
                 .into_traits();
                 let asset: Asset = nft.data.asset_standards.try_into().unwrap();
@@ -687,13 +689,9 @@ mod tests {
                     ("Palette", "P4"),
                     ("Rows", "Narrow"),
                     ("Waves", "W1"),
-                    // Extra metadata fields merged as traits
-                    ("artist", "Charles Machin - @CM_GenArt"),
-                    ("authNFT", "asset13as3a4t954ru7vhzy6pldse3qu8e7la2xgsr7u"),
-                    ("seed", "13719"),
-                    ("vendor", "BlockGen.art"),
-                    ("piece", "109"),
-                    ("medium", "Fully On-Chain BlockGen.Art Canvas"),
+                    // v2: the BlockGen metadata siblings (artist, authNFT,
+                    // seed, vendor, piece, medium) are dropped — they're
+                    // siblings of the `properties` slot, not visual traits.
                 ])
                 .into_traits();
                 let asset: Asset = deserialized.data.asset_standards.try_into().unwrap();
@@ -881,7 +879,8 @@ mod tests {
                     ("Power Level", "Undetermined"),
                     ("Rarity", "Common"),
                     ("Tail", "Redneck"),
-                    ("series", "2"), // Extra field included as trait
+                    // v2: `series` dropped — metadata sibling of the
+                    // attributes slot, not a visual trait.
                 ])
                 .into_traits();
                 let asset: Asset = deserialized.data.asset_standards.try_into().unwrap();


### PR DESCRIPTION
Introduces a **field-classification registry** in the v2 trait extractor — a single, layout-independent classification of metadata field names (`envelope` / `facet` / `provenance` / visual-trait) — and migrates the **maestro indexer** (the last consumer still extracting traits via the v1 `AssetMetadata` enum) onto v2. Trait extraction is now consistent regardless of JSON layout, and there's one extractor across the platform.

### Why

After cutting `collection-ownership` to v2, the extractor still had two problems:
- **Accidental, layout-dependent classification** — the same field (`artist`, `series`, `edition`, …) became a trait in a *flat*-layout collection but was dropped as a slot-sibling in a *structured*-layout one. The old `ENVELOPE_KEYS`/`PROMOTE_KEYS` lists couldn't express this consistently.
- **maestro's `get_all_assets` bootstrap fallback still used v1** — so if it ran (cnft.tools down on a non-authoritative env), it produced traits that disagreed with the v2/mitos path.

### What changed

**Field registry** (`cardano-assets/src/extract.rs`)
- `FieldClass { Envelope, Facet { surface }, Provenance }` + `classify_field(name) -> Option<FieldClass>` (unknown ⇒ visual trait, decided structurally). Applied **uniformly** to slot contents, flat fields, and the unsig set.
- `extract_traits` = structural candidates → `retain(trait_eligible)` → surface `rarity`/`tier` siblings. Subsumes `ENVELOPE_KEYS` (now the true-envelope subset, kept `pub`), `PROMOTE_KEYS`, `promote_siblings`, and the flat envelope pre-filter.
- A field is a collection-ownership trait iff it's unknown (visual) or a *surfaced* facet (`rarity`/`tier`); `artist`/`series`/provenance are classified out of the trait surface (consistently, in every layout). The full 4-way classification is exposed for the future structured-metadata capture (separate design doc).
- `type` is deliberately **not** registered → structural rule (anscestors `Type` = trait; pred `type` = dropped sibling — both correct).

**maestro v2 cutover** (`indexers/maestro/src/lib.rs`)
- `AssetStandards` keeps its typed fields (CID / purpose / import still need the enum) but now **retains the raw metadata JSON** via a custom `Deserialize`, so `TryFrom<AssetStandards> for Asset` runs `asset_from_metadata_value` over the *original* document rather than re-laundering it through v1 (which would re-introduce the mis-matches v2 fixes). Typed parse is lenient (`None` on failure) so a shape v1 can't match no longer drops the asset.
- New v2 entry point `cardano_assets::asset_from_metadata_value(serde_json::Value)`.

**Supporting** (`cardano-assets/src/extract.rs`, `lib.rs`)
- Bespoke unsig handling: shared `unsig_traits()` builds the algorithmic set (`num_props`/`colors`/`distributions`); the registry then classifies `index`/`series`/`source_*` out of the trait surface. Used by both the v1 `From` arm and v2 (single source of truth).
- `title`-as-name alias on the envelope; envelope key-matching trims (fixes a `" Project"` leading-space leak).

**v1 is untouched.** `From<AssetMetadata> for Asset` is unchanged — it's the frozen legacy path; only v2 registry-filters. (88 v1 lib tests stay green.)

### Behavioural changes (trait surface)

All registry-driven and documented in the re-derived golden tests:

| Collection | Now dropped from traits | Reason |
|---|---|---|
| gopher | `Name` | envelope (even inside a slot) |
| oldmoney | `Collection`/`Series`, `Number`/`Note Number`/`Plate Number`/`Serial Number` | facet / provenance |
| wildtangs | `artist` | facet — captured for data-collection, not surfaced |
| blockowls | `number` (keeps `rarity`) | provenance (rarity = surfaced facet) |
| unsig | `index`, `series`, `source_*` (keeps `num_props`/`colors`/`distributions`) | provenance / facet |

### Testing

- **cardano-assets** — 88 lib (v1, unchanged) + the v2 golden corpus (`extract_corpus.rs`, incl. the exhaustiveness guard) + doc tests, all green. Corpus re-derived for `gopher`/`oldmoney`.
- **maestro** — golden `test_deserialize_*` per-collection tests re-derived to the registry output, **plus 4 new parity tests** asserting maestro-derived traits `==` `asset_from_metadata_json`. 39 total, green.
- `clippy --all-targets -- -D warnings` clean on both.

### Rollout

Downstream: bump the `cardano-assets` + `maestro` rev in `cnft.dev-workers` after merge. The maestro path is the bootstrap *fallback* and dev is mitos-authoritative, so low-urgency. The structured-metadata capture (consuming the registry's facet/provenance classification) is a separate, design-only follow-up (`cnft.dev-workers/docs/design/STRUCTURED_METADATA_CAPTURE.md`).