### PR TITLE
feature [egui-widgets]: trade_flow widget

### DIFF
--- a/cardano-tx/src/builder/swap.rs
+++ b/cardano-tx/src/builder/swap.rs
@@ -62,6 +62,12 @@ pub struct SwapCostBreakdown {
     pub a_net_ada: i64,
     /// Net ADA gain/loss for Party B.
     pub b_net_ada: i64,
+    /// Party A's own ADA that passes through the tx and returns to them as change.
+    /// Not a cost — but it appears as the *counterparty's* "send" on a hardware
+    /// wallet, so surfacing it lets the UI explain that inflated figure.
+    pub a_passthrough: u64,
+    /// Party B's own ADA that passes through the tx and returns to them as change.
+    pub b_passthrough: u64,
 }
 
 /// A swap requires a vkey witness from BOTH parties (CIP-30 partial signing).
@@ -195,27 +201,32 @@ pub fn build_atomic_swap(
                 .collect();
             let mut tx = add_utxo_inputs(StagingTransaction::new(), &all_inputs)?;
 
+            // Keep each party's *payment* output separate from their *change*
+            // output. A buyer's payment then shows as a discrete, recognisable
+            // output line on a hardware wallet (Ledger); a merged payment+change
+            // output displays as one inflated "send" the buyer can't verify.
+
             // Output 1: Party A receives B's offered assets + B's ADA sweetener
             tx = add_receive_output(tx, a_addr.clone(), &b_offered, b_ada, b_min_utxo)?;
 
             // Output 2: Party B receives A's offered assets + A's ADA sweetener
             tx = add_receive_output(tx, b_addr.clone(), &a_offered, a_ada, a_min_utxo)?;
 
-            // Outputs 3+: Party A's change (split if needed)
+            // Party A's change (split if needed)
             if a_change > 0 || !a_kept.is_empty() {
                 let (new_tx, _) =
                     add_split_change_outputs(tx, a_addr.clone(), a_change, &a_kept, &params_clone)?;
                 tx = new_tx;
             }
 
-            // Outputs N+: Party B's change (split if needed)
+            // Party B's change (split if needed)
             if b_change > 0 || !b_kept.is_empty() {
                 let (new_tx, _) =
                     add_split_change_outputs(tx, b_addr.clone(), b_change, &b_kept, &params_clone)?;
                 tx = new_tx;
             }
 
-            // Final output: Optional orchestration fee to community wallet
+            // Optional orchestration fee to community wallet
             if let Some((ref fee_addr, fee_amount)) = fee_output_clone {
                 if fee_amount > 0 {
                     tx = tx.output(create_ada_output(fee_addr.clone(), fee_amount));
@@ -249,6 +260,12 @@ pub fn build_atomic_swap(
         - b_network_share as i64
         - b_platform_share as i64;
 
+    // Each side's own ADA that returns to them as change (= inputs - their outflow).
+    let a_passthrough =
+        a_total_lovelace.saturating_sub(a_ada + a_wrapper + a_network_share + a_platform_share);
+    let b_passthrough =
+        b_total_lovelace.saturating_sub(b_ada + b_wrapper + b_network_share + b_platform_share);
+
     Ok(SwapBuildResult {
         unsigned,
         costs: SwapCostBreakdown {
@@ -260,6 +277,8 @@ pub fn build_atomic_swap(
             b_min_utxo_cost: b_wrapper,
             a_net_ada,
             b_net_ada,
+            a_passthrough,
+            b_passthrough,
         },
     })
 }
@@ -737,6 +756,45 @@ mod tests {
             swap.unsigned.fee >= min_fee,
             "fee {} is below the 2-witness minimum {min_fee}",
             swap.unsigned.fee
+        );
+    }
+
+    #[test]
+    fn test_swap_keeps_payment_separate_from_change() {
+        // A sells an NFT for 2500 ADA. Each party's payment output is kept SEPARATE
+        // from their change output (4 outputs total, not a merged 2) so the buyer's
+        // payment shows as a discrete, verifiable line on a hardware wallet — do not
+        // consolidate these, it produces one inflated "send" a Ledger can't verify.
+        let nft = make_asset_id("ForSale");
+        let sides = [
+            SwapSide {
+                utxos: vec![make_utxo(
+                    &"a".repeat(64),
+                    3_000_000,
+                    vec![(nft.clone(), 1)],
+                )],
+                address: Address::from_bech32(TEST_ADDR_A).unwrap(),
+                offered_assets: HashMap::from([(nft.clone(), 1)]),
+                ada_lovelace: 0,
+            },
+            SwapSide {
+                utxos: vec![make_utxo(&"b".repeat(64), 2_600_000_000, vec![])],
+                address: Address::from_bech32(TEST_ADDR_B).unwrap(),
+                offered_assets: HashMap::new(),
+                ada_lovelace: 2_500_000_000,
+            },
+        ];
+        let swap = build_atomic_swap(&sides, None, &test_params(), 0).unwrap();
+        let output_count = swap
+            .unsigned
+            .staging
+            .outputs
+            .as_ref()
+            .map(|o| o.len())
+            .unwrap_or(0);
+        assert_eq!(
+            output_count, 4,
+            "payment and change must stay as separate outputs per party"
         );
     }
 

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -49,6 +49,7 @@ mod app {
         SigningStatus,
         FeeReport,
         TxEstimate,
+        TradeFlow,
         WalletAssetPicker,
         UtxoMap,
         ManagedWalletUtxos,
@@ -167,6 +168,7 @@ mod app {
                 Self::SigningStatus,
                 Self::FeeReport,
                 Self::TxEstimate,
+                Self::TradeFlow,
                 Self::WalletAssetPicker,
                 Self::UtxoMap,
                 Self::ManagedWalletUtxos,
@@ -245,6 +247,7 @@ mod app {
                 Self::SigningStatus => "Signing Status",
                 Self::FeeReport => "Fee Report",
                 Self::TxEstimate => "TX Estimate",
+                Self::TradeFlow => "Trade Flow",
                 Self::WalletAssetPicker => "Wallet Asset Picker",
                 Self::UtxoMap => "UTxO Shelf",
                 Self::ManagedWalletUtxos => "Managed Wallet UTxOs",
@@ -348,6 +351,7 @@ mod app {
                 | Self::SigningStatus
                 | Self::FeeReport
                 | Self::TxEstimate
+                | Self::TradeFlow
                 | Self::WalletAssetPicker => "Trade Desk",
                 Self::UtxoMap
                 | Self::ManagedWalletUtxos
@@ -453,6 +457,9 @@ mod app {
                 }
                 Self::TxEstimate => {
                     "Per-wallet transaction estimate with platform fee, network fee, min UTxO, and net ADA"
+                }
+                Self::TradeFlow => {
+                    "Give / get / net view of a swap; flags UTxO rebalancing so a hardware wallet's inflated 'send' reads as an explained mechanic"
                 }
                 Self::WalletAssetPicker => {
                     "Modal asset browser with accordion policy groups and card grid selection"
@@ -657,6 +664,7 @@ mod app {
         asset_strip_state: stories::asset_strip::AssetStripStoryState,
         fee_report_state: stories::fee_report::FeeReportStoryState,
         tx_estimate_state: stories::tx_estimate::TxEstimateStoryState,
+        trade_flow_state: stories::trade_flow::TradeFlowStoryState,
         signing_status_state: stories::signing_status::SigningStatusStoryState,
         trade_table_state: stories::trade_table::TradeTableStoryState,
         wallet_asset_picker_state: stories::wallet_asset_picker::WalletAssetPickerStoryState,
@@ -776,6 +784,7 @@ mod app {
                 asset_strip_state: stories::asset_strip::AssetStripStoryState::default(),
                 fee_report_state: stories::fee_report::FeeReportStoryState::default(),
                 tx_estimate_state: stories::tx_estimate::TxEstimateStoryState::default(),
+                trade_flow_state: stories::trade_flow::TradeFlowStoryState::default(),
                 signing_status_state: stories::signing_status::SigningStatusStoryState::default(),
                 trade_table_state: stories::trade_table::TradeTableStoryState::default(),
                 wallet_asset_picker_state:
@@ -968,6 +977,9 @@ mod app {
                             }
                             Story::TxEstimate => {
                                 stories::tx_estimate::show(ui, &mut self.tx_estimate_state)
+                            }
+                            Story::TradeFlow => {
+                                stories::trade_flow::show(ui, &mut self.trade_flow_state)
                             }
                             Story::WalletAssetPicker => stories::wallet_asset_picker::show(
                                 &ctx,

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -68,6 +68,7 @@ pub mod coverage_delta_bar;
 pub mod fee_report;
 pub mod managed_wallet_utxos;
 pub mod signing_status;
+pub mod trade_flow;
 pub mod trade_table;
 pub mod trait_delta;
 pub mod tx_estimate;

--- a/ui/_storybook-egui/src/stories/trade_flow.rs
+++ b/ui/_storybook-egui/src/stories/trade_flow.rs
@@ -1,0 +1,214 @@
+//! Storybook demo for the TradeFlow widget.
+
+use egui_widgets::trade_flow::{self, TradeFlowConfig, TradeFlowData};
+use egui_widgets::FlowAsset;
+
+use crate::{ACCENT, BG_MAIN, TEXT_MUTED};
+
+pub struct TradeFlowStoryState {
+    pub give_nfts: u32,
+    pub give_ada: u64,
+    pub get_nfts: u32,
+    pub get_ada: u64,
+    pub peer_passthrough_ada: u64,
+    pub peer_label: String,
+}
+
+impl Default for TradeFlowStoryState {
+    fn default() -> Self {
+        // Default = the buyer's view of a 1600-ADA NFT purchase from a seller whose
+        // NFTs sit in fat UTxOs (the case that confuses a hardware wallet).
+        Self {
+            give_nfts: 0,
+            give_ada: 1600,
+            get_nfts: 2,
+            get_ada: 0,
+            peer_passthrough_ada: 2780,
+            peer_label: "$djo".into(),
+        }
+    }
+}
+
+pub fn show(ui: &mut egui::Ui, state: &mut TradeFlowStoryState) {
+    ui.label(
+        egui::RichText::new("TradeFlow Widget")
+            .color(ACCENT)
+            .strong(),
+    );
+    ui.label(
+        egui::RichText::new(
+            "The local user's view of a swap in give / get / net terms. Flags the UTxO \
+             rebalancing (a counterparty's own ADA, spent with the assets they send and \
+             returned as change) so the inflated \"send\" a hardware wallet shows reads as an \
+             explained mechanic, not a surprise.",
+        )
+        .color(TEXT_MUTED)
+        .size(11.0),
+    );
+    ui.add_space(12.0);
+
+    // Preset scenarios
+    ui.horizontal_wrapped(|ui| {
+        ui.label(
+            egui::RichText::new("Presets:")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        if ui
+            .selectable_label(false, "Buyer: pay 1600 for 2 NFTs")
+            .clicked()
+        {
+            state.give_nfts = 0;
+            state.give_ada = 1600;
+            state.get_nfts = 2;
+            state.get_ada = 0;
+            state.peer_passthrough_ada = 2780;
+            state.peer_label = "$djo".into();
+        }
+        if ui
+            .selectable_label(false, "Seller: sell 2 NFTs for 1600")
+            .clicked()
+        {
+            state.give_nfts = 2;
+            state.give_ada = 0;
+            state.get_nfts = 0;
+            state.get_ada = 1600;
+            state.peer_passthrough_ada = 3;
+            state.peer_label = "$boef".into();
+        }
+        if ui.selectable_label(false, "NFT-for-NFT swap").clicked() {
+            state.give_nfts = 1;
+            state.give_ada = 0;
+            state.get_nfts = 1;
+            state.get_ada = 0;
+            state.peer_passthrough_ada = 3;
+            state.peer_label = "$partner".into();
+        }
+        if ui
+            .selectable_label(false, "Buy NFT + 5 ADA sweetener")
+            .clicked()
+        {
+            state.give_nfts = 0;
+            state.give_ada = 5;
+            state.get_nfts = 1;
+            state.get_ada = 0;
+            state.peer_passthrough_ada = 20;
+            state.peer_label = "$seller".into();
+        }
+    });
+
+    ui.add_space(8.0);
+
+    // Controls
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new("NFTs you give:")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        ui.add(egui::DragValue::new(&mut state.give_nfts).range(0..=8));
+        ui.add_space(12.0);
+        ui.label(
+            egui::RichText::new("ADA you give:")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        ui.add(egui::DragValue::new(&mut state.give_ada).range(0..=100_000));
+    });
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new("NFTs you get:")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        ui.add(egui::DragValue::new(&mut state.get_nfts).range(0..=8));
+        ui.add_space(12.0);
+        ui.label(
+            egui::RichText::new("ADA you get:")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        ui.add(egui::DragValue::new(&mut state.get_ada).range(0..=100_000));
+    });
+    ui.horizontal(|ui| {
+        ui.label(
+            egui::RichText::new("Partner's UTxO rebalancing (ADA):")
+                .color(egui_widgets::theme::TEXT_SECONDARY)
+                .size(10.0),
+        );
+        ui.add(egui::DragValue::new(&mut state.peer_passthrough_ada).range(0..=100_000));
+    });
+
+    ui.add_space(12.0);
+
+    // Build the view-model from the controls.
+    let you_give: Vec<FlowAsset> = (0..state.give_nfts)
+        .map(|i| FlowAsset::new(format!("SpaceBud #{}", 7800 + i)))
+        .collect();
+    let you_get: Vec<FlowAsset> = (0..state.get_nfts)
+        .map(|i| FlowAsset::new(format!("SpaceBud #{}", 2900 + i)))
+        .collect();
+
+    // Min-UTxO you lock for the assets you receive (~1.29 ADA for the first,
+    // a little more per extra asset under one output).
+    let min_utxo_locked = if state.get_nfts > 0 {
+        1_290_000 + (state.get_nfts.saturating_sub(1) as u64) * 100_000
+    } else {
+        0
+    };
+    let network_fee: u64 = 90_000; // your half of a ~0.18 ADA fee
+
+    let net_ada = (state.get_ada * 1_000_000) as i64
+        - (state.give_ada * 1_000_000) as i64
+        - min_utxo_locked as i64
+        - network_fee as i64;
+
+    let data = TradeFlowData {
+        you_give,
+        you_give_ada: state.give_ada * 1_000_000,
+        you_get,
+        you_get_ada: state.get_ada * 1_000_000,
+        net_ada,
+        network_fee,
+        min_utxo_locked,
+        peer_passthrough_ada: state.peer_passthrough_ada * 1_000_000,
+        peer_label: state.peer_label.clone(),
+    };
+
+    let config = TradeFlowConfig::default();
+
+    // Widget
+    ui.allocate_ui(egui::vec2(360.0, ui.available_height()), |ui| {
+        egui::Frame::new()
+            .fill(BG_MAIN)
+            .corner_radius(6.0)
+            .inner_margin(14.0)
+            .stroke(egui::Stroke::new(
+                1.0_f32,
+                egui_widgets::theme::BG_HIGHLIGHT,
+            ))
+            .show(ui, |ui| {
+                trade_flow::show(ui, &data, &config);
+            });
+    });
+
+    ui.add_space(12.0);
+
+    ui.collapsing("Debug values", |ui| {
+        ui.label(
+            egui::RichText::new(format!(
+                "net_ada: {net_ada} lovelace\nmin_utxo_locked: {min_utxo_locked} lovelace\n\
+                 network_fee: {network_fee} lovelace\npeer_passthrough: {} lovelace",
+                state.peer_passthrough_ada * 1_000_000
+            ))
+            .color(TEXT_MUTED)
+            .size(10.0)
+            .family(egui::FontFamily::Monospace),
+        );
+    });
+
+    ui.add_space(8.0);
+    if ui.button("Reset").clicked() {
+        *state = TradeFlowStoryState::default();
+    }
+}

--- a/ui/egui-widgets/WIDGETS.md
+++ b/ui/egui-widgets/WIDGETS.md
@@ -199,6 +199,9 @@ generalise them into other contexts.
   per-item counts + providers + batch execute.
 - **`tx_estimate`** → `TxEstimateData` — Per-wallet ADA cost breakdown
   during trade negotiation.
+- **`trade_flow`** → `TradeFlowData` + `FlowAsset` — Plain give / get / net
+  view of a swap; names pass-through amounts so a hardware wallet's inflated
+  "send" reads as explained, not surprising.
 - **`trait_delta`** → `TraitItem` — Gains (+green) / losses (-red)
   trait chips for trade swaps.
 - **`printing_timeline`** → `PrintingTimelineConfig` — Horizontal

--- a/ui/egui-widgets/src/image_text_editor.rs
+++ b/ui/egui-widgets/src/image_text_editor.rs
@@ -393,7 +393,11 @@ impl ImageTextEditor {
                 ];
                 for (ci, corner) in corners.iter().enumerate() {
                     painter.circle_filled(*corner, handle_radius, Color32::from_rgb(100, 180, 255));
-                    painter.circle_stroke(*corner, handle_radius, Stroke::new(1.0_f32, Color32::WHITE));
+                    painter.circle_stroke(
+                        *corner,
+                        handle_radius,
+                        Stroke::new(1.0_f32, Color32::WHITE),
+                    );
 
                     let handle_rect =
                         Rect::from_center_size(*corner, egui::vec2(hit_size, hit_size));

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -56,6 +56,7 @@ pub mod theme;
 pub mod timestamp;
 pub mod toast;
 pub mod token_multiselect;
+pub mod trade_flow;
 pub mod trait_filter;
 pub mod typeahead_search;
 pub mod user_badge;
@@ -186,6 +187,7 @@ pub use theme::{rarity_rank_color, FontStrategy};
 pub use timestamp::{format_iso8601, Timestamp};
 pub use toast::{show_toasts, Toast, ToastKind, ToastQueue, DEFAULT_DURATION_FRAMES};
 pub use token_multiselect::{TokenMultiselect, TokenMultiselectResponse};
+pub use trade_flow::{FlowAsset, TradeFlowConfig, TradeFlowData};
 pub use trait_filter::{FilterEntry, TraitFilterConfig, TraitFilterResponse, TraitFilterState};
 pub use typeahead_search::{filter_options, TypeaheadOption, TypeaheadResponse, TypeaheadSearch};
 pub use utils::{

--- a/ui/egui-widgets/src/tag_list.rs
+++ b/ui/egui-widgets/src/tag_list.rs
@@ -70,7 +70,12 @@ impl<'a> TagList<'a> {
                 let cr = CornerRadius::same(3);
                 painter.rect_filled(rect, cr, bg);
                 if let Some(b) = border {
-                    painter.rect_stroke(rect, cr, Stroke::new(1.0_f32, b), egui::StrokeKind::Inside);
+                    painter.rect_stroke(
+                        rect,
+                        cr,
+                        Stroke::new(1.0_f32, b),
+                        egui::StrokeKind::Inside,
+                    );
                 }
                 painter.galley(
                     egui::pos2(rect.left() + PAD.x, rect.center().y - galley.size().y / 2.0),

--- a/ui/egui-widgets/src/token_multiselect.rs
+++ b/ui/egui-widgets/src/token_multiselect.rs
@@ -88,7 +88,12 @@ impl<'a> TokenMultiselect<'a> {
                 let cr = CornerRadius::same(3);
                 painter.rect_filled(rect, cr, bg);
                 if let Some(b) = border {
-                    painter.rect_stroke(rect, cr, Stroke::new(1.0_f32, b), egui::StrokeKind::Inside);
+                    painter.rect_stroke(
+                        rect,
+                        cr,
+                        Stroke::new(1.0_f32, b),
+                        egui::StrokeKind::Inside,
+                    );
                 }
                 painter.galley(
                     egui::pos2(rect.left() + PAD.x, rect.center().y - galley.size().y / 2.0),

--- a/ui/egui-widgets/src/trade_flow.rs
+++ b/ui/egui-widgets/src/trade_flow.rs
@@ -105,7 +105,7 @@ pub fn show(ui: &mut egui::Ui, data: &TradeFlowData, config: &TradeFlowConfig) {
     });
     ui.add_space(8.0);
 
-    // You give →
+    // You give
     flow_row(
         ui,
         "You give",
@@ -113,7 +113,7 @@ pub fn show(ui: &mut egui::Ui, data: &TradeFlowData, config: &TradeFlowConfig) {
         ChipVariant::Danger,
         &data.you_give,
         data.you_give_ada,
-        &format!("Leaves your wallet → {}", data.peer_label),
+        &format!("Leaves your wallet -> {}", data.peer_label),
         config,
     );
 
@@ -125,7 +125,7 @@ pub fn show(ui: &mut egui::Ui, data: &TradeFlowData, config: &TradeFlowConfig) {
     });
     ui.add_space(2.0);
 
-    // You get ←
+    // You get
     flow_row(
         ui,
         "You get",

--- a/ui/egui-widgets/src/trade_flow.rs
+++ b/ui/egui-widgets/src/trade_flow.rs
@@ -1,0 +1,318 @@
+//! Trade-flow widget — the local user's view of a P2P swap in plain
+//! give / get / net terms, decoupled from the raw eUTxO structure.
+//!
+//! The point of this widget is legibility: a raw wallet view makes "changing
+//! hands" and "passing through" look identical, which is what confuses users
+//! (and makes a hardware wallet report an inflated "send"). This widget shows
+//! what actually leaves and arrives, states the net, and — in a collapsible
+//! detail — names the pass-through amounts explicitly so the scary numbers a
+//! Ledger shows become explained ones.
+//!
+//! Companion to [`crate::tx_estimate`] (pre-lock cost estimate) and
+//! [`crate::fee_report`] (two-party fee breakdown). Driven by a plain view-model
+//! ([`TradeFlowData`]) so callers assemble it from their own wire types rather
+//! than decoding transaction CBOR.
+
+use egui::RichText;
+
+use crate::chip::{Chip, ChipVariant};
+use crate::icons::PhosphorIcon;
+use crate::theme;
+use crate::utils::format_lovelace;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// One asset moving in the trade, ready for display.
+pub struct FlowAsset {
+    /// Human-readable label (e.g. "SpaceBud #7812").
+    pub name: String,
+    /// Quantity — rendered as `×N` when greater than 1.
+    pub quantity: u64,
+}
+
+impl FlowAsset {
+    /// Convenience constructor for a single-quantity asset.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            quantity: 1,
+        }
+    }
+}
+
+/// The local user's view of a trade. Assemble from your own session/fee types;
+/// all lovelace amounts are raw lovelace.
+pub struct TradeFlowData {
+    /// Assets leaving the local wallet for the peer.
+    pub you_give: Vec<FlowAsset>,
+    /// ADA leaving the local wallet (payment / sweetener), lovelace.
+    pub you_give_ada: u64,
+    /// Assets arriving from the peer.
+    pub you_get: Vec<FlowAsset>,
+    /// ADA arriving from the peer, lovelace.
+    pub you_get_ada: u64,
+    /// Net ADA impact on the local wallet (positive = gains, negative = loses).
+    pub net_ada: i64,
+    /// The local user's share of the network fee, lovelace.
+    pub network_fee: u64,
+    /// Min-UTxO the local user funds for the assets they receive — locked in
+    /// their own wallet with the asset (recoverable), not a true loss. Lovelace.
+    pub min_utxo_locked: u64,
+    /// The peer's own ADA that passes through the transaction and returns to
+    /// them as change. Appears as a "send" on a hardware wallet but is not the
+    /// local user's cost. Lovelace.
+    pub peer_passthrough_ada: u64,
+    /// Display label for the peer (e.g. "$djo").
+    pub peer_label: String,
+}
+
+/// Display configuration.
+pub struct TradeFlowConfig {
+    /// Font size for line-item text.
+    pub font_size: f32,
+    /// Font size for the heading.
+    pub heading_size: f32,
+}
+
+impl Default for TradeFlowConfig {
+    fn default() -> Self {
+        Self {
+            font_size: 12.0,
+            heading_size: 12.0,
+        }
+    }
+}
+
+// ============================================================================
+// Widget
+// ============================================================================
+
+/// Render the trade-flow card. The caller supplies the surrounding frame.
+pub fn show(ui: &mut egui::Ui, data: &TradeFlowData, config: &TradeFlowConfig) {
+    crate::install_phosphor_font(ui.ctx());
+
+    // Heading
+    ui.horizontal(|ui| {
+        ui.label(PhosphorIcon::Handshake.rich_text(config.heading_size + 1.0, theme::ACCENT));
+        ui.label(
+            RichText::new("TRADE FLOW")
+                .color(theme::TEXT_SECONDARY)
+                .size(config.heading_size)
+                .strong(),
+        );
+    });
+    ui.add_space(8.0);
+
+    // You give →
+    flow_row(
+        ui,
+        "You give",
+        theme::ACCENT_RED,
+        ChipVariant::Danger,
+        &data.you_give,
+        data.you_give_ada,
+        &format!("Leaves your wallet → {}", data.peer_label),
+        config,
+    );
+
+    // A small downward hand-off cue between the two sides.
+    ui.add_space(2.0);
+    ui.horizontal(|ui| {
+        ui.add_space(4.0);
+        ui.label(PhosphorIcon::ArrowDown.rich_text(config.font_size, theme::TEXT_MUTED));
+    });
+    ui.add_space(2.0);
+
+    // You get ←
+    flow_row(
+        ui,
+        "You get",
+        theme::ACCENT_GREEN,
+        ChipVariant::Success,
+        &data.you_get,
+        data.you_get_ada,
+        &format!("Arrives from {}", data.peer_label),
+        config,
+    );
+
+    ui.add_space(8.0);
+    separator(ui);
+    ui.add_space(6.0);
+
+    // Net line
+    ui.horizontal(|ui| {
+        ui.label(
+            RichText::new("Net")
+                .color(theme::TEXT_MUTED)
+                .size(config.font_size)
+                .strong(),
+        );
+        ui.add_space(8.0);
+        let (sign, color) = if data.net_ada >= 0 {
+            ("+", theme::ACCENT_GREEN)
+        } else {
+            ("", theme::ACCENT_RED)
+        };
+        ui.label(
+            RichText::new(format!("{sign}{}", format_lovelace(data.net_ada)))
+                .color(color)
+                .size(config.font_size + 1.0)
+                .strong(),
+        );
+    });
+
+    // Collapsible "what else is in this transaction" — names the pass-through so
+    // the numbers a hardware wallet shows are explained, not surprising.
+    ui.add_space(6.0);
+    egui::CollapsingHeader::new(
+        RichText::new("What else is in this transaction")
+            .color(theme::TEXT_MUTED)
+            .size(config.font_size - 1.0),
+    )
+    .id_salt("trade_flow_detail")
+    .default_open(false)
+    .show(ui, |ui| {
+        detail_line(
+            ui,
+            "Network fee (your share)",
+            &format_lovelace(data.network_fee as i64),
+            None,
+            config,
+        );
+        if data.min_utxo_locked > 0 {
+            detail_line(
+                ui,
+                "Min-UTxO you lock with received assets",
+                &format_lovelace(data.min_utxo_locked as i64),
+                Some("Stays in your wallet with the asset — recoverable when you next move it."),
+                config,
+            );
+        }
+        if data.peer_passthrough_ada > 0 {
+            let hover = format!(
+                "Cardano can't move an asset without spending the whole UTxO it sits in. The ADA \
+                 locked alongside the assets {} sends is spent and returned to them as change — \
+                 rebalancing within the transaction, not a transfer to or from you.",
+                data.peer_label
+            );
+            detail_line(
+                ui,
+                &format!("UTxO rebalancing ({})", data.peer_label),
+                &format_lovelace(data.peer_passthrough_ada as i64),
+                Some(&hover),
+                config,
+            );
+        }
+
+        ui.add_space(6.0);
+        ui.horizontal_wrapped(|ui| {
+            ui.spacing_mut().item_spacing.x = 4.0;
+            ui.label(PhosphorIcon::Warning.rich_text(config.font_size - 1.0, theme::WARNING));
+            ui.label(
+                RichText::new(
+                    "A hardware wallet shows raw UTxO movement, so it reports this rebalancing as \
+                     part of a larger \"send\". Your actual net is shown above.",
+                )
+                .color(theme::TEXT_MUTED)
+                .size(config.font_size - 2.0)
+                .italics(),
+            );
+        });
+    });
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+/// A "You give / You get" row: a label, then wrapped chips for each asset plus
+/// an ADA chip when non-zero. Renders "— nothing —" when the side is empty.
+#[allow(clippy::too_many_arguments)]
+fn flow_row(
+    ui: &mut egui::Ui,
+    label: &str,
+    label_color: egui::Color32,
+    chip_variant: ChipVariant,
+    assets: &[FlowAsset],
+    ada_lovelace: u64,
+    hover: &str,
+    config: &TradeFlowConfig,
+) {
+    ui.horizontal_wrapped(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
+        ui.label(
+            RichText::new(label)
+                .color(label_color)
+                .size(config.font_size)
+                .strong(),
+        );
+
+        if assets.is_empty() && ada_lovelace == 0 {
+            ui.label(
+                RichText::new("— nothing —")
+                    .color(theme::TEXT_MUTED)
+                    .size(config.font_size)
+                    .italics(),
+            );
+            return;
+        }
+
+        for asset in assets {
+            let text = if asset.quantity > 1 {
+                format!("{} ×{}", asset.name, asset.quantity)
+            } else {
+                asset.name.clone()
+            };
+            Chip::new(&text)
+                .variant(chip_variant)
+                .on_hover_text(hover)
+                .show(ui);
+        }
+
+        if ada_lovelace > 0 {
+            Chip::new(&format_lovelace(ada_lovelace as i64))
+                .variant(chip_variant)
+                .on_hover_text(hover)
+                .show(ui);
+        }
+    });
+}
+
+/// A muted `label … value` detail line with an optional hover explainer.
+fn detail_line(
+    ui: &mut egui::Ui,
+    label: &str,
+    value: &str,
+    hover: Option<&str>,
+    config: &TradeFlowConfig,
+) {
+    ui.horizontal(|ui| {
+        let resp = ui.label(
+            RichText::new(label)
+                .color(theme::TEXT_MUTED)
+                .size(config.font_size - 1.0),
+        );
+        if let Some(h) = hover {
+            resp.on_hover_text(h);
+        }
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            ui.label(
+                RichText::new(value)
+                    .color(theme::TEXT_SECONDARY)
+                    .size(config.font_size - 1.0),
+            );
+        });
+    });
+}
+
+fn separator(ui: &mut egui::Ui) {
+    let rect = ui.available_rect_before_wrap();
+    let y = rect.min.y;
+    ui.painter().line_segment(
+        [egui::pos2(rect.min.x, y), egui::pos2(rect.max.x, y)],
+        egui::Stroke::new(1.0_f32, theme::BORDER),
+    );
+    ui.add_space(1.0);
+}


### PR DESCRIPTION
Adds a reusable `trade_flow` egui widget that renders a P2P swap in plain
give / get / net terms, and the `cardano-tx` cost-breakdown fields that drive it.
The goal is legibility: a raw wallet/UTxO view makes "changing hands" and
"passing through" look identical, which is what makes a hardware wallet (Ledger)
report an inflated "send". This widget states the net and names the UTxO
rebalancing explicitly so that inflated figure reads as an explained mechanic.

Consumed by the `trade-desk` worker in cnft.dev-workers (companion PR), which
maps its own `TradeFlow` wire type onto this widget's view-model.

## Changes

### `cardano-tx/src/builder/swap.rs`
- `SwapCostBreakdown` gains `a_passthrough` / `b_passthrough` — each party's own
  ADA that is spent with the assets they send and returned to them as change
  (= inputs − their outflow). Not a cost, but it appears as the *counterparty's*
  "send" on a hardware wallet, so surfacing it lets a UI explain the number.
- Documents and guards the payment/change output separation: each party's
  payment output is kept **separate** from their change output (not merged), so a
  buyer's payment shows as a discrete, verifiable line on a Ledger rather than one
  inflated "send". New test `test_swap_keeps_payment_separate_from_change` asserts
  4 outputs (a do-not-consolidate guard).

### `ui/egui-widgets` — new `trade_flow` widget
- `src/trade_flow.rs`: `TradeFlowData` + `FlowAsset` view-model, `TradeFlowConfig`,
  and `show(ui, &data, &config)`. Renders a **You give** (red chips) → **You get**
  (green chips) → **Net** card, with a collapsible "What else is in this
  transaction" that names the network-fee share, the min-UTxO you lock with
  received assets, and the **UTxO rebalancing** back to the counterparty, plus a
  hardware-wallet caveat. Built from the shared atoms (`Chip`, `PhosphorIcon`,
  `theme`, `format_lovelace`); no non-ASCII glyphs. Ungated (no cardano deps).
- `src/lib.rs`: `pub mod trade_flow;` + re-export of `FlowAsset`, `TradeFlowConfig`,
  `TradeFlowData`.
- `WIDGETS.md`: catalog entry.

### `ui/_storybook-egui` — story
- `src/stories/trade_flow.rs`: interactive story with DragValue controls and four
  presets (buyer / seller / NFT-for-NFT / sweetener), including the fat-UTxO
  buyer case that produces a large pass-through.
- `src/stories/mod.rs` + `src/lib.rs`: the six standard registration edits
  (enum, `all()`, `label()`, `category()` → Trade Desk, `description()`, and the
  app field/init/match-arm).

### Incidental
- `image_text_editor.rs`, `tag_list.rs`, `token_multiselect.rs`: `cargo fmt`
  reflow only (line-wrapping of existing `Stroke::new` calls) — no behaviour change.

## Testing

`cargo test -p cardano-tx` — swap suite passes (incl. the new guard test).
`cargo check -p egui-widgets` and `cargo check --target wasm32-unknown-unknown -p storybook-egui`
build clean; clippy + fmt clean. The story renders under
`cd ui/_storybook-egui && trunk serve` (Trade Desk → Trade Flow).

## Consumer / deploy

The `trade-desk` worker (cnft.dev-workers) reads the new `SwapCostBreakdown`
fields to build its `TradeFlow` wire message. After merge, bump the pinned
`cardano-tx` / `egui-widgets` revs there and re-comment the local `[patch]` block.