### PR TITLE
feature: add `augie-plugin` protocol crate + Koios `datum_info` wire fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,6 +342,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "augie-plugin"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "authorizations"
 version = "0.1.0"
 dependencies = [

--- a/indexers/koios/src/lib.rs
+++ b/indexers/koios/src/lib.rs
@@ -166,6 +166,11 @@ pub struct DatumInfoRequest {
 /// Plutus-JSON rendering.
 #[derive(Debug, Clone, Deserialize)]
 pub struct KoiosDatumInfo {
+    /// Koios wires this as `datum_hash` (matching the `_datum_hashes`
+    /// request key), *not* `hash` — deserialising it as `hash` fails the
+    /// whole batch with `missing field \`hash\``. The alias keeps the bare
+    /// `hash` spelling accepted in case a mirror/proxy emits it.
+    #[serde(rename = "datum_hash", alias = "hash")]
     pub hash: String,
     /// Raw datum CBOR (hex), if the node holds the preimage.
     #[serde(default)]
@@ -1104,6 +1109,41 @@ mod tests {
     async fn rate_limit_delay() {
         // Koios free tier has rate limits, wait 1 second between requests
         sleep(Duration::from_millis(1000)).await;
+    }
+
+    /// `/datum_info` rows key the hash as `datum_hash`. Captured from a
+    /// live response — the previous `hash` spelling failed the whole
+    /// batch with `missing field \`hash\``, which surfaced downstream as
+    /// an unbuildable cancel-offer cart.
+    #[test]
+    fn test_datum_info_deserialises_koios_wire_shape() {
+        let body = r#"[
+          {"datum_hash":"14420b67fb7c9ef762b9658d88108a6f76b4af2a72f66dbf828d2bb0adb2b015",
+           "creation_tx_hash":"73c1524c4a0e0c921d7ac4b4388cb5a1e6b1757b515e4189df788e28953fce98",
+           "bytes":"d8799f581ccba51a2e5bff",
+           "value":{"constructor":0}}
+        ]"#;
+        let rows: Vec<KoiosDatumInfo> = serde_json::from_str(body).expect("datum_info wire shape");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0].hash,
+            "14420b67fb7c9ef762b9658d88108a6f76b4af2a72f66dbf828d2bb0adb2b015"
+        );
+        assert_eq!(rows[0].bytes.as_deref(), Some("d8799f581ccba51a2e5bff"));
+    }
+
+    /// The bare `hash` spelling stays accepted via alias, so a mirror or
+    /// proxy emitting the older shape doesn't break resolution.
+    #[test]
+    fn test_datum_info_accepts_bare_hash_alias() {
+        let body =
+            r#"[{"hash":"ec3131073f6c9c0ad76835c886fc467a796f50343b1630e5d50dc92e87c772d2"}]"#;
+        let rows: Vec<KoiosDatumInfo> = serde_json::from_str(body).expect("bare hash alias");
+        assert_eq!(
+            rows[0].hash,
+            "ec3131073f6c9c0ad76835c886fc467a796f50343b1630e5d50dc92e87c772d2"
+        );
+        assert!(rows[0].bytes.is_none());
     }
 
     #[test]

--- a/services/augie-plugin/Cargo.toml
+++ b/services/augie-plugin/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "augie-plugin"
+version.workspace = true
+authors.workspace = true
+edition = "2021"
+description = "Wire protocol for services that advertise Discord commands to the Augie bot host"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/services/augie-plugin/src/address.rs
+++ b/services/augie-plugin/src/address.rs
@@ -1,0 +1,31 @@
+//! How the host reaches a plugin.
+//!
+//! Strictly speaking this is host-side configuration rather than wire protocol
+//! — a plugin never sees it. It lives here because several crates on the host
+//! side need the same vocabulary (config parsing, command dispatch, and
+//! component routing all live in different crates that don't depend on each
+//! other), and duplicating it three times would be worse than a slightly loose
+//! crate boundary.
+
+use serde::{Deserialize, Serialize};
+
+/// A plugin's address.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceAddress {
+    /// Cloudflare service binding — preferred. No public surface, no egress.
+    Binding(String),
+    /// Plain HTTPS base URL, for services that aren't service-bound.
+    Url(String),
+}
+
+impl ServiceAddress {
+    /// Short label for logs — never includes the URL, which may carry a host
+    /// that shouldn't end up in log aggregation.
+    pub fn label(&self) -> &str {
+        match self {
+            ServiceAddress::Binding(binding) => binding,
+            ServiceAddress::Url(_) => "url",
+        }
+    }
+}

--- a/services/augie-plugin/src/invocation.rs
+++ b/services/augie-plugin/src/invocation.rs
@@ -1,0 +1,207 @@
+//! What Augie sends a plugin: [`CommandInvocation`] and [`ComponentInvocation`].
+//!
+//! Both are *normalised* — a plugin never sees a raw Discord interaction, and
+//! therefore needs no Discord library to participate.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::PermissionClass;
+
+/// A slash-command invocation, already resolved and authorised by Augie.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommandInvocation {
+    /// Top-level command name, e.g. `"comp"`.
+    pub command: String,
+
+    /// Subcommand, if the command declared any, e.g. `"create"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subcommand: Option<String>,
+
+    /// Supplied options, keyed by parameter name. Absent optional parameters
+    /// are simply missing rather than present-and-null.
+    #[serde(default)]
+    pub options: HashMap<String, OptionValue>,
+
+    pub user: InvokingUser,
+
+    /// Guild the command was run in. Always present — Augie rejects plugin
+    /// commands in DMs before dispatch, since permission classes are
+    /// guild-scoped and meaningless outside one.
+    pub guild_id: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<String>,
+
+    /// The caller's resolved class. Augie has already gated on this; it is
+    /// passed so a plugin can apply its own defence in depth without needing
+    /// to interpret role IDs.
+    pub permission_class: PermissionClass,
+
+    /// Discord interaction token, for a plugin that wants to send its own
+    /// follow-ups on a long operation. Valid for 15 minutes.
+    pub interaction_token: String,
+
+    /// Discord application ID, needed to address the follow-up webhook.
+    pub application_id: String,
+}
+
+/// A button click or select-menu submission.
+///
+/// `custom_id` is **the plugin's own id**, exactly as it set it on the
+/// component it returned. Augie stores its routing separately and restores the
+/// original before dispatch, so a plugin never sees Augie's wire ids and never
+/// has to encode routing into its own.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComponentInvocation {
+    pub custom_id: String,
+
+    /// Selected values for a select menu; empty for a button.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub values: Vec<String>,
+
+    pub user: InvokingUser,
+    pub guild_id: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub channel_id: Option<String>,
+
+    pub permission_class: PermissionClass,
+    pub interaction_token: String,
+    pub application_id: String,
+}
+
+/// The Discord user who triggered an invocation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvokingUser {
+    /// Snowflake as a string — see the crate docs.
+    pub id: String,
+
+    /// Discord username (no discriminator).
+    pub username: String,
+
+    /// Guild nickname if set, else global name, else username. This is what a
+    /// plugin should render; `username` is for logs and audit records.
+    pub display_name: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub avatar_hash: Option<String>,
+}
+
+/// A resolved command option.
+///
+/// Externally tagged so the wire form is self-describing and a plugin can't
+/// silently coerce an integer option into a string.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptionValue {
+    String(String),
+    Integer(i64),
+    Number(f64),
+    Boolean(bool),
+    /// A user snowflake, as a string.
+    User(String),
+}
+
+impl OptionValue {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            OptionValue::String(s) | OptionValue::User(s) => Some(s),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            OptionValue::Integer(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            OptionValue::Number(n) => Some(*n),
+            OptionValue::Integer(i) => Some(*i as f64),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            OptionValue::Boolean(b) => Some(*b),
+            _ => None,
+        }
+    }
+}
+
+impl CommandInvocation {
+    /// Fetch an option by name.
+    pub fn option(&self, name: &str) -> Option<&OptionValue> {
+        self.options.get(name)
+    }
+
+    /// `"comp create"` — convenient for a single `match` over the whole
+    /// command surface rather than nested matching on command + subcommand.
+    pub fn route(&self) -> String {
+        match &self.subcommand {
+            Some(sub) => format!("{} {sub}", self.command),
+            None => self.command.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn invocation(sub: Option<&str>) -> CommandInvocation {
+        CommandInvocation {
+            command: "comp".to_string(),
+            subcommand: sub.map(str::to_string),
+            options: HashMap::from([
+                ("min_ada".to_string(), OptionValue::Integer(51)),
+                ("name".to_string(), OptionValue::String("Area 51".to_string())),
+            ]),
+            user: InvokingUser {
+                id: "179744071361757184".to_string(),
+                username: "spanners".to_string(),
+                display_name: "Spanners".to_string(),
+                avatar_hash: None,
+            },
+            guild_id: "1283465958945456149".to_string(),
+            channel_id: None,
+            permission_class: PermissionClass::Admin,
+            interaction_token: "tok".to_string(),
+            application_id: "1372830411196993578".to_string(),
+        }
+    }
+
+    #[test]
+    fn route_joins_subcommand() {
+        assert_eq!(invocation(Some("create")).route(), "comp create");
+        assert_eq!(invocation(None).route(), "comp");
+    }
+
+    #[test]
+    fn option_accessors_are_type_checked() {
+        let inv = invocation(Some("create"));
+        assert_eq!(inv.option("min_ada").and_then(OptionValue::as_i64), Some(51));
+        // An integer option must not masquerade as a string.
+        assert_eq!(inv.option("min_ada").and_then(OptionValue::as_str), None);
+        assert_eq!(
+            inv.option("name").and_then(OptionValue::as_str),
+            Some("Area 51")
+        );
+        assert!(inv.option("nope").is_none());
+    }
+
+    #[test]
+    fn snowflakes_survive_beyond_max_safe_integer() {
+        // 1283465958945456149 > 2^53; the whole reason these are strings.
+        let inv = invocation(None);
+        let round_tripped: CommandInvocation =
+            serde_json::from_str(&serde_json::to_string(&inv).unwrap()).unwrap();
+        assert_eq!(round_tripped.guild_id, "1283465958945456149");
+    }
+}

--- a/services/augie-plugin/src/lib.rs
+++ b/services/augie-plugin/src/lib.rs
@@ -1,0 +1,52 @@
+//! Wire protocol for services that advertise Discord commands to Augie.
+//!
+//! A **plugin** is any service that wants a Discord front-end without Augie
+//! growing code that knows about it. The plugin advertises what it exposes;
+//! Augie discovers, registers with Discord, and routes interactions back.
+//!
+//! ## The contract
+//!
+//! | Endpoint | Direction | Purpose |
+//! |----------|-----------|---------|
+//! | `GET /_augie/manifest` | Augie → plugin | Advertise commands ([`ServiceManifest`]) |
+//! | `POST /_augie/command` | Augie → plugin | Invoke a command ([`CommandInvocation`] → [`CommandResponse`]) |
+//! | `POST /_augie/component` | Augie → plugin | Button / select callback ([`ComponentInvocation`] → [`CommandResponse`]) |
+//!
+//! Only the first two are required. A plugin that never returns components
+//! never receives component callbacks.
+//!
+//! ## Why this crate carries no Discord types
+//!
+//! It would be natural to put `twilight_model::http::interaction::InteractionResponseData`
+//! on the wire and be done. That is not possible: **augminted-bots is on
+//! twilight 0.17 and cnft.dev-workers is on twilight 0.16**. A shared crate
+//! exposing twilight types could not be consumed by both without forcing one
+//! repo through a twilight migration, and mixing majors produces the
+//! duplicate-crate type mismatches this workspace has been bitten by before.
+//!
+//! So the protocol defines its own minimal, `serde`-only vocabulary
+//! ([`PluginEmbed`], [`PluginComponent`], …) and each host converts at its own
+//! edge. The crate depends on `serde` and nothing else, which also keeps it
+//! trivially WASM-safe.
+//!
+//! ## Snowflakes are strings
+//!
+//! Every Discord ID on this protocol is a `String`, never `u64`. Snowflakes
+//! exceed `Number.MAX_SAFE_INTEGER`, and both sides of this wire run in WASM
+//! where a `u64` silently loses precision through JS. Parse at the edge if you
+//! need an integer.
+
+mod invocation;
+mod manifest;
+mod response;
+
+pub use invocation::*;
+pub use manifest::*;
+pub use response::*;
+
+/// Path Augie fetches to discover a plugin's command surface.
+pub const MANIFEST_PATH: &str = "/_augie/manifest";
+/// Path Augie posts a [`CommandInvocation`] to.
+pub const COMMAND_PATH: &str = "/_augie/command";
+/// Path Augie posts a [`ComponentInvocation`] to.
+pub const COMPONENT_PATH: &str = "/_augie/component";

--- a/services/augie-plugin/src/lib.rs
+++ b/services/augie-plugin/src/lib.rs
@@ -36,10 +36,12 @@
 //! where a `u64` silently loses precision through JS. Parse at the edge if you
 //! need an integer.
 
+mod address;
 mod invocation;
 mod manifest;
 mod response;
 
+pub use address::*;
 pub use invocation::*;
 pub use manifest::*;
 pub use response::*;

--- a/services/augie-plugin/src/manifest.rs
+++ b/services/augie-plugin/src/manifest.rs
@@ -1,0 +1,208 @@
+//! What a plugin advertises: [`ServiceManifest`], fetched by Augie at
+//! config-refresh time and merged into the guild's registered command set.
+
+use serde::{Deserialize, Serialize};
+
+/// A plugin's complete command surface.
+///
+/// Fetched from `GET /_augie/manifest` during the `RefreshBotConfigs` chain —
+/// **not** at interaction time. Discord command registration is a deliberate,
+/// rate-limited, guild-scoped operation; it belongs to an explicit refresh, not
+/// to a request path.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ServiceManifest {
+    /// Stable identifier for this plugin, e.g. `"holder-map"`. Must match the
+    /// key a guild opts in under, and must not change once registered.
+    pub service: String,
+
+    /// Bumped whenever `commands` changes. Augie records the version it last
+    /// registered and warns when a live manifest differs, so "I changed the
+    /// command but nothing happened" surfaces as a log line rather than a
+    /// mystery. It is not a semver constraint — any change is just a change.
+    pub version: String,
+
+    /// Top-level commands. Names must be unique across *all* sources for a
+    /// guild (TOML config and every other plugin); a collision fails the
+    /// refresh rather than picking a winner.
+    #[serde(default)]
+    pub commands: Vec<PluginCommand>,
+}
+
+/// One command, or one subcommand of a command.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginCommand {
+    /// Discord command name. Lowercase, no spaces.
+    pub name: String,
+
+    /// Shown in the Discord command picker.
+    pub description: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<PluginParameter>,
+
+    /// Nested subcommands (`/comp create`). A command with subcommands should
+    /// not also declare parameters — Discord does not allow both.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub subcommands: Vec<PluginCommand>,
+
+    /// Who may run this. See [`PermissionClass`] for why this isn't role IDs.
+    #[serde(default)]
+    pub permission: PermissionClass,
+
+    /// Whether Augie should defer before dispatching. Set this for anything
+    /// that can't reliably answer inside Discord's 3-second window — which
+    /// includes essentially every cross-repo plugin call.
+    #[serde(default)]
+    pub needs_defer: bool,
+
+    /// Per-user cooldown. Deliberately a flat number rather than mirroring
+    /// `bot_config::CooldownPolicy`: the richer rate-limit shapes are Augie's
+    /// own vocabulary, and a plugin wanting one can be given it in guild
+    /// config instead of advertising it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cooldown_seconds: Option<u64>,
+}
+
+/// A command parameter. Mirrors the subset of Discord's option types that
+/// `bot_config::CommandParameter` already supports.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginParameter {
+    pub name: String,
+    pub description: String,
+    pub kind: ParameterKind,
+
+    #[serde(default)]
+    pub required: bool,
+
+    /// Fixed choices. Empty means free input.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub choices: Vec<ParameterChoice>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParameterKind {
+    String,
+    Integer,
+    Number,
+    Boolean,
+    /// Resolves to a Discord user ID (as a string — see the crate docs).
+    User,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ParameterChoice {
+    pub name: String,
+    pub value: String,
+}
+
+/// Who may run a command, expressed as intent rather than identity.
+///
+/// A plugin **cannot** advertise role IDs. Roles are per-guild, and a service
+/// that may be installed in several guilds has no way to know — or any business
+/// knowing — that "admin" means `1320158903262122115` in one of them. So the
+/// manifest declares a class and the guild's config maps classes to role IDs,
+/// which Augie resolves into `CommandPermissions::Restricted([...])` at
+/// registration.
+///
+/// Augie resolves the caller's class *before* dispatch and passes it on the
+/// invocation. A plugin should still check the class it was handed for anything
+/// destructive — defence in depth, not a re-derivation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionClass {
+    #[default]
+    Everyone,
+    Moderator,
+    Admin,
+}
+
+impl PermissionClass {
+    /// Whether this class satisfies `required`.
+    ///
+    /// Ordering is `Everyone < Moderator < Admin`, so an Admin passes a
+    /// Moderator gate.
+    pub fn satisfies(self, required: PermissionClass) -> bool {
+        self.rank() >= required.rank()
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            PermissionClass::Everyone => 0,
+            PermissionClass::Moderator => 1,
+            PermissionClass::Admin => 2,
+        }
+    }
+}
+
+impl ServiceManifest {
+    /// Every command name advertised, including subcommand paths
+    /// (`"comp"`, `"comp create"`, …). Used by Augie to detect collisions
+    /// across sources during a refresh.
+    pub fn command_paths(&self) -> Vec<String> {
+        fn walk(prefix: &str, cmd: &PluginCommand, out: &mut Vec<String>) {
+            let path = if prefix.is_empty() {
+                cmd.name.clone()
+            } else {
+                format!("{prefix} {}", cmd.name)
+            };
+            out.push(path.clone());
+            for sub in &cmd.subcommands {
+                walk(&path, sub, out);
+            }
+        }
+
+        let mut out = Vec::new();
+        for cmd in &self.commands {
+            walk("", cmd, &mut out);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cmd(name: &str, subs: Vec<PluginCommand>) -> PluginCommand {
+        PluginCommand {
+            name: name.to_string(),
+            description: format!("{name} description"),
+            parameters: vec![],
+            subcommands: subs,
+            permission: PermissionClass::Everyone,
+            needs_defer: true,
+            cooldown_seconds: None,
+        }
+    }
+
+    #[test]
+    fn command_paths_includes_subcommands() {
+        let manifest = ServiceManifest {
+            service: "holder-map".to_string(),
+            version: "1".to_string(),
+            commands: vec![cmd("comp", vec![cmd("create", vec![]), cmd("draw", vec![])])],
+        };
+
+        assert_eq!(
+            manifest.command_paths(),
+            vec!["comp", "comp create", "comp draw"]
+        );
+    }
+
+    #[test]
+    fn admin_satisfies_moderator_gate() {
+        assert!(PermissionClass::Admin.satisfies(PermissionClass::Moderator));
+        assert!(PermissionClass::Admin.satisfies(PermissionClass::Everyone));
+        assert!(!PermissionClass::Everyone.satisfies(PermissionClass::Admin));
+        assert!(!PermissionClass::Moderator.satisfies(PermissionClass::Admin));
+    }
+
+    #[test]
+    fn permission_class_defaults_to_everyone() {
+        let json = r#"{"name":"status","description":"d"}"#;
+        let parsed: PluginCommand = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.permission, PermissionClass::Everyone);
+        assert!(!parsed.needs_defer);
+    }
+}

--- a/services/augie-plugin/src/response.rs
+++ b/services/augie-plugin/src/response.rs
@@ -27,6 +27,15 @@ pub struct CommandResponse {
     /// message is milder than an accidentally-hidden one.
     #[serde(default)]
     pub ephemeral: bool,
+
+    /// Replace the message the component was attached to, rather than posting
+    /// a new one. Only meaningful on a [`crate::ComponentInvocation`] reply —
+    /// ignored on a command reply, where there is no prior message.
+    ///
+    /// Pagination wants this: without it every page click leaves another copy
+    /// of the embed in the channel.
+    #[serde(default)]
+    pub update_message: bool,
 }
 
 impl CommandResponse {
@@ -60,6 +69,13 @@ impl CommandResponse {
 
     pub fn ephemeral(mut self) -> Self {
         self.ephemeral = true;
+        self
+    }
+
+    /// Replace the message the clicked component belongs to. See
+    /// [`CommandResponse::update_message`].
+    pub fn updating(mut self) -> Self {
+        self.update_message = true;
         self
     }
 

--- a/services/augie-plugin/src/response.rs
+++ b/services/augie-plugin/src/response.rs
@@ -1,0 +1,243 @@
+//! What a plugin returns: [`CommandResponse`] and its rendering vocabulary.
+//!
+//! Deliberately a small subset of Discord's message model. It carries what a
+//! service front-end actually needs — text, embeds, buttons, selects — and
+//! nothing else. Each host converts to its own twilight version at the edge;
+//! see the crate docs for why twilight types can't live on this wire.
+
+use serde::{Deserialize, Serialize};
+
+/// A plugin's reply to an invocation.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CommandResponse {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub embeds: Vec<PluginEmbed>,
+
+    /// Action rows. Discord permits at most 5, each holding at most 5
+    /// components; Augie validates before sending rather than letting Discord
+    /// reject the whole message.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rows: Vec<PluginActionRow>,
+
+    /// Visible only to the invoking user. Default `false`, so a plugin has to
+    /// opt in to ephemeral — the failure mode of an accidentally-public
+    /// message is milder than an accidentally-hidden one.
+    #[serde(default)]
+    pub ephemeral: bool,
+}
+
+impl CommandResponse {
+    /// Plain text reply, visible to the channel.
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: Some(content.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Plain text reply, visible only to the caller. The right default for
+    /// errors and for anything reporting the caller's own state.
+    pub fn ephemeral_text(content: impl Into<String>) -> Self {
+        Self {
+            content: Some(content.into()),
+            ephemeral: true,
+            ..Default::default()
+        }
+    }
+
+    pub fn with_embed(mut self, embed: PluginEmbed) -> Self {
+        self.embeds.push(embed);
+        self
+    }
+
+    pub fn with_row(mut self, row: PluginActionRow) -> Self {
+        self.rows.push(row);
+        self
+    }
+
+    pub fn ephemeral(mut self) -> Self {
+        self.ephemeral = true;
+        self
+    }
+
+    /// Every `custom_id` in this response, in row order.
+    ///
+    /// Augie uses this to register component routing before sending, so it can
+    /// map a later click back to the originating plugin.
+    pub fn custom_ids(&self) -> Vec<&str> {
+        self.rows
+            .iter()
+            .flat_map(|row| row.components.iter())
+            .filter_map(PluginComponent::custom_id)
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PluginEmbed {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// RGB, e.g. `0x4caf50`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<u32>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub fields: Vec<PluginEmbedField>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub footer: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thumbnail_url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_url: Option<String>,
+
+    /// ISO 8601. A string rather than a timestamp type to keep this crate
+    /// dependency-free and to sidestep the u64-in-WASM problem entirely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PluginEmbedField {
+    pub name: String,
+    pub value: String,
+    #[serde(default)]
+    pub inline: bool,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct PluginActionRow {
+    pub components: Vec<PluginComponent>,
+}
+
+impl PluginActionRow {
+    pub fn new(components: Vec<PluginComponent>) -> Self {
+        Self { components }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PluginComponent {
+    Button {
+        /// The plugin's own id. Opaque to Augie, and handed back verbatim on
+        /// the resulting [`crate::ComponentInvocation`].
+        custom_id: String,
+        label: String,
+        #[serde(default)]
+        style: ButtonStyle,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        emoji: Option<String>,
+        #[serde(default)]
+        disabled: bool,
+    },
+    /// A button that opens a URL. Has no `custom_id` because it produces no
+    /// interaction — Discord handles it entirely client-side.
+    LinkButton {
+        url: String,
+        label: String,
+        #[serde(default)]
+        disabled: bool,
+    },
+    Select {
+        custom_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        placeholder: Option<String>,
+        options: Vec<SelectOption>,
+        #[serde(default)]
+        disabled: bool,
+    },
+}
+
+impl PluginComponent {
+    /// The component's `custom_id`, or `None` for a link button.
+    pub fn custom_id(&self) -> Option<&str> {
+        match self {
+            PluginComponent::Button { custom_id, .. }
+            | PluginComponent::Select { custom_id, .. } => Some(custom_id),
+            PluginComponent::LinkButton { .. } => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ButtonStyle {
+    #[default]
+    Primary,
+    Secondary,
+    Success,
+    Danger,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SelectOption {
+    pub label: String,
+    pub value: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub default: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_ids_skips_link_buttons() {
+        let response = CommandResponse::text("standings").with_row(PluginActionRow::new(vec![
+            PluginComponent::Button {
+                custom_id: "comp:refresh:01J".to_string(),
+                label: "Refresh".to_string(),
+                style: ButtonStyle::Secondary,
+                emoji: None,
+                disabled: false,
+            },
+            PluginComponent::LinkButton {
+                url: "https://aliens.epochify.space".to_string(),
+                label: "Globe".to_string(),
+                disabled: false,
+            },
+        ]));
+
+        assert_eq!(response.custom_ids(), vec!["comp:refresh:01J"]);
+    }
+
+    #[test]
+    fn empty_collections_are_omitted_from_the_wire() {
+        let json = serde_json::to_string(&CommandResponse::text("hi")).unwrap();
+        assert!(!json.contains("embeds"), "{json}");
+        assert!(!json.contains("rows"), "{json}");
+        // `ephemeral` is a plain bool with a false default, so it does ride
+        // along — that's deliberate, it makes the visibility explicit on
+        // every response rather than inferred from absence.
+        assert!(json.contains("ephemeral"), "{json}");
+    }
+
+    #[test]
+    fn component_tag_is_stable_on_the_wire() {
+        let button = PluginComponent::Button {
+            custom_id: "x".to_string(),
+            label: "Go".to_string(),
+            style: ButtonStyle::Danger,
+            emoji: None,
+            disabled: false,
+        };
+        let json = serde_json::to_string(&button).unwrap();
+        assert!(json.contains(r#""type":"button""#), "{json}");
+        assert!(json.contains(r#""style":"danger""#), "{json}");
+    }
+}


### PR DESCRIPTION
### `services/augie-plugin` (new crate)

Wire protocol for services that advertise Discord commands to the Augie bot host. A service publishes a manifest of commands; Augie discovers, registers them with Discord, and routes interactions back — so a service gains a Discord front-end without Augie growing code that knows about it.

Three endpoints, of which only the first two are required:

| Endpoint | Purpose |
|---|---|
| `GET /_augie/manifest` | Advertise commands (`ServiceManifest`) |
| `POST /_augie/command` | Invoke (`CommandInvocation` → `CommandResponse`) |
| `POST /_augie/component` | Button/select callback (`ComponentInvocation`) |

**`serde` is the only dependency, and that's load-bearing.** The obvious design would put `twilight_model` types on the wire — but augminted-bots resolves **twilight 0.17.1** while cnft.dev-workers is on **0.16**, and 0.17's components-v2 `Button`/`SelectMenu`/`ActionRow` each carry an `id` field 0.16 lacks. A crate exposing twilight types could not be consumed by both without forcing one repo through a migration. So the protocol defines its own minimal vocabulary (`PluginEmbed`, `PluginComponent`, …) and each host converts at its own edge.

Two other decisions worth noting for review:

- **Every Discord ID is a `String`, never `u64`.** Snowflakes exceed `Number.MAX_SAFE_INTEGER` and both sides run in WASM, where a `u64` silently loses precision through JS.
- **`PermissionClass` (`Everyone`/`Moderator`/`Admin`) instead of role IDs.** A plugin can't know that "admin" means a particular snowflake in a particular guild, so the manifest declares intent and the host maps classes to roles.

`ServiceAddress` (binding vs URL) lives here too. It's strictly host-side config rather than wire protocol — it's here because three consumer crates need the vocabulary and don't depend on each other, and one definition beat three copies. Noted in `address.rs` as a deliberately loose boundary.

9 unit tests.

### `indexers/koios` — `datum_info` wire shape

Koios returns the datum hash as `datum_hash`, not `hash`. Deserialising as `hash` failed the **entire batch** with `missing field 'hash'`, which surfaced downstream as an unbuildable cancel-offer cart. Adds `#[serde(rename = "datum_hash", alias = "hash")]` so the correct spelling works and the bare form stays accepted for mirrors/proxies. Two tests, one against a captured live response.

### Consumer impact

Already validated locally against both repos with path overrides:

- **cnft.dev-workers** pins current `main`, so this is additive only. `collection-ownership` and `holder-map` both consume the crate; all workers compile.
- **augminted-bots** is 9 commits behind and will jump to this rev. I dry-ran that bump with every consumed crate patched to local: clippy clean, 959 tests pass, and all workers *and widgets* compile on wasm32. `egui-widgets` moved 64 files in that span but stays on egui 0.34, so no duplicate-crate mismatch.