### PR TITLE
feature[cardano-tx]: atomic-swap coin selection, recipient-funded min-UTxO, correct 2-witness fee

### DIFF
--- a/cardano-tx/src/builder/swap.rs
+++ b/cardano-tx/src/builder/swap.rs
@@ -12,7 +12,7 @@ use cardano_assets::{AssetId, UtxoApi};
 use pallas_addresses::Address;
 use pallas_txbuilder::StagingTransaction;
 
-use super::{converge_fee, UnsignedTx};
+use super::{converge_fee_with_witnesses, UnsignedTx};
 use crate::error::TxBuildError;
 use crate::helpers::input::add_utxo_inputs;
 use crate::helpers::output::{add_assets_from_map, create_ada_output};
@@ -44,13 +44,19 @@ pub struct SwapBuildResult {
 /// Detailed cost breakdown for an atomic swap, one entry per side.
 #[derive(Debug)]
 pub struct SwapCostBreakdown {
-    /// Total network TX fee (split between parties).
+    /// Total network TX fee.
     pub network_fee: u64,
+    /// Network fee borne by Party A (an even split of `network_fee`; A absorbs the
+    /// rounding remainder).
+    pub a_network_fee: u64,
+    /// Network fee borne by Party B (an even split of `network_fee`).
+    pub b_network_fee: u64,
     /// Total platform/orchestration fee.
     pub platform_fee: u64,
-    /// Min UTxO lovelace Party A must fund for the output carrying their assets to B.
+    /// Min-UTxO lovelace Party A funds for the assets A *receives* (the wrapper
+    /// lands in A's own wallet and is recoverable). 0 when A receives only ADA.
     pub a_min_utxo_cost: u64,
-    /// Min UTxO lovelace Party B must fund for the output carrying their assets to A.
+    /// Min-UTxO lovelace Party B funds for the assets B *receives*.
     pub b_min_utxo_cost: u64,
     /// Net ADA gain/loss for Party A (positive = gains ADA, negative = loses ADA).
     pub a_net_ada: i64,
@@ -58,10 +64,8 @@ pub struct SwapCostBreakdown {
     pub b_net_ada: i64,
 }
 
-/// Additional fee per VKey witness beyond the first (bytes × min_fee_coefficient).
-/// Each VKey witness is ~100 bytes CBOR. `converge_fee` accounts for one witness
-/// via its dummy-sign approach, so we add the marginal cost of each extra signer.
-const EXTRA_WITNESS_BYTES: u64 = 100;
+/// A swap requires a vkey witness from BOTH parties (CIP-30 partial signing).
+const SWAP_WITNESSES: u32 = 2;
 
 /// Generous flat network-fee headroom (lovelace) added to each side's coin-selection
 /// target. The exact fee is computed by `converge_fee`; over-selecting here only
@@ -102,21 +106,31 @@ pub fn build_atomic_swap(
     let a_min_utxo = min_utxo_for_assets(params, &a_offered_ids);
     let b_min_utxo = min_utxo_for_assets(params, &b_offered_ids);
 
-    let a_receive_min = a.ada_lovelace.max(a_min_utxo);
-    let b_receive_min = b.ada_lovelace.max(b_min_utxo);
+    let a_ada = a.ada_lovelace;
+    let b_ada = b.ada_lovelace;
+
+    // ── Cost allocation ──────────────────────────────────────────────────
+    // Min-UTxO wrapper: the mandatory ADA that must ride with an asset lands in
+    // the *recipient's* wallet (and is recoverable when they later move it), so
+    // the recipient funds it — not the sender. A sender's ADA sweetener already
+    // covers part of the receive output; the recipient funds only the shortfall
+    // up to min-UTxO. This lets an asset seller receive clean proceeds instead of
+    // subsidising the buyer's min-UTxO.
+    let a_wrapper = b_min_utxo.saturating_sub(b_ada); // A receives B's assets
+    let b_wrapper = a_min_utxo.saturating_sub(a_ada); // B receives A's assets
+
+    let a_platform_share = fee_output_amount / 2;
+    let b_platform_share = fee_output_amount - a_platform_share;
 
     // ── Coin selection ───────────────────────────────────────────────────
     // Select a minimal input set per side instead of consuming the whole wallet:
     // must-spend the UTxOs that hold the offered assets, then top up ADA to cover
-    // that side's outflow (receive-output funding + fee share + platform-fee share).
-    // A generous flat fee estimate is fine — `converge_fee` computes the exact fee
-    // below and any surplus returns as change; we only ever *reduce* input count.
-    let a_platform_share = fee_output_amount / 2;
-    let b_platform_share = fee_output_amount - a_platform_share;
-    let a_fee_share = SELECTION_FEE_ESTIMATE / 2 + SELECTION_FEE_ESTIMATE % 2;
-    let b_fee_share = SELECTION_FEE_ESTIMATE / 2;
-    let a_target = a_receive_min + a_fee_share + a_platform_share;
-    let b_target = b_receive_min + b_fee_share + b_platform_share;
+    // that side's outflow (ADA sweetener + wrapper it funds + fee share + platform
+    // share). A generous flat fee estimate is fine — `converge_fee` computes the
+    // exact fee below and any surplus returns as change.
+    let (a_fee_est, b_fee_est) = split_network_fee(SELECTION_FEE_ESTIMATE);
+    let a_target = a_ada + a_wrapper + a_fee_est + a_platform_share;
+    let b_target = b_ada + b_wrapper + b_fee_est + b_platform_share;
 
     let a_selected = select_side_inputs(a, a_target)?;
     let b_selected = select_side_inputs(b, b_target)?;
@@ -132,52 +146,46 @@ pub fn build_atomic_swap(
     let a_kept_assets = subtract_assets(&a_all_assets, &a.offered_assets);
     let b_kept_assets = subtract_assets(&b_all_assets, &b.offered_assets);
 
-    // Extra witness cost: 1 extra signer beyond what converge_fee accounts for
-    let extra_witness_fee = EXTRA_WITNESS_BYTES * params.min_fee_coefficient;
-
-    // Each side pays half the TX fee + half the orchestration fee
-    // (Fee is split evenly; the orchestration fee is already accounted for in fee_output)
+    // Each side pays half the network fee + half the orchestration fee.
     let fee_output_clone = fee_output.clone();
     let a_addr = a.address.clone();
     let b_addr = b.address.clone();
     let a_offered = a.offered_assets.clone();
     let b_offered = b.offered_assets.clone();
-    let a_ada = a.ada_lovelace;
-    let b_ada = b.ada_lovelace;
     let a_kept = a_kept_assets.clone();
     let b_kept = b_kept_assets.clone();
 
     let params_clone = params.clone();
-    let unsigned = converge_fee(
+    // Size the fee for BOTH parties' witnesses — `converge_fee` (1 witness) would
+    // undersize the 2-signature swap and the node would reject it as below the
+    // minimum fee.
+    let unsigned = converge_fee_with_witnesses(
         move |fee| {
-            let total_fee = fee + extra_witness_fee;
-            // Split TX fee evenly between parties
-            let fee_per_side = total_fee / 2;
-            let fee_remainder = total_fee % 2; // Party A absorbs the rounding remainder
+            // Network fee split evenly between the two parties.
+            let (a_fee_share, b_fee_share) = split_network_fee(fee);
 
-            // Party A's change = total input - receive output they fund (B gets A's assets)
-            //                    - fee share - orchestration fee share
-            // A funds the output that delivers A's offered assets to B (a_receive_min ADA)
-            let a_change = a_total_lovelace
-                .checked_sub(a_receive_min)
-                .and_then(|v| v.checked_sub(fee_per_side + fee_remainder))
-                .and_then(|v| v.checked_sub(fee_output_amount / 2))
-                .ok_or(TxBuildError::InsufficientFunds {
-                    needed: a_receive_min + fee_per_side + fee_remainder + fee_output_amount / 2,
-                    available: a_total_lovelace,
-                })?;
+            // Party A's outflow = ADA sweetener A gives + the min-UTxO wrapper A
+            //   funds for the assets A receives + A's fee share + A's platform share.
+            //   A's own asset-input ADA (freed when A's offered UTxO is spent) returns
+            //   to A as change — A no longer funds the wrapper for what it sends.
+            let a_outflow = a_ada + a_wrapper + a_fee_share + a_platform_share;
+            let a_change =
+                a_total_lovelace
+                    .checked_sub(a_outflow)
+                    .ok_or(TxBuildError::InsufficientFunds {
+                        needed: a_outflow,
+                        available: a_total_lovelace,
+                    })?;
 
-            // Party B's change = total input - receive output they fund (A gets B's assets)
-            //                    - fee share - orchestration fee share
-            let b_change = b_total_lovelace
-                .checked_sub(b_receive_min)
-                .and_then(|v| v.checked_sub(fee_per_side))
-                .and_then(|v| v.checked_sub(fee_output_amount - fee_output_amount / 2))
-                .ok_or(TxBuildError::InsufficientFunds {
-                    needed: b_receive_min + fee_per_side + fee_output_amount
-                        - fee_output_amount / 2,
-                    available: b_total_lovelace,
-                })?;
+            // Party B's outflow, symmetric.
+            let b_outflow = b_ada + b_wrapper + b_fee_share + b_platform_share;
+            let b_change =
+                b_total_lovelace
+                    .checked_sub(b_outflow)
+                    .ok_or(TxBuildError::InsufficientFunds {
+                        needed: b_outflow,
+                        available: b_total_lovelace,
+                    })?;
 
             // Build the transaction from the pre-selected minimal input set
             let all_inputs: Vec<&UtxoApi> = a_selected
@@ -214,47 +222,55 @@ pub fn build_atomic_swap(
                 }
             }
 
-            Ok(tx.fee(total_fee).network_id(network_id))
+            Ok(tx.fee(fee).network_id(network_id))
         },
         300_000, // Initial fee estimate (generous for multi-input/output TX)
         params,
+        SWAP_WITNESSES,
     )?;
 
-    // Compute cost breakdown from the converged fee
+    // Compute cost breakdown from the converged fee (already sized for both witnesses)
     let network_fee = unsigned.fee;
-    let total_fee_with_witness = network_fee + extra_witness_fee;
-    let fee_per_side = total_fee_with_witness / 2;
-    let fee_remainder = total_fee_with_witness % 2;
+    let (a_network_share, b_network_share) = split_network_fee(network_fee);
 
-    let a_platform_share = fee_output_amount / 2;
-    let b_platform_share = fee_output_amount - a_platform_share;
-    let a_network_share = fee_per_side + fee_remainder;
-    let b_network_share = fee_per_side;
-
-    // Net ADA = received from peer - sent to peer - min UTxO cost - network fee - platform fee
-    // Note: change output splitting is NOT a cost — that ADA stays in your wallet.
+    // Net ADA = ADA received from peer - ADA sweetener given - min-UTxO wrapper the
+    // party funds for assets it *receives* - its network fee - its platform fee.
+    // The wrapper is locked in the party's own wallet (recoverable), but counted as
+    // a cost here since it isn't liquid. Change splitting is NOT a cost — that ADA
+    // stays in the wallet.
     let a_net_ada = b_ada as i64
         - a_ada as i64
-        - a_min_utxo as i64
+        - a_wrapper as i64
         - a_network_share as i64
         - a_platform_share as i64;
     let b_net_ada = a_ada as i64
         - b_ada as i64
-        - b_min_utxo as i64
+        - b_wrapper as i64
         - b_network_share as i64
         - b_platform_share as i64;
 
     Ok(SwapBuildResult {
         unsigned,
         costs: SwapCostBreakdown {
-            network_fee: total_fee_with_witness,
+            network_fee,
+            a_network_fee: a_network_share,
+            b_network_fee: b_network_share,
             platform_fee: fee_output_amount,
-            a_min_utxo_cost: a_min_utxo,
-            b_min_utxo_cost: b_min_utxo,
+            a_min_utxo_cost: a_wrapper,
+            b_min_utxo_cost: b_wrapper,
             a_net_ada,
             b_net_ada,
         },
     })
+}
+
+/// Split the network fee evenly between the two parties (Party A absorbs the
+/// rounding remainder). The min-UTxO wrapper is already allocated to the asset
+/// recipient separately, so an even fee split still leaves an NFT seller with
+/// essentially their full sale price (they bear only ~half the ~0.18 ADA fee).
+/// Returns `(a_share, b_share)` with `a_share + b_share == total_fee`.
+fn split_network_fee(total_fee: u64) -> (u64, u64) {
+    (total_fee / 2 + total_fee % 2, total_fee / 2)
 }
 
 /// Create a receive output with offered assets and ADA sweetener.
@@ -670,14 +686,115 @@ mod tests {
         assert!(result.is_ok(), "swap with sweetener failed: {result:?}");
 
         let swap = result.unwrap();
-        // Party A offers NFT (has min UTxO cost), Party B offers pure ADA (no min UTxO)
-        assert!(swap.costs.a_min_utxo_cost > 0);
-        assert_eq!(swap.costs.b_min_utxo_cost, 0);
-        // Party A receives 5 ADA sweetener, net should be positive
+        // Min-UTxO is funded by the *recipient* of the assets:
+        //  - Party A receives only ADA (B's sweetener) → funds no wrapper.
+        //  - Party B receives A's NFT → funds its min-UTxO wrapper.
+        assert_eq!(swap.costs.a_min_utxo_cost, 0);
+        assert!(swap.costs.b_min_utxo_cost > 0);
+        // Party A receives a 5 ADA sweetener with no costs → net positive.
         assert!(
             swap.costs.a_net_ada > 0,
             "seller should profit: {}",
             swap.costs.a_net_ada
+        );
+    }
+
+    #[test]
+    fn test_swap_fee_covers_two_witnesses() {
+        // Regression: the fee must be >= the node's minimum for a *2-signature* tx.
+        // The builder previously sized for 1 witness + a too-small fudge, so the
+        // node rejected the tx as "fee below the minimum fee required".
+        let nft_a = make_asset_id("A");
+        let nft_b = make_asset_id("B");
+        let sides = [
+            SwapSide {
+                utxos: vec![make_utxo(
+                    &"a".repeat(64),
+                    10_000_000,
+                    vec![(nft_a.clone(), 1)],
+                )],
+                address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+                offered_assets: HashMap::from([(nft_a.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+            SwapSide {
+                utxos: vec![make_utxo(
+                    &"b".repeat(64),
+                    10_000_000,
+                    vec![(nft_b.clone(), 1)],
+                )],
+                address: Address::from_bech32(TEST_ADDR_B).unwrap(),
+                offered_assets: HashMap::from([(nft_b.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+        ];
+        let params = test_params();
+        let swap = build_atomic_swap(&sides, None, &params, 0).unwrap();
+
+        // The converged fee must cover the fully-signed (2-witness) transaction.
+        let min_fee = crate::fee::calculate_fee_with_witnesses(&swap.unsigned.staging, &params, 2);
+        assert!(
+            swap.unsigned.fee >= min_fee,
+            "fee {} is below the 2-witness minimum {min_fee}",
+            swap.unsigned.fee
+        );
+    }
+
+    #[test]
+    fn test_nft_sale_cost_allocation() {
+        // A sells an NFT; B pays 2500 ADA. The buyer funds the NFT's min-UTxO
+        // wrapper (it lands in the buyer's wallet), and the network fee is split
+        // evenly — so the seller nets the price minus only their half of the fee.
+        let nft = make_asset_id("ForSale");
+        let price = 2_500_000_000u64;
+        let sides = [
+            SwapSide {
+                utxos: vec![make_utxo(
+                    &"a".repeat(64),
+                    3_000_000,
+                    vec![(nft.clone(), 1)],
+                )],
+                address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+                offered_assets: HashMap::from([(nft.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+            SwapSide {
+                // Buyer's 2500 ADA across a couple of UTxOs + headroom for fee/wrapper.
+                utxos: vec![
+                    make_utxo(&"b".repeat(64), 2_000_000_000, vec![]),
+                    make_utxo(&"c".repeat(64), 510_000_000, vec![]),
+                ],
+                address: Address::from_bech32(TEST_ADDR_B).unwrap(),
+                offered_assets: HashMap::new(),
+                ada_lovelace: price,
+            },
+        ];
+
+        let swap = build_atomic_swap(&sides, None, &test_params(), 0).unwrap();
+
+        // Seller (A) funds no wrapper — the ADA lands cleanly.
+        assert_eq!(swap.costs.a_min_utxo_cost, 0, "seller funds no wrapper");
+        // Buyer (B) funds the NFT's min-UTxO wrapper (lands in the buyer's wallet).
+        assert!(
+            swap.costs.b_min_utxo_cost > 0,
+            "buyer funds the NFT wrapper"
+        );
+        // Network fee split evenly between the two parties.
+        assert_eq!(
+            swap.costs.a_network_fee + swap.costs.b_network_fee,
+            swap.costs.network_fee,
+            "fee shares sum to the total"
+        );
+        assert_eq!(
+            swap.costs.a_network_fee,
+            swap.costs.network_fee / 2 + swap.costs.network_fee % 2,
+            "seller bears half the fee (plus remainder)"
+        );
+        // Seller receives the price minus only their half of the network fee.
+        assert_eq!(
+            swap.costs.a_net_ada,
+            price as i64 - swap.costs.a_network_fee as i64,
+            "seller nets price minus half the fee"
         );
     }
 

--- a/cardano-tx/src/builder/swap.rs
+++ b/cardano-tx/src/builder/swap.rs
@@ -6,7 +6,7 @@
 //!
 //! The transaction requires VKey witnesses from both parties (CIP-30 partial signing).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use cardano_assets::{AssetId, UtxoApi};
 use pallas_addresses::Address;
@@ -18,10 +18,13 @@ use crate::helpers::input::add_utxo_inputs;
 use crate::helpers::output::{add_assets_from_map, create_ada_output};
 use crate::helpers::utxo_query::{collect_utxo_native_assets, total_utxo_lovelace};
 use crate::params::TxBuildParams;
+use crate::select::{select, Selection, Strategy};
 
 /// One side of an atomic swap.
 pub struct SwapSide {
-    /// UTxOs available from this party (pre-selected to cover offered assets).
+    /// This party's available UTxO pool. `build_atomic_swap` selects a minimal
+    /// covering subset (the UTxOs holding the offered assets + an ADA top-up) —
+    /// pass the full wallet set; it is not consumed wholesale.
     pub utxos: Vec<UtxoApi>,
     /// Payment address for this party's receive output and change.
     pub address: Address,
@@ -60,6 +63,11 @@ pub struct SwapCostBreakdown {
 /// via its dummy-sign approach, so we add the marginal cost of each extra signer.
 const EXTRA_WITNESS_BYTES: u64 = 100;
 
+/// Generous flat network-fee headroom (lovelace) added to each side's coin-selection
+/// target. The exact fee is computed by `converge_fee`; over-selecting here only
+/// returns as change, so ~1 ADA is a safe upper bound for a native multi-sig swap.
+const SELECTION_FEE_ESTIMATE: u64 = 1_000_000;
+
 /// Build an atomic swap transaction between two parties.
 ///
 /// # Arguments
@@ -84,22 +92,45 @@ pub fn build_atomic_swap(
         return Err(TxBuildError::NoSuitableUtxo);
     }
 
-    let a_utxo_refs: Vec<&UtxoApi> = a.utxos.iter().collect();
-    let b_utxo_refs: Vec<&UtxoApi> = b.utxos.iter().collect();
-
-    let a_total_lovelace = total_utxo_lovelace(&a_utxo_refs);
-    let b_total_lovelace = total_utxo_lovelace(&b_utxo_refs);
-
-    // Collect all native assets from each side's UTxOs
-    let a_all_assets = collect_utxo_native_assets(&a_utxo_refs, None);
-    let b_all_assets = collect_utxo_native_assets(&b_utxo_refs, None);
-
-    // Calculate assets each side keeps (all assets minus what they offered)
-    let a_kept_assets = subtract_assets(&a_all_assets, &a.offered_assets);
-    let b_kept_assets = subtract_assets(&b_all_assets, &b.offered_assets);
-
     // Fee output amount (0 if no fee)
     let fee_output_amount = fee_output.as_ref().map(|(_, amt)| *amt).unwrap_or(0);
+
+    // Compute min UTxO for each receive output based on actual assets being delivered.
+    // Each party funds the output that delivers their offered assets to the peer.
+    let a_offered_ids: Vec<AssetId> = a.offered_assets.keys().cloned().collect();
+    let b_offered_ids: Vec<AssetId> = b.offered_assets.keys().cloned().collect();
+    let a_min_utxo = min_utxo_for_assets(params, &a_offered_ids);
+    let b_min_utxo = min_utxo_for_assets(params, &b_offered_ids);
+
+    let a_receive_min = a.ada_lovelace.max(a_min_utxo);
+    let b_receive_min = b.ada_lovelace.max(b_min_utxo);
+
+    // ── Coin selection ───────────────────────────────────────────────────
+    // Select a minimal input set per side instead of consuming the whole wallet:
+    // must-spend the UTxOs that hold the offered assets, then top up ADA to cover
+    // that side's outflow (receive-output funding + fee share + platform-fee share).
+    // A generous flat fee estimate is fine — `converge_fee` computes the exact fee
+    // below and any surplus returns as change; we only ever *reduce* input count.
+    let a_platform_share = fee_output_amount / 2;
+    let b_platform_share = fee_output_amount - a_platform_share;
+    let a_fee_share = SELECTION_FEE_ESTIMATE / 2 + SELECTION_FEE_ESTIMATE % 2;
+    let b_fee_share = SELECTION_FEE_ESTIMATE / 2;
+    let a_target = a_receive_min + a_fee_share + a_platform_share;
+    let b_target = b_receive_min + b_fee_share + b_platform_share;
+
+    let a_selected = select_side_inputs(a, a_target)?;
+    let b_selected = select_side_inputs(b, b_target)?;
+
+    let a_total_lovelace = total_utxo_lovelace(&a_selected);
+    let b_total_lovelace = total_utxo_lovelace(&b_selected);
+
+    // Collect all native assets from each side's *selected* UTxOs
+    let a_all_assets = collect_utxo_native_assets(&a_selected, None);
+    let b_all_assets = collect_utxo_native_assets(&b_selected, None);
+
+    // Calculate assets each side keeps (assets in selected UTxOs minus what they offered)
+    let a_kept_assets = subtract_assets(&a_all_assets, &a.offered_assets);
+    let b_kept_assets = subtract_assets(&b_all_assets, &b.offered_assets);
 
     // Extra witness cost: 1 extra signer beyond what converge_fee accounts for
     let extra_witness_fee = EXTRA_WITNESS_BYTES * params.min_fee_coefficient;
@@ -115,16 +146,6 @@ pub fn build_atomic_swap(
     let b_ada = b.ada_lovelace;
     let a_kept = a_kept_assets.clone();
     let b_kept = b_kept_assets.clone();
-
-    // Compute min UTxO for each receive output based on actual assets being delivered.
-    // Each party funds the output that delivers their offered assets to the peer.
-    let a_offered_ids: Vec<AssetId> = a.offered_assets.keys().cloned().collect();
-    let b_offered_ids: Vec<AssetId> = b.offered_assets.keys().cloned().collect();
-    let a_min_utxo = min_utxo_for_assets(params, &a_offered_ids);
-    let b_min_utxo = min_utxo_for_assets(params, &b_offered_ids);
-
-    let a_receive_min = a.ada_lovelace.max(a_min_utxo);
-    let b_receive_min = b.ada_lovelace.max(b_min_utxo);
 
     let params_clone = params.clone();
     let unsigned = converge_fee(
@@ -158,8 +179,12 @@ pub fn build_atomic_swap(
                     available: b_total_lovelace,
                 })?;
 
-            // Build the transaction
-            let all_inputs: Vec<&UtxoApi> = a.utxos.iter().chain(b.utxos.iter()).collect();
+            // Build the transaction from the pre-selected minimal input set
+            let all_inputs: Vec<&UtxoApi> = a_selected
+                .iter()
+                .copied()
+                .chain(b_selected.iter().copied())
+                .collect();
             let mut tx = add_utxo_inputs(StagingTransaction::new(), &all_inputs)?;
 
             // Output 1: Party A receives B's offered assets + B's ADA sweetener
@@ -456,6 +481,85 @@ fn subtract_assets(
     kept
 }
 
+/// Select a minimal input set for one swap side: the UTxOs holding the offered
+/// assets (must-spend), topped up with the smallest pure-ADA UTxO(s) needed to
+/// cover `target_lovelace`. Replaces the old whole-wallet input sweep — the pool
+/// top-up draws only pure-ADA UTxOs (see [`crate::select::select`]), so no
+/// unrelated assets get dragged into the transaction as change.
+fn select_side_inputs(
+    side: &SwapSide,
+    target_lovelace: u64,
+) -> Result<Vec<&UtxoApi>, TxBuildError> {
+    // A swap draws from the party's whole pool — nothing is earmarked/excluded.
+    // Must be `'static` so the returned refs borrow only from `side.utxos`, not a
+    // local (the `Selection` unifies all three borrows under one lifetime).
+    static EMPTY_EXCLUDE: std::sync::OnceLock<HashSet<(String, u32)>> = std::sync::OnceLock::new();
+    let exclude = EMPTY_EXCLUDE.get_or_init(HashSet::new);
+
+    let must_spend = utxos_covering_offered(&side.utxos, &side.offered_assets)?;
+    let sel = Selection {
+        must_spend,
+        pool: &side.utxos,
+        exclude,
+        strategy: Strategy::SmallestSufficient,
+    };
+    select(&sel, target_lovelace).map_err(|e| match e {
+        crate::select::SelectError::Insufficient { target, available } => {
+            TxBuildError::InsufficientFunds {
+                needed: target,
+                available,
+            }
+        }
+        // A duplicate must-spend would only arise from a genuinely malformed UTxO
+        // pool (same ref twice); surface it as "no suitable UTxO" rather than a
+        // funds shortfall.
+        crate::select::SelectError::DuplicateMustSpend { .. } => TxBuildError::NoSuitableUtxo,
+    })
+}
+
+/// Greedily pick the UTxOs that hold a side's offered assets, accumulating UTxOs
+/// per asset until the offered quantity is covered (an NFT = one UTxO; a fungible
+/// token = however many UTxOs sum to the offered quantity). Returns
+/// [`TxBuildError::NoSuitableUtxo`] if the pool can't cover an offered asset.
+fn utxos_covering_offered<'a>(
+    utxos: &'a [UtxoApi],
+    offered: &HashMap<AssetId, u64>,
+) -> Result<Vec<&'a UtxoApi>, TxBuildError> {
+    if offered.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Remaining quantity still needed per offered asset.
+    let mut needed: HashMap<AssetId, u64> = offered.clone();
+    let mut chosen: Vec<&'a UtxoApi> = Vec::new();
+    let mut chosen_refs: HashSet<(&'a str, u32)> = HashSet::new();
+
+    for utxo in utxos {
+        // Only take this UTxO if it still contributes to an uncovered offered asset.
+        let contributes = utxo
+            .assets
+            .iter()
+            .any(|aq| needed.get(&aq.asset_id).is_some_and(|&rem| rem > 0));
+        if !contributes {
+            continue;
+        }
+        if chosen_refs.insert((utxo.tx_hash.as_str(), utxo.output_index)) {
+            for aq in &utxo.assets {
+                if let Some(rem) = needed.get_mut(&aq.asset_id) {
+                    *rem = rem.saturating_sub(aq.quantity);
+                }
+            }
+            chosen.push(utxo);
+        }
+    }
+
+    if needed.values().any(|&rem| rem > 0) {
+        return Err(TxBuildError::NoSuitableUtxo);
+    }
+
+    Ok(chosen)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -704,6 +808,124 @@ mod tests {
             swap.costs.a_net_ada > -5_000_000,
             "net ADA unreasonably negative (change overhead leaked?): {}",
             swap.costs.a_net_ada
+        );
+    }
+
+    #[test]
+    fn test_coin_selection_bounds_inputs() {
+        // Party offers one NFT held in a single UTxO, but the wallet also holds
+        // 50 unrelated pure-ADA UTxOs. Selection must NOT sweep them all.
+        let nft = make_asset_id("OfferedNFT");
+        let mut utxos = vec![make_utxo(
+            &"f".repeat(64),
+            3_000_000,
+            vec![(nft.clone(), 1)],
+        )];
+        for i in 0..50u32 {
+            utxos.push(make_utxo(&format!("{i:064x}"), 2_000_000, vec![]));
+        }
+        let side = SwapSide {
+            utxos,
+            address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+            offered_assets: HashMap::from([(nft.clone(), 1)]),
+            ada_lovelace: 0,
+        };
+        // The NFT UTxO alone (3 ADA) already covers the small target → 1 input.
+        let selected = select_side_inputs(&side, 2_500_000).unwrap();
+        assert_eq!(selected.len(), 1, "expected only the offered-asset UTxO");
+        assert!(selected[0].assets.iter().any(|aq| aq.asset_id == nft));
+    }
+
+    #[test]
+    fn test_coin_selection_tops_up_ada() {
+        // NFT sits in a UTxO with only 1 ADA — selection must add ADA UTxOs to
+        // reach the target, but still far fewer than the whole wallet.
+        let nft = make_asset_id("OfferedNFT");
+        let mut utxos = vec![make_utxo(
+            &"f".repeat(64),
+            1_000_000,
+            vec![(nft.clone(), 1)],
+        )];
+        for i in 0..8u32 {
+            utxos.push(make_utxo(&format!("{i:064x}"), 2_000_000, vec![]));
+        }
+        let side = SwapSide {
+            utxos,
+            address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+            offered_assets: HashMap::from([(nft.clone(), 1)]),
+            ada_lovelace: 0,
+        };
+        let selected = select_side_inputs(&side, 4_000_000).unwrap();
+        assert!(
+            (2..6).contains(&selected.len()),
+            "expected a small topped-up set, got {}",
+            selected.len()
+        );
+        assert!(selected
+            .iter()
+            .any(|u| u.assets.iter().any(|aq| aq.asset_id == nft)));
+        let total: u64 = selected.iter().map(|u| u.lovelace).sum();
+        assert!(total >= 4_000_000);
+    }
+
+    #[test]
+    fn test_utxos_covering_offered_fungible_accumulates() {
+        // A fungible offer of 100 spread across two 60-qty UTxOs needs both.
+        let ft = make_asset_id("TOKEN");
+        let utxos = vec![
+            make_utxo(&"a".repeat(64), 2_000_000, vec![(ft.clone(), 60)]),
+            make_utxo(&"b".repeat(64), 2_000_000, vec![(ft.clone(), 60)]),
+            make_utxo(&"c".repeat(64), 2_000_000, vec![]),
+        ];
+        let offered = HashMap::from([(ft.clone(), 100)]);
+        let covering = utxos_covering_offered(&utxos, &offered).unwrap();
+        assert_eq!(covering.len(), 2, "need both token UTxOs to cover qty 100");
+    }
+
+    #[test]
+    fn test_swap_ignores_unrelated_utxos() {
+        // Each side offers one NFT (in one UTxO) but holds 40 unrelated ADA UTxOs.
+        // Fee scales with tx size, so a bounded fee proves inputs weren't swept.
+        let nft_a = make_asset_id("PirateA");
+        let nft_b = make_asset_id("PirateB");
+
+        let mut a_utxos = vec![make_utxo(
+            &"a".repeat(64),
+            5_000_000,
+            vec![(nft_a.clone(), 1)],
+        )];
+        let mut b_utxos = vec![make_utxo(
+            &"b".repeat(64),
+            5_000_000,
+            vec![(nft_b.clone(), 1)],
+        )];
+        for i in 0..40u32 {
+            a_utxos.push(make_utxo(&format!("a{i:063x}"), 2_000_000, vec![]));
+            b_utxos.push(make_utxo(&format!("b{i:063x}"), 2_000_000, vec![]));
+        }
+
+        let sides = [
+            SwapSide {
+                utxos: a_utxos,
+                address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+                offered_assets: HashMap::from([(nft_a.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+            SwapSide {
+                utxos: b_utxos,
+                address: Address::from_bech32(TEST_ADDR_B).unwrap(),
+                offered_assets: HashMap::from([(nft_b.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+        ];
+
+        let swap = build_atomic_swap(&sides, None, &test_params(), 0).unwrap();
+        // Each NFT UTxO (5 ADA) covers its side's small target alone → ~2 inputs.
+        // If all 82 UTxOs were swept in, the size-driven fee would balloon.
+        assert!(
+            swap.unsigned.fee < 300_000,
+            "fee too high — inputs not minimised: {}",
+            swap.unsigned.fee
         );
     }
 }


### PR DESCRIPTION
Reworks `build_atomic_swap` in `cardano-tx/src/builder/swap.rs` across four areas —
coin selection, cost allocation, fee splitting, and fee sizing. Together these take
the trade-desk swap from "builds bloated, over-charges the seller, and gets rejected
on-chain" to producing minimal, correctly-priced transactions the node accepts.

Single file changed; the only consumer is the `trade-desk` worker (cnft.dev-workers).

## What changed

### 1. Coin selection (was: consume every wallet UTxO)
`build_atomic_swap` used `a.utxos.iter().chain(b.utxos.iter())` — i.e. **every** UTxO in
each party's wallet became an input. A typical collector wallet has dozens–hundreds of
UTxOs, so every trade swept the whole wallet: inflated size-driven fees, whole-wallet
asset consolidation into split change, and `max_tx_size` risk.

Now each side selects a minimal covering set via the crate's existing `select::Selection`
engine: must-spend the UTxOs holding the offered assets (`utxos_covering_offered`), then
top up ADA with `Strategy::SmallestSufficient` (`select_side_inputs`). The pool top-up
only draws pure-ADA UTxOs, so no unrelated assets get dragged in. Real-world result: a
2500-ADA-side sale dropped from ~4.38 ADA fee to ~0.18 ADA (~24×).

`SwapSide.utxos` is now documented as "the party's available pool" (the builder selects a
subset) rather than "pre-selected".

### 2. Cost allocation: min-UTxO funded by the recipient
Previously the **sender** funded the min-UTxO wrapper for the assets they send — so an NFT
seller subsidised the ~1.29 ADA min-UTxO that lands in the *buyer's* wallet, netting
~2498.61 on a 2500 sale.

The mandatory wrapper now falls on the **recipient** of the assets (it lands in their own
wallet and is recoverable when they later move it). A sender's ADA *sweetener* still comes
from the sender; the recipient funds only the shortfall up to min-UTxO. An NFT seller now
receives essentially their full sale price.

### 3. Network fee split 50/50
The network fee is split evenly between both parties (`split_network_fee`, Party A absorbs
the rounding remainder), independent of who offers ADA.

### 4. Correct fee sizing for 2 witnesses (on-chain rejection fix)
A swap carries a vkey witness from **both** parties, but the builder sized the fee with
`converge_fee` (1 witness) plus a hand-rolled `EXTRA_WITNESS_BYTES` fudge for the 2nd
signer. Since a real vkey witness is ~102 bytes and the converger leaves no slack, the
fully-signed tx's true minimum landed ~88–200 lovelace above the set fee → the node
rejected it with `transaction fee is below the minimum fee required`.

Now uses `converge_fee_with_witnesses(closure, .., SWAP_WITNESSES = 2)`, which signs the
tx with 2 distinct dummy keys and measures the real serialized size — the exact node
minimum, no fudge. `EXTRA_WITNESS_BYTES` removed.

## API / behavior notes

- `SwapCostBreakdown` gains `a_network_fee` / `b_network_fee` (per-side network shares).
- `SwapCostBreakdown.{a,b}_min_utxo_cost` now mean the wrapper each side funds for the
  assets it **receives** (0 when it receives only ADA), not the min-UTxO for what it sends.
- Net-ADA and fee-report figures shift accordingly; the `trade-desk` consumer reads these
  fields directly (its `enhance_fee_report` and client-side estimate are updated in the
  cnft.dev-workers PR).

## Testing

`cargo test -p cardano-tx` — 25 tests pass, clippy + fmt clean. New/updated coverage:
- `test_coin_selection_bounds_inputs` / `test_coin_selection_tops_up_ada` /
  `test_utxos_covering_offered_fungible_accumulates` / `test_swap_ignores_unrelated_utxos`
  — selection picks a minimal, bounded input set.
- `test_nft_sale_cost_allocation` — buyer funds the NFT wrapper, fee splits 50/50, seller
  nets price minus half the fee.
- `test_swap_fee_covers_two_witnesses` — regression guard: `fee >= calculate_fee_with_witnesses(staging, 2)`.
- `test_swap_with_ada_sweetener` assertions updated for the recipient-funded semantics.