### PR TITLE
chore: cardano-tx cancel-tx options, maestro output resolution, wallet-core error typing

### DIFF
--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -1149,6 +1149,34 @@ pub fn build_cancel_offers_tx_with(
     requests: &[CancelOfferRequest],
     contract: &CancelContract,
 ) -> Result<super::UnsignedTx, TxBuildError> {
+    build_cancel_offers_tx_inner(deps, requests, contract, None)
+}
+
+/// As [`build_cancel_offers_tx_with`], but with a dedicated collateral UTxO
+/// instead of doubling the fee input as collateral.
+///
+/// Needed for chained carts: a chained TX's fee input is the *predicted*
+/// change of the previous unsubmitted TX, and wallets resolve collateral
+/// against the chain — phantom collateral makes the whole batch unsignable
+/// (Eternl `signTxs`: "Could not resolve transaction input UTxOs"). The
+/// caller reserves one confirmed wallet UTxO (excluded from funding) and
+/// passes it here for every cancel TX in the batch; collateral is only
+/// consumed on script failure, so sharing it across the chain is safe.
+pub fn build_cancel_offers_tx_with_collateral(
+    deps: &super::TxDeps,
+    requests: &[CancelOfferRequest],
+    contract: &CancelContract,
+    collateral_utxo: &UtxoApi,
+) -> Result<super::UnsignedTx, TxBuildError> {
+    build_cancel_offers_tx_inner(deps, requests, contract, Some(collateral_utxo))
+}
+
+fn build_cancel_offers_tx_inner(
+    deps: &super::TxDeps,
+    requests: &[CancelOfferRequest],
+    contract: &CancelContract,
+    dedicated_collateral: Option<&UtxoApi>,
+) -> Result<super::UnsignedTx, TxBuildError> {
     use crate::helpers::output::{build_change_output, create_ada_output};
     use crate::selection;
     use pallas_crypto::hash::Hash;
@@ -1165,13 +1193,22 @@ pub fn build_cancel_offers_tx_with(
 
     let estimated_fee = selection::estimate_simple_fee(&deps.params);
 
-    // Select a wallet UTxO to pay the fee (also serves as collateral).
-    // Default config prefers pure ADA but falls back to asset-bearing
-    // UTxOs; the asset-bearing case is handled below by routing assets
-    // through the regular output (success) and `collateral_output`
-    // (script-fail).
+    // Select a wallet UTxO to pay the fee (doubles as collateral unless a
+    // dedicated collateral UTxO is provided). Default config prefers pure
+    // ADA but falls back to asset-bearing UTxOs; the asset-bearing case is
+    // handled below by routing assets through the regular output (success)
+    // and `collateral_output` (script-fail).
+    let fee_candidates: Vec<UtxoApi> = match dedicated_collateral {
+        Some(c) => deps
+            .utxos
+            .iter()
+            .filter(|u| !(u.tx_hash == c.tx_hash && u.output_index == c.output_index))
+            .cloned()
+            .collect(),
+        None => deps.utxos.clone(),
+    };
     let fee_utxo = selection::select_utxo_for_amount(
-        &deps.utxos,
+        &fee_candidates,
         0,
         estimated_fee,
         &selection::UtxoSelectionConfig::new(&deps.params),
@@ -1200,6 +1237,19 @@ pub fn build_cancel_offers_tx_with(
         .try_into()
         .map_err(|_| TxBuildError::InvalidHex("fee tx hash".into()))?;
     let fee_input = Input::new(Hash::from(fee_tx_bytes), fee_utxo.output_index as u64);
+
+    // Collateral: the dedicated UTxO when provided, else the fee input.
+    let collateral_utxo = dedicated_collateral.cloned();
+    let collateral_input = match &collateral_utxo {
+        Some(c) => {
+            let bytes: [u8; 32] = hex::decode(&c.tx_hash)
+                .map_err(|e| TxBuildError::InvalidHex(format!("{e}")))?
+                .try_into()
+                .map_err(|_| TxBuildError::InvalidHex("collateral tx hash".into()))?;
+            Input::new(Hash::from(bytes), u64::from(c.output_index))
+        }
+        None => fee_input.clone(),
+    };
 
     // Parse all CO inputs
     let mut script_inputs: Vec<Input> = Vec::with_capacity(requests.len());
@@ -1286,7 +1336,7 @@ pub fn build_cancel_offers_tx_with(
                 .reference_input(ref_input.clone())
                 .language_view(ScriptKind::PlutusV2, v2_cost_model.clone())
                 .disclosed_signer(Hash::from(owner_pkh_bytes))
-                .collateral_input(fee_input.clone());
+                .collateral_input(collateral_input.clone());
 
             // Include datums in witness set
             for datum in &datums {
@@ -1295,10 +1345,10 @@ pub fn build_cancel_offers_tx_with(
 
             // Single output: all CO value + fee UTxO value - fee.
             // When the fee UTxO carries native assets, those assets must
-            // appear in the regular output (success path) and in
-            // `collateral_output` (failure path) — Conway rejects TXs whose
-            // collateral inputs hold assets without a return output to
-            // receive them.
+            // appear in the regular output (success path) and — when it is
+            // also the collateral — in `collateral_output` (failure path);
+            // Conway rejects TXs whose collateral inputs hold assets
+            // without a return output to receive them.
             if fee_utxo.assets.is_empty() {
                 tx = tx.output(create_ada_output(from_address.clone(), output_value));
             } else {
@@ -1306,20 +1356,33 @@ pub fn build_cancel_offers_tx_with(
                 let main_output =
                     build_change_output(from_address.clone(), output_value, &fee_utxo_refs, None)?;
                 tx = tx.output(main_output);
+            }
 
-                // Reserve a generous lovelace budget for total_collateral
-                // (~5 ADA). At typical cancel fees (~1.5 ADA × 150%
-                // collateral_percent ≈ 2.25 ADA) this is plenty; the rest of
-                // the fee UTxO's lovelace plus all of its assets flow back
-                // to the user via collateral_return if the script fails.
-                const COLLATERAL_RESERVE_LOVELACE: u64 = 5_000_000;
-                let collateral_return_lovelace = fee_utxo
-                    .lovelace
-                    .saturating_sub(COLLATERAL_RESERVE_LOVELACE);
+            // Collateral return. Reserve a generous lovelace budget for
+            // total_collateral (~5 ADA). At typical cancel fees (~1.5 ADA ×
+            // 150% collateral_percent ≈ 2.25 ADA) this is plenty; the rest
+            // of the collateral UTxO's lovelace plus all of its assets flow
+            // back to the user via collateral_return if the script fails.
+            //
+            // Legacy (fee input doubles as collateral): only emitted when
+            // the fee UTxO carries assets, preserving the established TX
+            // shape. Dedicated collateral: emitted whenever the remainder
+            // clears min-ADA, so a large reserved UTxO is never fully
+            // forfeited on script failure.
+            const COLLATERAL_RESERVE_LOVELACE: u64 = 5_000_000;
+            let return_source = match &collateral_utxo {
+                Some(c) => {
+                    let remainder = c.lovelace.saturating_sub(COLLATERAL_RESERVE_LOVELACE);
+                    (!c.assets.is_empty() || remainder >= 2_000_000).then_some(c)
+                }
+                None => (!fee_utxo.assets.is_empty()).then_some(&fee_utxo),
+            };
+            if let Some(source) = return_source {
+                let source_refs: [&UtxoApi; 1] = [source];
                 let collateral_return = build_change_output(
                     from_address.clone(),
-                    collateral_return_lovelace,
-                    &fee_utxo_refs,
+                    source.lovelace.saturating_sub(COLLATERAL_RESERVE_LOVELACE),
+                    &source_refs,
                     None,
                 )?;
                 tx = tx.collateral_output(collateral_return);
@@ -1357,6 +1420,117 @@ mod tests {
         // Below threshold: fee should be minimum 2 ADA
         assert_eq!(calculate_marketplace_fee(5_000_000), 2_000_000);
         assert_eq!(calculate_marketplace_fee(10_000_000), 2_000_000);
+    }
+
+    /// Dedicated collateral (chained carts): the reserved UTxO must be the
+    /// sole collateral input, must NOT fund the TX (fee input stays a
+    /// different UTxO), and must get a collateral-return output so a large
+    /// reserved UTxO is never fully forfeited on script failure. Without a
+    /// confirmed collateral, a chained TX's collateral would be the
+    /// predicted change of its unsubmitted parent — unresolvable by the
+    /// wallet at signing time (Eternl signTxs: "Could not resolve
+    /// transaction input UTxOs").
+    #[test]
+    fn test_cancel_batch_dedicated_collateral() {
+        use crate::params::TxBuildParams;
+        use pallas_addresses::Address;
+
+        let addr = Address::from_bech32(
+            "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
+        ).unwrap();
+        let funding = UtxoApi {
+            tx_hash: "a".repeat(64),
+            output_index: 0,
+            lovelace: 50_000_000,
+            assets: vec![],
+            tags: vec![],
+        };
+        let collateral = UtxoApi {
+            tx_hash: "b".repeat(64),
+            output_index: 3,
+            lovelace: 12_000_000,
+            assets: vec![],
+            tags: vec![],
+        };
+        let deps = super::super::TxDeps {
+            utxos: vec![funding.clone(), collateral.clone()],
+            params: TxBuildParams {
+                min_fee_coefficient: 44,
+                min_fee_constant: 155_381,
+                coins_per_utxo_byte: 4310,
+                max_tx_size: 16_384,
+                max_value_size: 5_000,
+                price_mem: Some((577, 10_000)),
+                price_step: Some((721, 10_000_000)),
+                ..Default::default()
+            },
+            from_address: addr,
+            network_id: 0,
+        };
+        let reqs = [CancelOfferRequest {
+            co_tx_hash: "c".repeat(64),
+            co_output_index: 1,
+            co_lovelace: 10_000_000,
+            owner_pkh: "d".repeat(56),
+            datum_cbor_hex: None,
+            ex_units_mem: None,
+            ex_units_steps: None,
+        }];
+
+        let unsigned = build_cancel_offers_tx_with_collateral(
+            &deps,
+            &reqs,
+            &CancelContract::wayup(),
+            &collateral,
+        )
+        .expect("build with dedicated collateral");
+
+        let staging = &unsigned.staging;
+        let coll_inputs = staging.collateral_inputs.as_ref().expect("collateral set");
+        assert_eq!(coll_inputs.len(), 1);
+        assert_eq!(hex::encode(coll_inputs[0].tx_hash.0), collateral.tx_hash);
+        assert_eq!(coll_inputs[0].txo_index, u64::from(collateral.output_index));
+
+        // The collateral UTxO must not appear among the spending inputs —
+        // the fee comes from the other (funding) UTxO.
+        let inputs = staging.inputs.as_ref().expect("inputs set");
+        assert!(
+            !inputs
+                .iter()
+                .any(|i| hex::encode(i.tx_hash.0) == collateral.tx_hash),
+            "collateral must not double as a spending input"
+        );
+        assert!(
+            inputs
+                .iter()
+                .any(|i| hex::encode(i.tx_hash.0) == funding.tx_hash),
+            "fee must be funded from the non-collateral UTxO"
+        );
+
+        // Return output protects the reserved UTxO on script failure:
+        // everything above the ~5 ADA total_collateral budget flows back.
+        let coll_return = staging
+            .collateral_output
+            .as_ref()
+            .expect("collateral return output");
+        assert_eq!(coll_return.lovelace, collateral.lovelace - 5_000_000);
+
+        // Legacy shape untouched: without a dedicated collateral the fee
+        // input doubles as collateral and a pure-ADA fee UTxO emits no
+        // collateral return.
+        let legacy = build_cancel_offers_tx_with(&deps, &reqs, &CancelContract::wayup())
+            .expect("legacy build");
+        let legacy_coll = legacy
+            .staging
+            .collateral_inputs
+            .as_ref()
+            .expect("collateral set");
+        let legacy_inputs = legacy.staging.inputs.as_ref().expect("inputs set");
+        assert!(legacy_inputs.iter().any(|i| {
+            hex::encode(i.tx_hash.0) == hex::encode(legacy_coll[0].tx_hash.0)
+                && i.txo_index == legacy_coll[0].txo_index
+        }));
+        assert!(legacy.staging.collateral_output.is_none());
     }
 
     #[test]

--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -1323,9 +1323,13 @@ fn build_cancel_offers_tx_inner(
         total_co_lovelace += req.co_lovelace;
 
         if let Some(ref hex) = req.datum_cbor_hex {
-            if let Ok(bytes) = hex::decode(hex) {
-                datums.push(bytes);
-            }
+            // A hash-datum CO REQUIRES its datum in the witness set; a
+            // malformed hex here would silently drop it and the TX would
+            // fail on chain with `MissingRequiredDatums`. Fail the build
+            // loudly instead of swallowing the decode error.
+            let bytes = hex::decode(hex)
+                .map_err(|e| TxBuildError::InvalidHex(format!("datum_cbor_hex: {e}")))?;
+            datums.push(bytes);
         }
     }
 
@@ -1361,6 +1365,26 @@ fn build_cancel_offers_tx_inner(
                         needed: fee + split,
                         available: total_input,
                     })?;
+
+            // Every output must clear min-ADA or the ledger rejects the TX
+            // at submit (`OutputTooSmallUTxO`) — a failure that would sign
+            // fine and only surface on chain. Guard the main return output
+            // and each change split (parcel / collateral) here so an
+            // over-large split total, or a tiny split, fails the build
+            // loudly instead. Report as InsufficientFunds: the wallet needs
+            // more headroom for the requested splits.
+            let min_ada = deps.params.min_pure_utxo();
+            if output_value < min_ada {
+                return Err(TxBuildError::InsufficientFunds {
+                    needed: fee + split + min_ada,
+                    available: total_input,
+                });
+            }
+            if let Some(&bad) = opts.change_splits.iter().find(|&&s| s < min_ada) {
+                return Err(TxBuildError::BuildFailed(format!(
+                    "change split {bad} below min-ADA {min_ada}"
+                )));
+            }
 
             let mut tx = StagingTransaction::new();
 

--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -1149,7 +1149,32 @@ pub fn build_cancel_offers_tx_with(
     requests: &[CancelOfferRequest],
     contract: &CancelContract,
 ) -> Result<super::UnsignedTx, TxBuildError> {
-    build_cancel_offers_tx_inner(deps, requests, contract, None, None)
+    build_cancel_offers_tx_opts(deps, requests, contract, &CancelTxOptions::default())
+}
+
+/// Structural options for a multi-cancel TX build.
+#[derive(Default)]
+pub struct CancelTxOptions<'a> {
+    /// Collateral from this confirmed UTxO instead of the fee input.
+    /// Required for chained carts — see [`build_cancel_offers_tx_with_collateral`].
+    pub dedicated_collateral: Option<&'a UtxoApi>,
+    /// Extra pure-ADA outputs split off the change, one output per entry,
+    /// appended AFTER the main change output (so the change index — and any
+    /// chained-change prediction keyed to it — is unchanged). Used for the
+    /// collateral bootstrap and for fee-parcel replenishment: small
+    /// confirmed UTxOs are what let future carts fund every TX without
+    /// chaining, and thus sign in a single CIP-103 dialog.
+    pub change_splits: &'a [u64],
+}
+
+/// As [`build_cancel_offers_tx_with`], parameterised by [`CancelTxOptions`].
+pub fn build_cancel_offers_tx_opts(
+    deps: &super::TxDeps,
+    requests: &[CancelOfferRequest],
+    contract: &CancelContract,
+    opts: &CancelTxOptions,
+) -> Result<super::UnsignedTx, TxBuildError> {
+    build_cancel_offers_tx_inner(deps, requests, contract, opts)
 }
 
 /// As [`build_cancel_offers_tx_with`], but with a dedicated collateral UTxO
@@ -1168,7 +1193,15 @@ pub fn build_cancel_offers_tx_with_collateral(
     contract: &CancelContract,
     collateral_utxo: &UtxoApi,
 ) -> Result<super::UnsignedTx, TxBuildError> {
-    build_cancel_offers_tx_inner(deps, requests, contract, Some(collateral_utxo), None)
+    build_cancel_offers_tx_opts(
+        deps,
+        requests,
+        contract,
+        &CancelTxOptions {
+            dedicated_collateral: Some(collateral_utxo),
+            change_splits: &[],
+        },
+    )
 }
 
 /// As [`build_cancel_offers_tx_with`] (fee input doubles as collateral),
@@ -1183,16 +1216,24 @@ pub fn build_cancel_offers_tx_bootstrap(
     contract: &CancelContract,
     split_lovelace: u64,
 ) -> Result<super::UnsignedTx, TxBuildError> {
-    build_cancel_offers_tx_inner(deps, requests, contract, None, Some(split_lovelace))
+    build_cancel_offers_tx_opts(
+        deps,
+        requests,
+        contract,
+        &CancelTxOptions {
+            dedicated_collateral: None,
+            change_splits: &[split_lovelace],
+        },
+    )
 }
 
 fn build_cancel_offers_tx_inner(
     deps: &super::TxDeps,
     requests: &[CancelOfferRequest],
     contract: &CancelContract,
-    dedicated_collateral: Option<&UtxoApi>,
-    collateral_split: Option<u64>,
+    opts: &CancelTxOptions,
 ) -> Result<super::UnsignedTx, TxBuildError> {
+    let dedicated_collateral = opts.dedicated_collateral;
     use crate::helpers::output::{build_change_output, create_ada_output};
     use crate::selection;
     use pallas_crypto::hash::Hash;
@@ -1312,7 +1353,7 @@ fn build_cancel_offers_tx_inner(
 
     super::converge_fee_with_witnesses(
         |fee| {
-            let split = collateral_split.unwrap_or(0);
+            let split: u64 = opts.change_splits.iter().sum();
             let output_value =
                 total_input
                     .checked_sub(fee + split)
@@ -1375,12 +1416,14 @@ fn build_cancel_offers_tx_inner(
                 tx = tx.output(main_output);
             }
 
-            // Collateral bootstrap: a dedicated pure-ADA output the wallet
-            // can use as confirmed collateral for future carts. Appended
-            // after the main change so the change output's index — and with
-            // it the caller's chained-change prediction — is unchanged.
-            if split > 0 {
-                tx = tx.output(create_ada_output(from_address.clone(), split));
+            // Change splits (collateral bootstrap / fee-parcel
+            // replenishment): dedicated pure-ADA outputs the wallet can use
+            // as confirmed collateral or per-TX fee funding in future
+            // carts. One output per entry, appended after the main change
+            // so the change output's index — and with it the caller's
+            // chained-change prediction — is unchanged.
+            for &s in opts.change_splits {
+                tx = tx.output(create_ada_output(from_address.clone(), s));
             }
 
             // Collateral return. Reserve a generous lovelace budget for

--- a/cardano-tx/src/builder/collection_offer.rs
+++ b/cardano-tx/src/builder/collection_offer.rs
@@ -1149,7 +1149,7 @@ pub fn build_cancel_offers_tx_with(
     requests: &[CancelOfferRequest],
     contract: &CancelContract,
 ) -> Result<super::UnsignedTx, TxBuildError> {
-    build_cancel_offers_tx_inner(deps, requests, contract, None)
+    build_cancel_offers_tx_inner(deps, requests, contract, None, None)
 }
 
 /// As [`build_cancel_offers_tx_with`], but with a dedicated collateral UTxO
@@ -1168,7 +1168,22 @@ pub fn build_cancel_offers_tx_with_collateral(
     contract: &CancelContract,
     collateral_utxo: &UtxoApi,
 ) -> Result<super::UnsignedTx, TxBuildError> {
-    build_cancel_offers_tx_inner(deps, requests, contract, Some(collateral_utxo))
+    build_cancel_offers_tx_inner(deps, requests, contract, Some(collateral_utxo), None)
+}
+
+/// As [`build_cancel_offers_tx_with`] (fee input doubles as collateral),
+/// but additionally splits `split_lovelace` off the change into its own
+/// pure-ADA output — a collateral bootstrap for wallets that have no UTxO
+/// suitable as dedicated collateral. The split output can't collateralise
+/// *this* chain (it's unconfirmed until this TX lands), but once confirmed
+/// every future cart reserves it via the dedicated-collateral path.
+pub fn build_cancel_offers_tx_bootstrap(
+    deps: &super::TxDeps,
+    requests: &[CancelOfferRequest],
+    contract: &CancelContract,
+    split_lovelace: u64,
+) -> Result<super::UnsignedTx, TxBuildError> {
+    build_cancel_offers_tx_inner(deps, requests, contract, None, Some(split_lovelace))
 }
 
 fn build_cancel_offers_tx_inner(
@@ -1176,6 +1191,7 @@ fn build_cancel_offers_tx_inner(
     requests: &[CancelOfferRequest],
     contract: &CancelContract,
     dedicated_collateral: Option<&UtxoApi>,
+    collateral_split: Option<u64>,
 ) -> Result<super::UnsignedTx, TxBuildError> {
     use crate::helpers::output::{build_change_output, create_ada_output};
     use crate::selection;
@@ -1296,11 +1312,12 @@ fn build_cancel_offers_tx_inner(
 
     super::converge_fee_with_witnesses(
         |fee| {
+            let split = collateral_split.unwrap_or(0);
             let output_value =
                 total_input
-                    .checked_sub(fee)
+                    .checked_sub(fee + split)
                     .ok_or(TxBuildError::InsufficientFunds {
-                        needed: fee,
+                        needed: fee + split,
                         available: total_input,
                     })?;
 
@@ -1356,6 +1373,14 @@ fn build_cancel_offers_tx_inner(
                 let main_output =
                     build_change_output(from_address.clone(), output_value, &fee_utxo_refs, None)?;
                 tx = tx.output(main_output);
+            }
+
+            // Collateral bootstrap: a dedicated pure-ADA output the wallet
+            // can use as confirmed collateral for future carts. Appended
+            // after the main change so the change output's index — and with
+            // it the caller's chained-change prediction — is unchanged.
+            if split > 0 {
+                tx = tx.output(create_ada_output(from_address.clone(), split));
             }
 
             // Collateral return. Reserve a generous lovelace budget for
@@ -1531,6 +1556,46 @@ mod tests {
                 && i.txo_index == legacy_coll[0].txo_index
         }));
         assert!(legacy.staging.collateral_output.is_none());
+
+        // Bootstrap: legacy collateral (fee input, confirmed) plus a
+        // dedicated pure-ADA split appended AFTER the main change, so the
+        // change output's index — and the caller's chained-change
+        // prediction — is unchanged. Value conservation: change shrinks by
+        // exactly the split.
+        let split = 10_000_000u64;
+        let boot = build_cancel_offers_tx_bootstrap(&deps, &reqs, &CancelContract::wayup(), split)
+            .expect("bootstrap build");
+        let outputs = boot.staging.outputs.as_ref().expect("outputs set");
+        assert_eq!(outputs.len(), 2, "main change + collateral split");
+        assert_eq!(outputs[1].lovelace, split, "split appended after change");
+        // Value conservation: outputs + fee == CO value + fee UTxO value.
+        let boot_inputs = boot.staging.inputs.as_ref().expect("inputs set");
+        let fee_input_lovelace = boot_inputs
+            .iter()
+            .find_map(|i| {
+                let h = hex::encode(i.tx_hash.0);
+                [&funding, &collateral]
+                    .into_iter()
+                    .find(|u| u.tx_hash == h && u64::from(u.output_index) == i.txo_index)
+                    .map(|u| u.lovelace)
+            })
+            .expect("fee input is one of the wallet UTxOs");
+        assert_eq!(
+            outputs[0].lovelace + split + boot.fee,
+            reqs[0].co_lovelace + fee_input_lovelace,
+        );
+        let boot_coll = boot
+            .staging
+            .collateral_inputs
+            .as_ref()
+            .expect("collateral set");
+        assert!(
+            boot_inputs.iter().any(|i| {
+                hex::encode(i.tx_hash.0) == hex::encode(boot_coll[0].tx_hash.0)
+                    && i.txo_index == boot_coll[0].txo_index
+            }),
+            "bootstrap keeps legacy fee-input-as-collateral"
+        );
     }
 
     #[test]

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -1843,10 +1843,33 @@ impl MaestroApi {
     ) -> Result<T, MaestroError> {
         use http_client::HttpMethod;
 
-        let response_details = self
-            .client
-            .request_text_with_details(HttpMethod::POST, &url, Some(body))
-            .await?;
+        // Retry 429 with backoff, mirroring `get_url_with_retry`. Safe here
+        // because every `post_url` caller is idempotent (resolve outputs,
+        // datums-by-hash, evaluate) — transaction submission does NOT go
+        // through this path (it uses a raw `Fetch`), so this never re-sends
+        // a state-changing POST.
+        const MAX_RETRIES: u32 = 3;
+        let mut attempt = 0;
+        let response_details = loop {
+            let details = self
+                .client
+                .request_text_with_details(HttpMethod::POST, &url, Some(body))
+                .await?;
+            if details.status_code == 429 && attempt < MAX_RETRIES {
+                let delay_ms = details
+                    .retry_after_seconds()
+                    .map(|s| s * 1000)
+                    .unwrap_or_else(|| 1000 * (1 << attempt));
+                warn!(
+                    "Rate limited on POST attempt {} for URL: {url}, retrying after {delay_ms}ms",
+                    attempt + 1
+                );
+                worker_utils::sleep::sleep(delay_ms as i32).await;
+                attempt += 1;
+                continue;
+            }
+            break details;
+        };
 
         match response_details.status_code {
             status if (200..300).contains(&status) => {

--- a/indexers/maestro/src/lib.rs
+++ b/indexers/maestro/src/lib.rs
@@ -485,6 +485,34 @@ struct DatumsByHashesResponse {
     data: std::collections::HashMap<String, DatumData>,
 }
 
+/// One resolved output from `POST /transactions/outputs`.
+#[derive(Deserialize, Debug)]
+pub struct ResolvedTxOut {
+    pub tx_hash: String,
+    pub index: u32,
+    pub address: String,
+    pub datum: Option<ResolvedTxOutDatum>,
+}
+
+/// Datum attachment on a resolved output. `kind` is `"hash"` or `"inline"`
+/// — the distinction matters for spending: witness-set datums are only
+/// legal for hash-datum inputs (supplying one for an inline-datum input is
+/// rejected by the ledger with `NotAllowedSupplementalDatums`).
+#[derive(Deserialize, Debug)]
+pub struct ResolvedTxOutDatum {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub hash: Option<String>,
+    /// Hex-encoded CBOR. Present for inline datums; for hash datums only
+    /// when `resolve_datums=true` and Maestro knows the preimage.
+    pub bytes: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+struct ResolveTxOutputsResponse {
+    data: Vec<ResolvedTxOut>,
+}
+
 /// Minimal view of `GET /transactions/{tx_hash}`. Only the fields any
 /// caller in the workspace actually reads — keeping the struct narrow
 /// shields us from upstream additions (Maestro adds fields freely; serde
@@ -1076,6 +1104,26 @@ impl MaestroApi {
             MaestroError::Deserialization(format!("Failed to serialize datum hashes: {e}"))
         })?;
         let response: DatumsByHashesResponse = self.post_url(url, &body).await?;
+        Ok(response.data)
+    }
+
+    /// Resolve transaction outputs by `"tx_hash#index"` reference in one
+    /// call (`POST /transactions/outputs`), datums resolved. With
+    /// `allow_spent`, already-spent outputs are included rather than
+    /// silently dropped from the result.
+    pub async fn resolve_transaction_outputs(
+        &self,
+        refs: &[String],
+        allow_spent: bool,
+    ) -> Result<Vec<ResolvedTxOut>, MaestroError> {
+        let url = format!(
+            "https://{}/transactions/outputs?resolve_datums=true&allow_spent={allow_spent}",
+            self.base_url
+        );
+        let body = serde_json::to_value(refs).map_err(|e| {
+            MaestroError::Deserialization(format!("Failed to serialize output refs: {e}"))
+        })?;
+        let response: ResolveTxOutputsResponse = self.post_url(url, &body).await?;
         Ok(response.data)
     }
 

--- a/ui/wallet-core/src/cip30.rs
+++ b/ui/wallet-core/src/cip30.rs
@@ -354,7 +354,23 @@ impl WalletApi {
         }
 
         let result = sign_txs_js(&self.api, &array, partial_sign).await?;
+        // Guard against a non-array return: `js_sys::Array::from` on a bare
+        // string char-splits it into single-char "witnesses" of the wrong
+        // length, which would then be silently assembled as garbage. Require
+        // an actual array of the expected length.
+        if !result.is_array() {
+            return Err(WalletError::SigningFailed(
+                "signTxs did not return an array".into(),
+            ));
+        }
         let result_array = js_sys::Array::from(&result);
+        if result_array.length() as usize != tx_hexes.len() {
+            return Err(WalletError::SigningFailed(format!(
+                "signTxs returned {} witnesses for {} txs",
+                result_array.length(),
+                tx_hexes.len()
+            )));
+        }
         let mut witnesses = Vec::with_capacity(tx_hexes.len());
         for val in result_array.iter() {
             let hex = val.as_string().ok_or_else(|| {

--- a/ui/wallet-core/src/error.rs
+++ b/ui/wallet-core/src/error.rs
@@ -10,7 +10,7 @@ pub enum WalletError {
     #[error("Wallet not enabled: {0}")]
     NotEnabled(String),
 
-    #[error("User rejected connection")]
+    #[error("Rejected by user")]
     UserRejected,
 
     #[error("Wallet API error: {0}")]
@@ -29,9 +29,72 @@ pub enum WalletError {
     JsError(String),
 }
 
+impl WalletError {
+    /// True for a user-cancelled prompt (connect / sign / submit). Lets the
+    /// UI treat a deliberate decline as a no-op rather than a hard failure
+    /// (no scary error toast).
+    pub fn is_user_rejected(&self) -> bool {
+        matches!(self, WalletError::UserRejected)
+    }
+}
+
 impl From<wasm_bindgen::JsValue> for WalletError {
     fn from(value: wasm_bindgen::JsValue) -> Self {
-        let msg = value.as_string().unwrap_or_else(|| format!("{value:?}"));
-        WalletError::JsError(msg)
+        let (code, message) = extract_js_error(&value);
+
+        // Detect a user-cancelled prompt. Code is ambiguous across CIP-30
+        // error types (e.g. `2` = TxSignError.UserDeclined but also
+        // TxSendError.Failure), so key on the unambiguous APIError.Refused
+        // (-3) plus decline wording in the message. Deliberately does NOT
+        // match a bare "refused" (TxSendError.Refused = the NODE rejecting a
+        // tx, not the user).
+        let lower = message.to_ascii_lowercase();
+        let declined = code == Some(-3.0)
+            || lower.contains("declined")
+            || lower.contains("user cancel")
+            || lower.contains("cancelled by")
+            || lower.contains("canceled by")
+            || lower.contains("rejected by user")
+            || lower.contains("user rejected");
+        if declined {
+            return WalletError::UserRejected;
+        }
+
+        // Otherwise preserve the real, human-readable message (prefixed with
+        // the CIP-30 code when present) instead of an opaque `JsValue(...)`.
+        match code {
+            Some(c) => WalletError::JsError(format!("[{}] {message}", c as i64)),
+            None => WalletError::JsError(message),
+        }
     }
+}
+
+/// Pull a `(code, message)` out of whatever a wallet throws. CIP-30 errors
+/// are objects `{ code: number, info: string }`; wallets/relays also throw
+/// plain `Error` objects (`.message`), Maestro-style `{ code, message }`,
+/// or bare strings. `JsValue::as_string()` is `None` for all the object
+/// shapes, which is why the old impl produced `JsValue(Object(...))`.
+fn extract_js_error(value: &wasm_bindgen::JsValue) -> (Option<f64>, String) {
+    use wasm_bindgen::JsValue;
+
+    if let Some(s) = value.as_string() {
+        return (None, s);
+    }
+
+    let get_str = |key: &str| -> Option<String> {
+        js_sys::Reflect::get(value, &JsValue::from_str(key))
+            .ok()
+            .and_then(|v| v.as_string())
+            .filter(|s| !s.is_empty())
+    };
+    let code = js_sys::Reflect::get(value, &JsValue::from_str("code"))
+        .ok()
+        .and_then(|v| v.as_f64());
+
+    // CIP-30 uses `info`; Error/Maestro use `message`.
+    let message = get_str("info")
+        .or_else(|| get_str("message"))
+        .unwrap_or_else(|| format!("{value:?}"));
+
+    (code, message)
 }


### PR DESCRIPTION
Reusable primitives extracted from the jpg-store-mirror collection-offer (CO) bulk-cancellation work. Three independent, additive improvements:

- **cardano-tx** — cancel-TX builder gains dedicated-collateral and change-split support, plus safety guards.
- **maestro** — new batch output/datum resolution endpoint; POST rate-limit retry parity.
- **wallet-core** — CIP-30 errors are finally typed and human-readable, with user-decline detection.

All changes are backward compatible: no public item was removed or had its signature changed. The previous cancel-builder entry points remain as thin wrappers over the new options-based core.

## cardano-tx (`builder/collection_offer.rs`)

- New `CancelTxOptions { dedicated_collateral, change_splits }` and `build_cancel_offers_tx_opts()` as the parameterised core. `build_cancel_offers_tx_with` is now a wrapper; added `build_cancel_offers_tx_with_collateral()` and `build_cancel_offers_tx_bootstrap()`.
- **Dedicated collateral:** collateral can come from a caller-reserved confirmed UTxO instead of doubling the fee input; that UTxO is excluded from fee-candidate selection so it can't be spent as both, and a collateral-return output is emitted (reserving ~5 ADA) so a large reserved UTxO isn't forfeited on script failure.
- **Change splits:** extra pure-ADA outputs appended *after* the change output (change index unchanged), for collateral bootstrap / fee-parcel replenishment in the consumer.
- **Safety:** every output is now checked against min-ADA (a bad split total or tiny split fails the build instead of producing an on-chain `OutputTooSmallUTxO`); a malformed `datum_cbor_hex` now errors instead of being silently dropped (which would have surfaced far away as `MissingRequiredDatums`).
- Added `test_cancel_batch_dedicated_collateral` covering collateral isolation, the return output, split ordering/value conservation, and the legacy shape. Full suite: 247 passing.

## maestro (`indexers/maestro/src/lib.rs`)

- New `resolve_transaction_outputs(refs, allow_spent)` (`POST /transactions/outputs?resolve_datums=true`) returning `ResolvedTxOut` / `ResolvedTxOutDatum` — exposes each output's datum **kind** (`hash` vs `inline`) and bytes, so a consumer can decide whether a spend needs a witness-set datum (attaching one for an inline datum is rejected with `NotAllowedSupplementalDatums`).
- `post_url` now retries HTTP 429 with backoff, matching `get_url_with_retry`. Safe: every `post_url` caller is idempotent (resolve/datums/evaluate); transaction submission uses a raw `Fetch` and is never retried here.

## wallet-core (`ui/wallet-core/src/error.rs`, `cip30.rs`)

- Rewrote `From<JsValue> for WalletError`: the old impl called `as_string()` (always `None` on an object), so every wallet error collapsed to `JsValue(Object(...))`. New `extract_js_error` pulls a real `(code, message)` from CIP-30 `{code, info}`, `Error`/`{code, message}`, or a bare string, and classifies user-cancelled prompts (APIError.Refused `-3` or decline wording — deliberately **not** a bare "refused", which is the node) into `WalletError::UserRejected`. Added `is_user_rejected()`; broadened the variant's display to "Rejected by user" (it now covers sign/submit, not just connect).
- `sign_txs` now rejects a non-array or wrong-length return instead of letting `Array::from` char-split a bare string into bogus per-tx witnesses.

## Compatibility & testing

- Additive only — verified with a full `cargo check --workspace` on the consumer repo: every `cardano-tx`/`maestro`/`wallet-core` consumer compiles, and the other wallet-connecting frontends (meme-builder, txmints, client-portal) build for wasm unchanged. They inherit the improved wallet-error messages for free.
- `cargo test -p cardano-tx`: 247 passing. Clippy clean at `-D warnings` on all three crates.