### PR TITLE
cardano-tx: sign with Ed25519-BIP32 extended keys (`SecretKeyExtended`)

### DIFF
--- a/cardano-tx/src/builder/mint.rs
+++ b/cardano-tx/src/builder/mint.rs
@@ -1434,7 +1434,12 @@ mod tests {
             &payouts,
         )
         .expect("inline mint builds");
-        let sk = pallas_crypto::key::ed25519::SecretKey::from([1u8; 32]);
+        let sk = {
+            let mut kb = [1u8; 64];
+            kb[0] &= 0b1111_1000;
+            kb[31] = (kb[31] & 0b0011_1111) | 0b0100_0000;
+            pallas_crypto::key::ed25519::SecretKeyExtended::from_bytes(kb).expect("valid xprv key")
+        };
         let signed = unsigned.build_and_sign(&sk).expect("sign");
         signed.tx_cbor_hex.len() / 2 // hex → bytes
     }
@@ -1515,7 +1520,13 @@ mod tests {
                 &payouts,
             )
             .ok()?;
-            let sk = pallas_crypto::key::ed25519::SecretKey::from([1u8; 32]);
+            let sk = {
+                let mut kb = [1u8; 64];
+                kb[0] &= 0b1111_1000;
+                kb[31] = (kb[31] & 0b0011_1111) | 0b0100_0000;
+                pallas_crypto::key::ed25519::SecretKeyExtended::from_bytes(kb)
+                    .expect("valid xprv key")
+            };
             let signed = unsigned.build_and_sign(&sk).ok()?;
             Some(signed.tx_cbor_hex.len() / 2)
         }

--- a/cardano-tx/src/builder/mod.rs
+++ b/cardano-tx/src/builder/mod.rs
@@ -132,7 +132,7 @@ impl UnsignedTx {
     /// just to turn an [`UnsignedTx`] into submittable bytes.
     pub fn build_and_sign(
         self,
-        secret_key: &pallas_crypto::key::ed25519::SecretKey,
+        secret_key: &pallas_crypto::key::ed25519::SecretKeyExtended,
     ) -> Result<SignedTx, TxBuildError> {
         use pallas_txbuilder::BuildConway;
         let built = self
@@ -153,7 +153,7 @@ impl UnsignedTx {
     /// `cnft.dev-workers/docs/design/WALLET_UTXO_LEDGER.md`.
     pub fn build_and_sign_multi(
         self,
-        secret_keys: &[&pallas_crypto::key::ed25519::SecretKey],
+        secret_keys: &[&pallas_crypto::key::ed25519::SecretKeyExtended],
     ) -> Result<SignedTx, TxBuildError> {
         use pallas_txbuilder::BuildConway;
         let built = self
@@ -175,7 +175,7 @@ impl UnsignedTx {
     /// `ChangeUtxo` so it doesn't need this.
     pub fn build_and_sign_tracked(
         self,
-        secret_key: &pallas_crypto::key::ed25519::SecretKey,
+        secret_key: &pallas_crypto::key::ed25519::SecretKeyExtended,
     ) -> Result<(SignedTx, TxEffects), TxBuildError> {
         let spent = staging_spent(&self.staging);
         let outputs = staging_outputs(&self.staging);
@@ -193,7 +193,7 @@ impl UnsignedTx {
     /// across more than one of its addresses (e.g. the Mode-B refund over `D` + `O`).
     pub fn build_and_sign_multi_tracked(
         self,
-        secret_keys: &[&pallas_crypto::key::ed25519::SecretKey],
+        secret_keys: &[&pallas_crypto::key::ed25519::SecretKeyExtended],
     ) -> Result<(SignedTx, TxEffects), TxBuildError> {
         let spent = staging_spent(&self.staging);
         let outputs = staging_outputs(&self.staging);

--- a/cardano-tx/src/sign.rs
+++ b/cardano-tx/src/sign.rs
@@ -2,15 +2,21 @@
 //!
 //! Ed25519 signing for built transactions. No IO — just cryptography.
 
-use pallas_crypto::key::ed25519::SecretKey;
+use pallas_crypto::key::ed25519::SecretKeyExtended;
 use pallas_txbuilder::BuiltTransaction;
 
 use crate::error::TxBuildError;
 
-/// Sign a built transaction with an Ed25519 secret key.
+/// Sign a built transaction with an Ed25519-BIP32 *extended* secret key.
+///
+/// Cardano HD wallets (CIP-1852 / Icarus) derive extended keys, so the signing
+/// surface takes [`SecretKeyExtended`]. pallas's `BuiltTransaction::sign` is
+/// generic over its (crate-private) signer trait and implements it for both the
+/// plain and the extended key — every caller here signs with HD-derived keys,
+/// so we standardise on extended.
 pub fn sign_transaction(
     tx: BuiltTransaction,
-    secret_key: &SecretKey,
+    secret_key: &SecretKeyExtended,
 ) -> Result<BuiltTransaction, TxBuildError> {
     tx.sign(secret_key)
         .map_err(|e| TxBuildError::SignFailed(format!("{e}")))
@@ -25,11 +31,11 @@ pub fn sign_transaction(
 /// ~101 wasted bytes, not an error. An empty slice returns the tx unsigned.
 pub fn sign_transaction_multi(
     tx: BuiltTransaction,
-    secret_keys: &[&SecretKey],
+    secret_keys: &[&SecretKeyExtended],
 ) -> Result<BuiltTransaction, TxBuildError> {
     let mut tx = tx;
     for sk in secret_keys {
-        // `sk` is `&&SecretKey` (iterating `&[&SecretKey]`); `.sign` wants `&S`.
+        // `sk` is `&&SecretKeyExtended`; `.sign` wants `&S`.
         tx = tx
             .sign(*sk)
             .map_err(|e| TxBuildError::SignFailed(format!("{e}")))?;


### PR DESCRIPTION
Switches `cardano-tx`'s transaction-signing surface from the plain `pallas_crypto::key::ed25519::SecretKey` to the extended key `SecretKeyExtended`. This is the shared-crates half of moving the custodial wallet stack onto Cardano's **real** HD scheme (CIP-1852 / Icarus, Ed25519-BIP32) in `cnft.dev-workers`.

### Why
Cardano HD wallets derive **extended** private keys (`kL‖kR`), not 32-byte ed25519 seeds. A BIP32-Ed25519 extended key's `kL` is already the scalar and must not be SHA-512-hashed the way a standard seed is, so it cannot be passed as a `SecretKey` — it has to sign as a `SecretKeyExtended`. pallas's `BuiltTransaction::sign` is generic over an `Ed25519Signer` trait that's implemented for *both* key types, but that trait isn't exported, so these helpers can't be made generic. Every real caller signs with an HD-derived key, so we standardise the whole signing surface on the extended key.

This is purely a key-*type* change at the signing boundary; the underlying signature/nonce construction is unchanged (pallas → cryptoxide, RFC 8032 `H(kR‖msg)`).

### Changes
- **`sign.rs`** — `sign_transaction` and `sign_transaction_multi` now take `&SecretKeyExtended` / `&[&SecretKeyExtended]` (+ doc clarifying why).
- **`builder/mod.rs`** — `build_and_sign`, `build_and_sign_multi`, `build_and_sign_tracked`, `build_and_sign_multi_tracked` now take extended keys.
- **`builder/mint.rs`** — two internal mint tests construct a valid `SecretKeyExtended` (clamped 64-byte key) instead of `SecretKey::from([1u8; 32])`; assertions unchanged.

### ⚠️ Breaking change
The six public signing functions above change their parameter type. Downstream callers must pass `SecretKeyExtended`. In `cnft.dev-workers` this is handled by the matching wallet-derivation migration (`MasterSeed::derive` now yields `SecretKeyExtended`); consumers should bump the `cardano-tx` rev together with that change. No behavioural change for anything already signing with HD-derived keys.

### Testing
- `cargo test -p cardano-tx` — **246 passed**, 0 failed.
- Validated end-to-end against the consuming repo (minting-engine / wallet-operations / minting-core) on the `wasm32-unknown-unknown` target.

🤖 Generated with [Claude Code