### PR TITLE
chore: ensure discord web jwt times out correctly

### DIFF
--- a/discord-auth/src/web.rs
+++ b/discord-auth/src/web.rs
@@ -33,6 +33,9 @@ pub struct Session {
     /// Discord identity (from the JWT `name`/`avatar`/`sub` claims), for
     /// the "logged in as" UI. `None` for anonymous / debug sessions.
     pub identity: Option<Identity>,
+    /// JWT `exp` claim, unix seconds. `None` for debug/anonymous sessions.
+    /// Apps can use this to prompt re-login before a request bounces.
+    pub expires_at: Option<u64>,
 }
 
 /// The Discord identity carried in a session, for display.
@@ -100,6 +103,17 @@ impl Session {
 
     fn from_jwt(jwt: &str) -> Self {
         let payload = decode_payload(jwt).unwrap_or_default();
+
+        // An expired token would authenticate the UI (unlocking gated
+        // controls) only for every request to bounce off the server's
+        // strict `exp` validation. Treat it as logged-out instead: drop
+        // the stored token and return to anonymous so the app shows the
+        // login gate rather than a wall of 401s.
+        if payload.exp.is_some_and(|exp| now_secs() >= exp) {
+            remove(SESSION_KEY);
+            return Self::default();
+        }
+
         let identity = (!payload.sub.is_empty()).then_some(Identity {
             user_id: payload.sub,
             name: payload.name,
@@ -111,6 +125,7 @@ impl Session {
             auth_header: Some(("Authorization".into(), format!("Bearer {jwt}"))),
             fresh_login: false,
             identity,
+            expires_at: payload.exp,
         }
     }
 
@@ -123,6 +138,7 @@ impl Session {
             auth_header: Some(("X-Debug-Token".into(), token.to_string())),
             fresh_login: false,
             identity: None,
+            expires_at: None,
         }
     }
 
@@ -146,7 +162,8 @@ pub fn begin_login(client_id: &str, redirect_uri: &str, scopes: &[&str]) {
 }
 
 /// The display-relevant JWT claims (decoded WITHOUT verifying — the server
-/// verifies; the frontend only needs these to render).
+/// verifies; the frontend only needs these to render, and `exp` to avoid
+/// presenting a token the server will reject anyway).
 #[derive(Default, serde::Deserialize)]
 struct Payload {
     #[serde(default)]
@@ -157,6 +174,15 @@ struct Payload {
     avatar: Option<String>,
     #[serde(default)]
     ent: String,
+    /// Standard JWT expiry, unix seconds.
+    #[serde(default)]
+    exp: Option<u64>,
+}
+
+/// Current wall-clock time in unix seconds (browser clock — good enough
+/// for a pre-flight expiry check; the server remains authoritative).
+fn now_secs() -> u64 {
+    (js_sys::Date::now() / 1000.0) as u64
 }
 
 /// Decode a JWT payload without verifying its signature.


### PR DESCRIPTION
The frontend `Session` restored an expired JWT from `localStorage` and set `authenticated: true` unconditionally — it never decoded the `exp` claim. The result: a day after login (24h TTL), the UI still rendered as logged-in and kept attaching the dead token, so every gated request bounced off the server's strict `exp` validation as a 401. Users had to manually log out and back in to recover.

This adds a pre-flight expiry check so a stale token is treated as logged-out.

**Changes** (`discord-auth/src/web.rs`)

- `Payload` now decodes the standard `exp` claim (unverified — the server remains authoritative; the frontend only uses it to avoid presenting a token it knows will be rejected).
- `Session::from_jwt` treats a past-`exp` token as anonymous: it clears the stored session key and returns `Session::default()`, so the app shows the login gate instead of a wall of 401s.
- New public field `Session.expires_at: Option<u64>` (the `exp`, or `None` for debug/anonymous sessions), so consuming apps can prompt re-login proactively before a request fails.
- Added a small `now_secs()` helper (browser `Date::now()`).

**Consumer note**

`Session` gains a public field. It derives `Default` and is constructed internally via `Self::default()` / struct-update, so `..Default::default()` and update-syntax callers are unaffected; only an exhaustive struct literal without `..` would need the extra field (none found in the known consumers).

**Testing**

`web` is a wasm/browser module — validated by exercising the flow in the collection-ownership frontend: after 24h a restored session now lands on the login gate rather than an unlocked-but-401ing UI. Belt-and-braces on the consumer side (a 401 latch that clears the session and re-gates) covers what a client-side clock check can't see — revocation and signing-secret rotation.