### PR TITLE
feature: rendering protocol and additional widgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
 name = "augie-plugin"
 version = "0.1.0"
 dependencies = [
+ "render-protocol",
  "serde",
  "serde_json",
 ]
@@ -6945,6 +6946,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wallet-link"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5077,6 +5077,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "render-protocol"
+version = "0.1.0"
+dependencies = [
+ "cardano-assets",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/authorizations/src/features.rs
+++ b/authorizations/src/features.rs
@@ -20,6 +20,20 @@ crate::features! {
         name: "Visual Search",
         locked_hint: "Hold a qualifying role in a partner Discord — sign in to unlock",
     };
+    /// Market scenario modelling — re-price a collection's listing book
+    /// against a hypothetical floor to surface what becomes under-priced if
+    /// the floor moves.
+    ///
+    /// **Deliberately granted to nobody yet.** The capability is built and
+    /// enforced, but which holding earns it is an open decision, so today only
+    /// wildcard (`*`) operator tokens see it. Naming the entitlement now means
+    /// turning it on later is a gate-config change, not a code change — and
+    /// nothing ships to general users in the meantime.
+    pub const MARKET_SCENARIOS = {
+        id: "tools.market-scenarios",
+        name: "Market Scenarios",
+        locked_hint: "Advanced market tooling — access tier not yet assigned",
+    };
     /// Operator control surface — add/edit/delete tracked collections,
     /// trigger syncs, and the visual-analysis tooling. Granted to specific
     /// Discord accounts via the gate config; the operator `X-Debug-Token`

--- a/cardano-assets/src/collection.rs
+++ b/cardano-assets/src/collection.rs
@@ -85,7 +85,11 @@ pub struct CollectionDetails {
     pub description: Option<String>,
     #[serde(alias = "royaltyAddress")]
     pub royalty_address: Option<String>,
-    #[serde(alias = "royaltyPct", default, deserialize_with = "de_f64_null_default")]
+    #[serde(
+        alias = "royaltyPct",
+        default,
+        deserialize_with = "de_f64_null_default"
+    )]
     pub royalty_percentage: f64,
     pub image: Option<String>,
     pub banner: Option<String>,

--- a/cnft-tools/src/test.rs
+++ b/cnft-tools/src/test.rs
@@ -2,11 +2,10 @@
 mod tests {
     #![allow(clippy::assertions_on_constants)]
 
-    use crate::{CnftApi, CnftAsset};
+    use crate::CnftAsset;
 
     use std::collections::HashMap;
     use test_utils::test_case;
-    use tracing::Level;
 
     #[test]
     fn test_deserialize() {
@@ -165,18 +164,4 @@ mod tests {
         assert!(!asset.traits.contains_key("Eyes")); // null trait value skipped
     }
 
-    #[tokio::test]
-    async fn test_encounter() {
-        worker_utils::init_tracing(Some(Level::DEBUG));
-
-        match CnftApi::default()
-            .get_for_policy("43206de9e07fbd36ce6c109b3d34637727233c58a0b38f1da00a9ccf")
-            .await
-        {
-            Ok(assets) => {
-                assert_eq!(assets.len(), 3333);
-            }
-            Err(err) => panic!("failed to call microversus api: {err:?}"),
-        }
-    }
 }

--- a/discord-auth/src/lib.rs
+++ b/discord-auth/src/lib.rs
@@ -64,6 +64,11 @@ pub mod scopes {
 ///   roles = ["444444444444444444"]        # OG
 ///   match = "all"                         # require every listed role
 ///   features = ["tools.visual-search", "tools.pricing"]
+///
+/// [[server]]
+/// guild_id = "555555555555555555"
+/// label = "Private"
+/// unlisted = true                         # grants, but never advertised
 /// ```
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct GuildRoleConfig {
@@ -103,6 +108,14 @@ pub struct ServerConfig {
     /// a logged-in-but-unqualified user knows where to go.
     #[serde(default)]
     pub invite_url: Option<String>,
+    /// Never advertise this server on the requirements screen, even though its
+    /// roles grant features. For private/invite-only communities: granting
+    /// access and telling the world to come join are separate decisions, and
+    /// omitting `invite_url` alone still lists the server by name. `unlisted`
+    /// removes it from [`GuildRoleConfig::access_providers`] entirely; role
+    /// resolution for members is unaffected.
+    #[serde(default)]
+    pub unlisted: bool,
     #[serde(default, rename = "grant")]
     pub grants: Vec<RoleGrant>,
 }
@@ -182,9 +195,13 @@ impl GuildRoleConfig {
     /// screen ("join one of these to gain access"). A server with no label
     /// falls back to its guild id. Exposes only label + invite (no role
     /// ids), so it's safe to serve publicly.
+    ///
+    /// `unlisted` servers are omitted: they still grant, they're just never
+    /// held out as somewhere to go.
     pub fn access_providers(&self, feature_id: &str) -> Vec<AccessProvider> {
         self.servers
             .iter()
+            .filter(|s| !s.unlisted)
             .filter(|s| {
                 s.grants
                     .iter()
@@ -317,6 +334,15 @@ guild_id = "g2"
   roles = ["member"]
   features = ["tools.visual-search"]
 
+[[server]]
+guild_id = "g3"
+label = "Private"
+unlisted = true
+  [[server.grant]]
+  roles = ["insider"]
+  requirement = "Hold the insider role"
+  features = ["tools.visual-search"]
+
 [[admin]]
 user_id = "admin-uid"
 features = ["admin.access"]
@@ -326,11 +352,32 @@ features = ["admin.access"]
         GuildRoleConfig::from_toml(CFG).unwrap()
     }
 
+    /// An unlisted server still grants — it is only hidden from the
+    /// requirements screen, so a private community can confer access without
+    /// being advertised as somewhere to go.
+    #[test]
+    fn unlisted_server_grants_but_is_never_advertised() {
+        let c = config();
+        let providers = c.access_providers("tools.visual-search");
+        let labels: Vec<&str> = providers.iter().map(|p| p.label.as_str()).collect();
+        assert!(labels.contains(&"Alpha"));
+        assert!(
+            !labels.contains(&"Private"),
+            "unlisted server must not appear on the requirements screen"
+        );
+
+        // Resolution is unaffected: an insider still gets the feature.
+        let mut roles = HashMap::new();
+        roles.insert("g3".to_string(), vec!["insider".to_string()]);
+        let granted = c.resolve("someone", &roles);
+        assert!(granted.iter().any(|f| f == "tools.visual-search"));
+    }
+
     #[test]
     fn parses_and_lists_guilds() {
         let c = config();
-        assert_eq!(c.servers.len(), 2);
-        assert_eq!(c.guild_ids(), vec!["g1", "g2"]);
+        assert_eq!(c.servers.len(), 3);
+        assert_eq!(c.guild_ids(), vec!["g1", "g2", "g3"]);
         // Default match mode is Any.
         assert_eq!(c.servers[0].grants[0].match_mode, MatchMode::Any);
         assert_eq!(c.servers[0].grants[2].match_mode, MatchMode::All);

--- a/pipeline/tx-classifier/src/indexers/koios.rs
+++ b/pipeline/tx-classifier/src/indexers/koios.rs
@@ -38,19 +38,25 @@ pub async fn get_tx_from_koios(
 }
 
 /// Convert a Koios `/tx_info` transaction into the pipeline's [`RawTxData`].
-pub fn convert_koios_tx_to_raw_data(
-    tx: &KoiosTransaction,
-) -> Result<RawTxData, TxClassifierError> {
+pub fn convert_koios_tx_to_raw_data(tx: &KoiosTransaction) -> Result<RawTxData, TxClassifierError> {
     let inputs = tx.inputs.iter().map(koios_utxo_to_input).collect();
     let outputs = tx.outputs.iter().map(koios_utxo_to_output).collect();
-    let collateral_inputs = tx.collateral_inputs.iter().map(koios_utxo_to_input).collect();
+    let collateral_inputs = tx
+        .collateral_inputs
+        .iter()
+        .map(koios_utxo_to_input)
+        .collect();
     // Koios returns a single optional collateral return output.
     let collateral_outputs = tx
         .collateral_output
         .iter()
         .map(koios_utxo_to_output)
         .collect();
-    let reference_inputs = tx.reference_inputs.iter().map(koios_utxo_to_input).collect();
+    let reference_inputs = tx
+        .reference_inputs
+        .iter()
+        .map(koios_utxo_to_input)
+        .collect();
 
     // Mint/burn from the typed `assets_minted` list (quantity is signed: a
     // negative value is a burn).
@@ -127,7 +133,12 @@ fn koios_utxo_to_output(utxo: &KoisUtxo) -> TxOutput {
 fn koios_assets_to_map(utxo: &KoisUtxo) -> HashMap<String, u64> {
     (&utxo.asset_list)
         .into_iter()
-        .map(|a| (format!("{}{}", a.policy_id, a.asset_name), a.quantity as u64))
+        .map(|a| {
+            (
+                format!("{}{}", a.policy_id, a.asset_name),
+                a.quantity as u64,
+            )
+        })
         .collect()
 }
 

--- a/pipeline/tx-classifier/src/indexers/mod.rs
+++ b/pipeline/tx-classifier/src/indexers/mod.rs
@@ -142,9 +142,7 @@ impl IndexerPool {
         );
 
         let result = match self.provider {
-            IndexerProvider::Maestro => {
-                maestro::get_tx_from_maestro(&self.maestro, tx_hash).await
-            }
+            IndexerProvider::Maestro => maestro::get_tx_from_maestro(&self.maestro, tx_hash).await,
             IndexerProvider::Koios => koios::get_tx_from_koios(&self.koios, tx_hash).await,
         };
 

--- a/services/augie-plugin/Cargo.toml
+++ b/services/augie-plugin/Cargo.toml
@@ -7,6 +7,9 @@ description = "Wire protocol for services that advertise Discord commands to the
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+# A plugin describes a graphic it wants; the HOST renders it. See
+# `CommandResponse::render` for why the plugin cannot do this itself.
+render-protocol = { path = "../render-protocol" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/services/augie-plugin/src/invocation.rs
+++ b/services/augie-plugin/src/invocation.rs
@@ -179,7 +179,10 @@ mod tests {
             subcommand: sub.map(str::to_string),
             options: HashMap::from([
                 ("min_ada".to_string(), OptionValue::Integer(51)),
-                ("name".to_string(), OptionValue::String("Area 51".to_string())),
+                (
+                    "name".to_string(),
+                    OptionValue::String("Area 51".to_string()),
+                ),
             ]),
             user: InvokingUser {
                 id: "179744071361757184".to_string(),
@@ -205,7 +208,10 @@ mod tests {
     #[test]
     fn option_accessors_are_type_checked() {
         let inv = invocation(Some("create"));
-        assert_eq!(inv.option("min_ada").and_then(OptionValue::as_i64), Some(51));
+        assert_eq!(
+            inv.option("min_ada").and_then(OptionValue::as_i64),
+            Some(51)
+        );
         // An integer option must not masquerade as a string.
         assert_eq!(inv.option("min_ada").and_then(OptionValue::as_str), None);
         assert_eq!(

--- a/services/augie-plugin/src/invocation.rs
+++ b/services/augie-plugin/src/invocation.rs
@@ -45,6 +45,24 @@ pub struct CommandInvocation {
 
     /// Discord application ID, needed to address the follow-up webhook.
     pub application_id: String,
+
+    /// A short-lived identity token for the invoking user, minted by Augie.
+    ///
+    /// Present only when the command declared
+    /// [`crate::PluginCommand::needs_identity`] — a plugin that doesn't need
+    /// one shouldn't be handed a bearer credential it might log.
+    ///
+    /// **The point is that Augie mints it, not the plugin.** Identity is
+    /// Augie's to assert: it holds the signing key and it is the only party
+    /// that saw the Discord interaction. A plugin minting its own would mean
+    /// every plugin needing the secret, which is the hole this avoids.
+    ///
+    /// The token's signed action is the command name, so a surface it's handed
+    /// to can route on a *tamper-proof* intent rather than an unsigned query
+    /// parameter. Typical use is embedding it in a link so the destination
+    /// opens already authenticated instead of bouncing through OAuth.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity_token: Option<String>,
 }
 
 /// A button click or select-menu submission.
@@ -174,6 +192,7 @@ mod tests {
             permission_class: PermissionClass::Admin,
             interaction_token: "tok".to_string(),
             application_id: "1372830411196993578".to_string(),
+            identity_token: None,
         }
     }
 

--- a/services/augie-plugin/src/invocation.rs
+++ b/services/augie-plugin/src/invocation.rs
@@ -46,6 +46,21 @@ pub struct CommandInvocation {
     /// Discord application ID, needed to address the follow-up webhook.
     pub application_id: String,
 
+    /// Per-guild configuration for this plugin, verbatim from the guild's
+    /// opt-in block.
+    ///
+    /// Augie neither reads nor validates these values — it is a pass-through,
+    /// which is what keeps the protocol Discord-only. A collection service can
+    /// receive `policy_id` and a token service `contract`, without either
+    /// concept appearing in this type.
+    ///
+    /// This exists so a plugin does not have to keep its own copy of what the
+    /// guild config already knows. A duplicated table in the plugin drifts the
+    /// moment a guild is added in one place and not the other; passing it at
+    /// invocation time means there is one place to edit.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
+
     /// A short-lived identity token for the invoking user, minted by Augie.
     ///
     /// Present only when the command declared
@@ -88,6 +103,12 @@ pub struct ComponentInvocation {
     pub permission_class: PermissionClass,
     pub interaction_token: String,
     pub application_id: String,
+
+    /// Same pass-through config as [`CommandInvocation::config`]. A component
+    /// callback has to resolve the same guild context the command did, or page
+    /// 2 of a reply answers about something else.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub config: HashMap<String, String>,
 }
 
 /// The Discord user who triggered an invocation.
@@ -195,6 +216,7 @@ mod tests {
             permission_class: PermissionClass::Admin,
             interaction_token: "tok".to_string(),
             application_id: "1372830411196993578".to_string(),
+            config: HashMap::new(),
             identity_token: None,
         }
     }

--- a/services/augie-plugin/src/manifest.rs
+++ b/services/augie-plugin/src/manifest.rs
@@ -55,6 +55,36 @@ pub struct PluginCommand {
     #[serde(default)]
     pub needs_defer: bool,
 
+    /// Whether replies are visible only to the invoking user.
+    ///
+    /// **This has to be advertised, not just set on the response.** When
+    /// `needs_defer` is true Augie must ACK before it has called the plugin,
+    /// and Discord fixes ephemerality at that ACK — a later `CommandResponse`
+    /// with `ephemeral: true` cannot demote an already-public message. So a
+    /// deferred command that only set the response flag would leak into the
+    /// channel, silently and only in production.
+    ///
+    /// Defaults to `false` to match [`crate::CommandResponse`]'s default and
+    /// to keep existing manifests behaving exactly as before: an
+    /// accidentally-public message is the milder failure in general. Commands
+    /// answering about the caller's own private data should set it.
+    #[serde(default)]
+    pub ephemeral: bool,
+
+    /// Ask Augie to mint an identity token for the invoking user and pass it on
+    /// [`crate::CommandInvocation::identity_token`].
+    ///
+    /// **Opt-in, and default off.** A bearer credential handed to a service
+    /// that has no use for it is pure downside — one more place it can be
+    /// logged, forwarded or leaked — so a command asks only when it genuinely
+    /// needs to hand the user onward already authenticated.
+    ///
+    /// The usual reason is a link button: without a token the destination has
+    /// to re-authenticate the user itself, and an OAuth bounce from a Discord
+    /// button someone just clicked is friction they'll read as brokenness.
+    #[serde(default)]
+    pub needs_identity: bool,
+
     /// Per-user cooldown. Deliberately a flat number rather than mirroring
     /// `bot_config::CooldownPolicy`: the richer rate-limit shapes are Augie's
     /// own vocabulary, and a plugin wanting one can be given it in guild
@@ -172,6 +202,8 @@ mod tests {
             subcommands: subs,
             permission: PermissionClass::Everyone,
             needs_defer: true,
+            ephemeral: false,
+            needs_identity: false,
             cooldown_seconds: None,
         }
     }

--- a/services/augie-plugin/src/manifest.rs
+++ b/services/augie-plugin/src/manifest.rs
@@ -213,7 +213,10 @@ mod tests {
         let manifest = ServiceManifest {
             service: "holder-map".to_string(),
             version: "1".to_string(),
-            commands: vec![cmd("comp", vec![cmd("create", vec![]), cmd("draw", vec![])])],
+            commands: vec![cmd(
+                "comp",
+                vec![cmd("create", vec![]), cmd("draw", vec![])],
+            )],
         };
 
         assert_eq!(

--- a/services/augie-plugin/src/response.rs
+++ b/services/augie-plugin/src/response.rs
@@ -5,6 +5,7 @@
 //! nothing else. Each host converts to its own twilight version at the edge;
 //! see the crate docs for why twilight types can't live on this wire.
 
+use render_protocol::RenderRequest;
 use serde::{Deserialize, Serialize};
 
 /// A plugin's reply to an invocation.
@@ -27,6 +28,27 @@ pub struct CommandResponse {
     /// message is milder than an accidentally-hidden one.
     #[serde(default)]
     pub ephemeral: bool,
+
+    /// A graphic to render and attach to this reply.
+    ///
+    /// **The host renders it, not the plugin.** This is not a stylistic choice:
+    /// [`PluginEmbed`] can only reference an image by URL, and a plugin has no
+    /// way to attach bytes — so a plugin wanting a graphic would otherwise have
+    /// to host it at a public, guessable URL. Describing the graphic as markup
+    /// and letting the host render and attach it keeps the image private to the
+    /// message (ephemeral replies included) and keeps the rasteriser, fonts and
+    /// image pipeline in one service instead of every plugin.
+    ///
+    /// The attachment is named `render.png`; reference it from an embed as
+    /// `attachment://render.png` if you want it inside an embed rather than
+    /// beneath the message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub render: Option<RenderRequest>,
+
+    /// Components V2 layout. See [`PluginBlock`] — mutually exclusive with
+    /// `content` and `embeds`, which the host drops when this is set.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub layout: Vec<PluginBlock>,
 
     /// Replace the message the component was attached to, rather than posting
     /// a new one. Only meaningful on a [`crate::ComponentInvocation`] reply —
@@ -255,5 +277,86 @@ mod tests {
         let json = serde_json::to_string(&button).unwrap();
         assert!(json.contains(r#""type":"button""#), "{json}");
         assert!(json.contains(r#""style":"danger""#), "{json}");
+    }
+}
+
+/// Components V2 layout.
+///
+/// # Mutually exclusive with `content` and `embeds`
+///
+/// Discord refuses a message that carries both, and the `IS_COMPONENTS_V2` flag
+/// **cannot be removed once set** on a message. A plugin therefore picks one
+/// vocabulary per reply: set `layout` for V2, or `content`/`embeds` for the
+/// classic shape. The host ignores `content`/`embeds` when `layout` is present
+/// rather than sending a message Discord will reject.
+///
+/// The trade is real: V2 gives grouped containers, accent colours and inline
+/// galleries, but loses embeds and cannot be mixed. It is worth it when the
+/// reply is a composed card; it is not worth it for a line of text.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PluginBlock {
+    /// A visually grouped card with an optional accent bar.
+    Container {
+        /// RGB accent bar. A tier colour or brand colour reads as deliberate
+        /// where the default grey reads as unstyled.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        accent_color: Option<u32>,
+        blocks: Vec<PluginBlock>,
+    },
+
+    /// Markdown text. The V2 replacement for `content` — headings (`##`), bold
+    /// and links all work.
+    Text { content: String },
+
+    /// Images shown inline. `attachment://name` addresses a file on the same
+    /// message, which is how a rendered graphic is placed inside a container.
+    Gallery { items: Vec<GalleryItem> },
+
+    /// Text with a small image beside it.
+    ///
+    /// The compact alternative to [`PluginBlock::Gallery`]: Discord sizes a
+    /// gallery by how many items it holds, so a one-item gallery renders
+    /// full-width no matter how small the source image is. A section's
+    /// thumbnail is small by construction, which is what you want when the
+    /// image is illustrating a line of text rather than being the point.
+    Section {
+        /// Lines of markdown shown beside the thumbnail.
+        text: Vec<String>,
+        thumbnail: GalleryItem,
+    },
+
+    /// A horizontal rule between sections.
+    Separator {
+        #[serde(default = "default_true")]
+        divider: bool,
+    },
+
+    /// Buttons and selects, exactly as in the classic vocabulary.
+    Row(PluginActionRow),
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GalleryItem {
+    /// `attachment://name.png` for a file on this message, or an https URL.
+    pub url: String,
+
+    /// Alt text. Worth setting — a gallery with no description is unreadable
+    /// to anyone using a screen reader.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl GalleryItem {
+    /// An image attached to this same message.
+    pub fn attachment(name: &str, description: impl Into<String>) -> Self {
+        Self {
+            url: format!("attachment://{name}"),
+            description: Some(description.into()),
+        }
     }
 }

--- a/services/ownership/src/lib.rs
+++ b/services/ownership/src/lib.rs
@@ -325,6 +325,20 @@ impl OwnershipClient {
         self.post_json_value(&url, body).await
     }
 
+    /// Evaluate a pricing strategy against the live listing book without storing
+    /// it. `body` is a `PricingPlanRequest` — the same `PricingConfig` shape
+    /// [`Self::set_pricing_config`] takes, plus scenario knobs (`anchor_lovelace`
+    /// to price off a hypothetical floor, `royalty_pct` for round-trip
+    /// economics). Read-only; nothing is persisted.
+    pub async fn pricing_plan(
+        &self,
+        policy_id: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value, Error> {
+        let url = format!("{}/admin/policies/{policy_id}/pricing-plan", self.base_url);
+        self.post_json_value(&url, body).await
+    }
+
     /// Public sales summary: realized-sales shape, effective pricing config
     /// and resolved ladder rungs (JSON passthrough, same reasoning as above).
     pub async fn get_sales_summary(&self, policy_id: &str) -> Result<serde_json::Value, Error> {

--- a/services/render-protocol/Cargo.toml
+++ b/services/render-protocol/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "render-protocol"
+version.workspace = true
+authors.workspace = true
+edition = "2021"
+description = "Wire protocol for asking a graphics service to render markup to an image"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+# `cip14` gates the CIP-14 `Fingerprint` type — the whole point of `asset://`.
+cardano-assets = { path = "../../cardano-assets", features = ["cip14"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/services/render-protocol/src/lib.rs
+++ b/services/render-protocol/src/lib.rs
@@ -97,30 +97,85 @@ pub enum OutputFormat {
     },
 }
 
-/// An asset image reference: `asset://{fingerprint}/{size}`.
+/// How an asset image is named.
+///
+/// Both forms are accepted because they are not interchangeable in practice.
+/// The image service stores by fingerprint but *resolves* a fingerprint through
+/// an identity index (D1 → Cardanoscan), so fingerprint addressing only works
+/// for collections that index has reached. `policy:hex` needs no lookup and
+/// works for every collection — including ones indexed later.
+///
+/// A caller that has a fingerprint should send it; a caller that has the policy
+/// and asset name should send those rather than deriving a fingerprint the
+/// service may not be able to reverse.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AssetIdentifier {
+    /// CIP-14 fingerprint. Requires the image service's identity index to know it.
+    Fingerprint(Fingerprint),
+    /// Policy id and asset name, both hex. Always resolvable.
+    PolicyAsset {
+        policy_id: String,
+        asset_name_hex: String,
+    },
+}
+
+impl AssetIdentifier {
+    /// The identifier as the image service expects it in a request path.
+    pub fn as_path_segment(&self) -> String {
+        match self {
+            Self::Fingerprint(fp) => fp.as_str().to_string(),
+            Self::PolicyAsset {
+                policy_id,
+                asset_name_hex,
+            } => format!("{policy_id}:{asset_name_hex}"),
+        }
+    }
+}
+
+impl fmt::Display for AssetIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.as_path_segment())
+    }
+}
+
+/// An asset image reference: `asset://{identifier}/{size}`, where the
+/// identifier is a CIP-14 fingerprint or `policy_id:asset_name_hex`.
 ///
 /// Used as the `src` of an `<img>` in the markup. The renderer resolves it;
 /// the sender never supplies a URL.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AssetUri {
-    pub fingerprint: Fingerprint,
+    pub identifier: AssetIdentifier,
     pub size: ImageSize,
 }
 
 impl AssetUri {
-    pub fn new(fingerprint: Fingerprint, size: ImageSize) -> Self {
-        Self { fingerprint, size }
+    pub fn fingerprint(fingerprint: Fingerprint, size: ImageSize) -> Self {
+        Self {
+            identifier: AssetIdentifier::Fingerprint(fingerprint),
+            size,
+        }
+    }
+
+    pub fn policy_asset(
+        policy_id: impl Into<String>,
+        asset_name_hex: impl Into<String>,
+        size: ImageSize,
+    ) -> Self {
+        Self {
+            identifier: AssetIdentifier::PolicyAsset {
+                policy_id: policy_id.into(),
+                asset_name_hex: asset_name_hex.into(),
+            },
+            size,
+        }
     }
 }
 
 impl fmt::Display for AssetUri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "asset://{}/{}",
-            self.fingerprint.as_str(),
-            self.size.pixels()
-        )
+        write!(f, "asset://{}/{}", self.identifier, self.size.pixels())
     }
 }
 
@@ -154,11 +209,158 @@ impl FromStr for AssetUri {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let rest = s.strip_prefix("asset://").ok_or(AssetUriError::MissingScheme)?;
-        let (fp, size) = rest.split_once('/').ok_or(AssetUriError::MissingSize)?;
+        // Split on the LAST slash: neither identifier form contains one, but a
+        // future form might, and the size is always the final segment.
+        let (id, size) = rest.rsplit_once('/').ok_or(AssetUriError::MissingSize)?;
+
+        let identifier = match id.split_once(':') {
+            Some((policy_id, asset_name_hex)) => {
+                // Both halves land in a URL the renderer builds, so anything
+                // that isn't hex is rejected rather than passed through.
+                let hex_ok = |v: &str| !v.is_empty() && v.chars().all(|c| c.is_ascii_hexdigit());
+                if policy_id.len() != 56 || !hex_ok(policy_id) || !hex_ok(asset_name_hex) {
+                    return Err(AssetUriError::InvalidFingerprint);
+                }
+                AssetIdentifier::PolicyAsset {
+                    policy_id: policy_id.to_string(),
+                    asset_name_hex: asset_name_hex.to_string(),
+                }
+            }
+            None => AssetIdentifier::Fingerprint(
+                Fingerprint::new(id).map_err(|_| AssetUriError::InvalidFingerprint)?,
+            ),
+        };
 
         Ok(Self {
-            fingerprint: Fingerprint::new(fp).map_err(|_| AssetUriError::InvalidFingerprint)?,
+            identifier,
             size: size.parse()?,
+        })
+    }
+}
+
+/// A Discord avatar reference: `avatar://{user_id}/{hash}`.
+///
+/// A second scheme rather than allowing `https://cdn.discordapp.com/...` in the
+/// markup, so the rule stays absolute: markup never contains a fetchable URL.
+/// An allowlisted host would be less code, but "no URLs except this one" is a
+/// category that grows, where a scheme the renderer resolves does not.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AvatarUri {
+    pub user_id: String,
+    /// Discord's avatar hash. `None` renders the default avatar.
+    pub hash: Option<String>,
+}
+
+impl AvatarUri {
+    pub fn new(user_id: impl Into<String>, hash: Option<String>) -> Self {
+        Self {
+            user_id: user_id.into(),
+            hash,
+        }
+    }
+}
+
+impl fmt::Display for AvatarUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `default` rather than omitting the segment, so the URI always has the
+        // same shape and the parser never has to guess.
+        write!(
+            f,
+            "avatar://{}/{}",
+            self.user_id,
+            self.hash.as_deref().unwrap_or("default")
+        )
+    }
+}
+
+impl FromStr for AvatarUri {
+    type Err = AssetUriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rest = s
+            .strip_prefix("avatar://")
+            .ok_or(AssetUriError::MissingScheme)?;
+        let (user_id, hash) = rest.split_once('/').ok_or(AssetUriError::MissingSize)?;
+
+        // Snowflake and hex-hash only: both become path segments in a URL the
+        // renderer builds, so anything else is a path-traversal attempt.
+        if user_id.is_empty() || !user_id.chars().all(|c| c.is_ascii_digit()) {
+            return Err(AssetUriError::InvalidFingerprint);
+        }
+        if hash != "default" && (hash.is_empty() || !hash.chars().all(|c| c.is_ascii_alphanumeric()))
+        {
+            return Err(AssetUriError::InvalidFingerprint);
+        }
+
+        Ok(Self {
+            user_id: user_id.to_string(),
+            hash: (hash != "default").then(|| hash.to_string()),
+        })
+    }
+}
+
+/// Artwork we own, in object storage: `r2://{binding}/{key}`.
+///
+/// One scheme for every kind of art we host — tier emblems, overlays, ship
+/// templates, badges — rather than one scheme per kind doing the same thing
+/// with a different prefix.
+///
+/// `binding` is the renderer's R2 **binding name**, not a bucket name, and that
+/// is what bounds it: a binding the worker doesn't declare simply fails to
+/// resolve, so the wrangler config is the allowlist. There is no separate map
+/// to keep in step with reality.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct R2Uri {
+    pub binding: String,
+    pub key: String,
+}
+
+impl R2Uri {
+    pub fn new(binding: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            binding: binding.into(),
+            key: key.into(),
+        }
+    }
+}
+
+impl fmt::Display for R2Uri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "r2://{}/{}", self.binding, self.key)
+    }
+}
+
+impl FromStr for R2Uri {
+    type Err = AssetUriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rest = s.strip_prefix("r2://").ok_or(AssetUriError::MissingScheme)?;
+        let (binding, key) = rest.split_once('/').ok_or(AssetUriError::MissingSize)?;
+
+        // Cloudflare binding names are SCREAMING_SNAKE_CASE. Requiring the
+        // shape means a typo fails to parse rather than becoming a lookup for a
+        // binding that will never exist.
+        if binding.is_empty()
+            || !binding
+                .chars()
+                .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+        {
+            return Err(AssetUriError::InvalidFingerprint);
+        }
+
+        // The key is a path and may contain slashes, but must not climb: `..`
+        // in an object key is meaningless to R2 but meaningful to anything that
+        // later maps keys onto a filesystem or a URL.
+        if key.is_empty()
+            || key.starts_with('/')
+            || key.split('/').any(|segment| segment == ".." || segment.is_empty())
+        {
+            return Err(AssetUriError::InvalidFingerprint);
+        }
+
+        Ok(Self {
+            binding: binding.to_string(),
+            key: key.to_string(),
         })
     }
 }
@@ -212,7 +414,7 @@ mod tests {
 
     #[test]
     fn asset_uri_round_trips() {
-        let uri = AssetUri::new(Fingerprint::new(FP).unwrap(), ImageSize::Thumb);
+        let uri = AssetUri::fingerprint(Fingerprint::new(FP).unwrap(), ImageSize::Thumb);
 
         assert_eq!(uri.to_string(), format!("asset://{FP}/400"));
         assert_eq!(uri.to_string().parse::<AssetUri>().unwrap(), uri);
@@ -248,5 +450,140 @@ mod tests {
         let req: RenderRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.format, OutputFormat::Png);
         assert_eq!(<(u32, u32)>::from(req.viewport), (400, 240));
+    }
+}
+
+#[cfg(test)]
+mod avatar_tests {
+    use super::*;
+
+    #[test]
+    fn avatar_round_trips() {
+        let uri = AvatarUri::new("179744071361757184", Some("a1b2c3d4".to_string()));
+        assert_eq!(uri.to_string(), "avatar://179744071361757184/a1b2c3d4");
+        assert_eq!(uri.to_string().parse::<AvatarUri>().unwrap(), uri);
+    }
+
+    /// A user with no avatar still produces a well-formed URI, so the renderer
+    /// never has to handle a missing segment.
+    #[test]
+    fn a_missing_hash_becomes_default() {
+        let uri = AvatarUri::new("179744071361757184", None);
+        assert_eq!(uri.to_string(), "avatar://179744071361757184/default");
+        assert_eq!(uri.to_string().parse::<AvatarUri>().unwrap().hash, None);
+    }
+
+    /// Both segments land in a URL the renderer builds, so traversal attempts
+    /// must not parse.
+    #[test]
+    fn path_traversal_is_rejected() {
+        assert!("avatar://../../etc/passwd".parse::<AvatarUri>().is_err());
+        assert!("avatar://123/..%2f..%2fx".parse::<AvatarUri>().is_err());
+        assert!("avatar://not-a-snowflake/abc".parse::<AvatarUri>().is_err());
+    }
+
+    #[test]
+    fn an_asset_uri_is_not_an_avatar() {
+        assert_eq!(
+            "asset://asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3/400".parse::<AvatarUri>(),
+            Err(AssetUriError::MissingScheme)
+        );
+    }
+}
+
+#[cfg(test)]
+mod policy_asset_tests {
+    use super::*;
+
+    const POLICY: &str = "b3dab69f7e6100849434fb1781e34bd12a916557f6231b8d2629b6f6";
+    const NAME: &str = "50697261746531353039";
+
+    #[test]
+    fn policy_asset_round_trips() {
+        let uri = AssetUri::policy_asset(POLICY, NAME, ImageSize::Thumb);
+        assert_eq!(uri.to_string(), format!("asset://{POLICY}:{NAME}/400"));
+        assert_eq!(uri.to_string().parse::<AssetUri>().unwrap(), uri);
+    }
+
+    /// The two forms must stay distinguishable — a fingerprint has no colon.
+    #[test]
+    fn the_two_forms_parse_to_different_identifiers() {
+        let fp = "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3";
+        assert!(matches!(
+            format!("asset://{fp}/400").parse::<AssetUri>().unwrap().identifier,
+            AssetIdentifier::Fingerprint(_)
+        ));
+        assert!(matches!(
+            format!("asset://{POLICY}:{NAME}/400")
+                .parse::<AssetUri>()
+                .unwrap()
+                .identifier,
+            AssetIdentifier::PolicyAsset { .. }
+        ));
+    }
+
+    /// Both halves become URL path segments, so non-hex must not parse.
+    #[test]
+    fn non_hex_identifiers_are_rejected() {
+        assert!(format!("asset://{POLICY}:../../etc/x/400").parse::<AssetUri>().is_err());
+        assert!("asset://short:abcd/400".parse::<AssetUri>().is_err());
+        assert!(format!("asset://{POLICY}:zzzz/400").parse::<AssetUri>().is_err());
+    }
+
+    #[test]
+    fn the_path_segment_is_what_the_image_service_expects() {
+        assert_eq!(
+            AssetUri::policy_asset(POLICY, NAME, ImageSize::Thumb)
+                .identifier
+                .as_path_segment(),
+            format!("{POLICY}:{NAME}")
+        );
+    }
+}
+
+#[cfg(test)]
+mod r2_tests {
+    use super::*;
+
+    const KEY: &str = "world/blackflag/tiers/icons/beards_bandits.png";
+
+    #[test]
+    fn r2_uri_round_trips() {
+        let uri = R2Uri::new("STORAGE", KEY);
+        assert_eq!(uri.to_string(), format!("r2://STORAGE/{KEY}"));
+        assert_eq!(uri.to_string().parse::<R2Uri>().unwrap(), uri);
+    }
+
+    /// A key is a path and legitimately contains slashes.
+    #[test]
+    fn nested_keys_survive() {
+        let uri: R2Uri = format!("r2://STORAGE/{KEY}").parse().unwrap();
+        assert_eq!(uri.binding, "STORAGE");
+        assert_eq!(uri.key, KEY);
+    }
+
+    /// `..` is meaningless to R2 but meaningful to anything that later maps a
+    /// key onto a path or a URL, so it is refused at the boundary.
+    #[test]
+    fn traversal_is_rejected() {
+        assert!("r2://STORAGE/../secrets".parse::<R2Uri>().is_err());
+        assert!("r2://STORAGE/a/../../b".parse::<R2Uri>().is_err());
+        assert!("r2://STORAGE//leading".parse::<R2Uri>().is_err());
+        assert!("r2://STORAGE/".parse::<R2Uri>().is_err());
+    }
+
+    /// Binding names are SCREAMING_SNAKE_CASE; a lowercase bucket name is a
+    /// confusion worth catching at parse rather than as a failed lookup.
+    #[test]
+    fn a_bucket_name_is_not_a_binding_name() {
+        assert!(format!("r2://augminted-dev/{KEY}").parse::<R2Uri>().is_err());
+    }
+
+    #[test]
+    fn other_schemes_are_not_r2() {
+        assert_eq!(
+            "asset://abc:def/400".parse::<R2Uri>(),
+            Err(AssetUriError::MissingScheme)
+        );
     }
 }

--- a/services/render-protocol/src/lib.rs
+++ b/services/render-protocol/src/lib.rs
@@ -1,0 +1,250 @@
+//! What a service sends to ask for a graphic: [`RenderRequest`].
+//!
+//! # Why markup rather than a node tree
+//!
+//! The obvious design is for the requesting service to build the renderer's own
+//! node tree and serialise it. That is not possible with takumi: `Node` and
+//! `NodeKind` derive `Deserialize` but **not** `Serialize`, because the engine
+//! is built to *consume* trees produced elsewhere. A Rust producer therefore
+//! cannot emit one.
+//!
+//! Markup sidesteps that completely, and turns out to be the better boundary
+//! anyway:
+//!
+//! - **The producer needs no renderer.** A plugin composing a graphic depends on
+//!   this crate — serde and a fingerprint type — not on a rasteriser, a font
+//!   stack, or a layout engine. That matters most for workers, where every
+//!   dependency is bytes in a wasm bundle.
+//! - **It is inspectable.** The same string can be pasted into a browser to see
+//!   roughly what the renderer saw, which no bespoke IR gives you.
+//! - **It has one owner.** The format is HTML; nobody has to keep a mirrored
+//!   struct in step with anybody else's.
+//!
+//! Tailwind-style utility classes are supported through a `tw` attribute, so a
+//! caller writes `<div tw="flex flex-wrap gap-2">` rather than computing
+//! coordinates.
+//!
+//! # Images are named, not fetched
+//!
+//! A render request is foreign input. A renderer that resolves arbitrary URLs
+//! on the sender's behalf is server-side request forgery with extra steps, so
+//! images are referenced by [`AssetUri`] — `asset://{fingerprint}/{size}` — and
+//! the *rendering* service resolves them through a path it controls. The
+//! fingerprint is CIP-14, which is already the canonical key the IIIF image
+//! pipeline stores under, so this names an existing key rather than inventing
+//! an identifier.
+
+use std::fmt;
+use std::str::FromStr;
+
+use cardano_assets::Fingerprint;
+use serde::{Deserialize, Serialize};
+
+/// A request to render markup to an image.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RenderRequest {
+    /// HTML fragment. Styling via `style` attributes or `tw` utility classes.
+    ///
+    /// A fragment is parsed as-is; a source starting with `<html>` is parsed as
+    /// a document. Multiple roots are wrapped in a full-size container.
+    pub html: String,
+
+    /// Output dimensions in pixels. This is the canvas, not a hint — layout is
+    /// computed against it.
+    pub viewport: Viewport,
+
+    #[serde(default)]
+    pub format: OutputFormat,
+}
+
+impl RenderRequest {
+    /// A PNG request at the given size.
+    pub fn png(html: impl Into<String>, width: u32, height: u32) -> Self {
+        Self {
+            html: html.into(),
+            viewport: Viewport { width, height },
+            format: OutputFormat::Png,
+        }
+    }
+}
+
+/// Output canvas size in pixels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Viewport {
+    pub width: u32,
+    pub height: u32,
+}
+
+impl From<Viewport> for (u32, u32) {
+    fn from(v: Viewport) -> Self {
+        (v.width, v.height)
+    }
+}
+
+/// Encoding for the rendered image.
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OutputFormat {
+    #[default]
+    Png,
+    Jpeg {
+        /// 1–100.
+        quality: u8,
+    },
+    WebP {
+        /// 1–100.
+        quality: u8,
+    },
+}
+
+/// An asset image reference: `asset://{fingerprint}/{size}`.
+///
+/// Used as the `src` of an `<img>` in the markup. The renderer resolves it;
+/// the sender never supplies a URL.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AssetUri {
+    pub fingerprint: Fingerprint,
+    pub size: ImageSize,
+}
+
+impl AssetUri {
+    pub fn new(fingerprint: Fingerprint, size: ImageSize) -> Self {
+        Self { fingerprint, size }
+    }
+}
+
+impl fmt::Display for AssetUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "asset://{}/{}",
+            self.fingerprint.as_str(),
+            self.size.pixels()
+        )
+    }
+}
+
+/// Why an [`AssetUri`] could not be parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AssetUriError {
+    MissingScheme,
+    MissingSize,
+    InvalidFingerprint,
+    /// A width that has no warm cache entry — see [`ImageSize`].
+    UnsupportedSize(String),
+}
+
+impl fmt::Display for AssetUriError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingScheme => f.write_str("expected an `asset://` URI"),
+            Self::MissingSize => f.write_str("expected `asset://{fingerprint}/{size}`"),
+            Self::InvalidFingerprint => f.write_str("not a CIP-14 fingerprint"),
+            Self::UnsupportedSize(s) => {
+                write!(f, "unsupported size `{s}`: expected 400 or 1646")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AssetUriError {}
+
+impl FromStr for AssetUri {
+    type Err = AssetUriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rest = s.strip_prefix("asset://").ok_or(AssetUriError::MissingScheme)?;
+        let (fp, size) = rest.split_once('/').ok_or(AssetUriError::MissingSize)?;
+
+        Ok(Self {
+            fingerprint: Fingerprint::new(fp).map_err(|_| AssetUriError::InvalidFingerprint)?,
+            size: size.parse()?,
+        })
+    }
+}
+
+/// A width the image pipeline keeps warm.
+///
+/// Deliberately an enum rather than a free integer. Only these two widths are
+/// pre-generated; any other value silently trades a cache hit for an on-demand
+/// resize on every single render, which is the kind of cost that never shows up
+/// as an error and never gets noticed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageSize {
+    /// 400px — thumbnails, grid cells, composites.
+    Thumb,
+    /// 1646px — full-size single-asset display.
+    Full,
+}
+
+impl ImageSize {
+    pub fn pixels(self) -> u32 {
+        match self {
+            Self::Thumb => 400,
+            Self::Full => 1646,
+        }
+    }
+}
+
+impl FromStr for ImageSize {
+    type Err = AssetUriError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "400" | "thumb" => Ok(Self::Thumb),
+            "1646" | "full" => Ok(Self::Full),
+            other => Err(AssetUriError::UnsupportedSize(other.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real CIP-14 fingerprint — the bech32 checksum is verified on parse, so
+    /// an invented one would fail for the wrong reason. From the CIP-14 test
+    /// vectors in `cardano-assets`.
+    const FP: &str = "asset1rjklcrnsdzqp65wjgrg55sy9723kw09mlgvlc3";
+
+    #[test]
+    fn asset_uri_round_trips() {
+        let uri = AssetUri::new(Fingerprint::new(FP).unwrap(), ImageSize::Thumb);
+
+        assert_eq!(uri.to_string(), format!("asset://{FP}/400"));
+        assert_eq!(uri.to_string().parse::<AssetUri>().unwrap(), uri);
+    }
+
+    /// A plain URL must not be mistaken for an asset reference — that is the
+    /// whole point of the scheme.
+    #[test]
+    fn rejects_a_bare_url() {
+        assert_eq!(
+            "https://example.com/evil.png".parse::<AssetUri>(),
+            Err(AssetUriError::MissingScheme)
+        );
+    }
+
+    #[test]
+    fn rejects_a_cold_size() {
+        let err = format!("asset://{FP}/1024").parse::<AssetUri>().unwrap_err();
+        assert_eq!(err, AssetUriError::UnsupportedSize("1024".to_string()));
+    }
+
+    #[test]
+    fn rejects_a_non_fingerprint() {
+        assert_eq!(
+            "asset://not-a-fingerprint/400".parse::<AssetUri>(),
+            Err(AssetUriError::InvalidFingerprint)
+        );
+    }
+
+    #[test]
+    fn request_defaults_to_png() {
+        let json = r#"{"html":"<div/>","viewport":{"width":400,"height":240}}"#;
+        let req: RenderRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.format, OutputFormat::Png);
+        assert_eq!(<(u32, u32)>::from(req.viewport), (400, 240));
+    }
+}

--- a/services/render-protocol/src/lib.rs
+++ b/services/render-protocol/src/lib.rs
@@ -165,10 +165,12 @@ impl FromStr for AssetUri {
 
 /// A width the image pipeline keeps warm.
 ///
-/// Deliberately an enum rather than a free integer. Only these two widths are
-/// pre-generated; any other value silently trades a cache hit for an on-demand
-/// resize on every single render, which is the kind of cost that never shows up
-/// as an error and never gets noticed.
+/// Deliberately an enum rather than a free integer. The image service will
+/// render *any* width on request, so an arbitrary value is not an error — it is
+/// a 2-3 second on-demand render for the first caller, versus a warm hit for
+/// these two. That is exactly the kind of cost that never surfaces as a failure
+/// and so never gets noticed; restricting the type makes it a deliberate choice
+/// to add a width rather than an accident.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ImageSize {

--- a/services/wallet-link/Cargo.toml
+++ b/services/wallet-link/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wallet-link"
+version.workspace = true
+authors.workspace = true
+edition = "2021"
+description = "Wire types for the Discord↔Cardano wallet link owned by auth-service"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/services/wallet-link/src/lib.rs
+++ b/services/wallet-link/src/lib.rs
@@ -1,0 +1,72 @@
+//! What auth-service says about a user's linked wallets.
+//!
+//! auth-service owns the Discord↔stake mapping. This crate exists so the
+//! services that *ask* about it — `/traits` in collection-ownership,
+//! `/check-rank` in game-sessions — share one definition of the answer rather
+//! than each keeping a private copy.
+//!
+//! That is not hypothetical tidiness. A hand-mirrored struct deserialises a
+//! renamed or dropped field to `None`/absent rather than failing, so the
+//! symptom is a user who appears to have no wallets — indistinguishable from a
+//! user who genuinely has none. The same shape silently cost every asset its
+//! rarity rank earlier in this codebase's life.
+
+use serde::{Deserialize, Serialize};
+
+/// Path auth-service serves the internal lookup on, appended with the Discord
+/// user id. Internal-key authenticated: this maps an identity to wallets, which
+/// must never become a public lookup.
+pub const INTERNAL_WALLETS_PATH: &str = "/_internal/wallets";
+
+/// One wallet a user has verified control of.
+///
+/// Order is meaningful — the list arrives in the order the user arranged it,
+/// so the first entry is their primary. Consumers that only need addresses
+/// should still preserve it rather than collecting into a set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LinkedWallet {
+    /// Bech32 stake address (`stake1…`).
+    pub stake_address: String,
+
+    /// ADA handle, when the wallet has one. Display only — never an identifier,
+    /// since handles are transferable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handle: Option<String>,
+}
+
+/// Build the lookup path for a Discord user.
+pub fn wallets_path(discord_user_id: &str) -> String {
+    format!("{INTERNAL_WALLETS_PATH}/{discord_user_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wallet_without_a_handle_round_trips() {
+        let wallet = LinkedWallet {
+            stake_address: "stake1u8962x3wtddcq2syq258ka3d9mxxkx5md5xawzx67pac9tgc5rhq9".to_string(),
+            handle: None,
+        };
+        let json = serde_json::to_string(&wallet).unwrap();
+        assert!(!json.contains("handle"), "absent handle should be omitted");
+        assert_eq!(serde_json::from_str::<LinkedWallet>(&json).unwrap(), wallet);
+    }
+
+    /// Producers may add fields; a consumer must not break on them.
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let json = r#"{"stake_address":"stake1abc","handle":"$boef","linked_at":123}"#;
+        let wallet: LinkedWallet = serde_json::from_str(json).unwrap();
+        assert_eq!(wallet.handle.as_deref(), Some("$boef"));
+    }
+
+    #[test]
+    fn path_includes_the_user_id() {
+        assert_eq!(
+            wallets_path("179744071361757184"),
+            "/_internal/wallets/179744071361757184"
+        );
+    }
+}

--- a/ui/_storybook-egui/src/lib.rs
+++ b/ui/_storybook-egui/src/lib.rs
@@ -38,6 +38,7 @@ mod app {
         RangeBar,
         PipRow,
         PriceTimeline,
+        Leaderboard,
         FocusList,
         CardBrowser,
         IconGallery,
@@ -160,6 +161,7 @@ mod app {
                 Self::RangeBar,
                 Self::PipRow,
                 Self::PriceTimeline,
+                Self::Leaderboard,
                 Self::FocusList,
                 Self::CardBrowser,
                 Self::IconGallery,
@@ -242,6 +244,7 @@ mod app {
                 Self::RangeBar => "Range Bar",
                 Self::PipRow => "Pip Row",
                 Self::PriceTimeline => "Price Timeline",
+                Self::Leaderboard => "Leaderboard",
                 Self::FocusList => "Focus List",
                 Self::CardBrowser => "Card Browser",
                 Self::IconGallery => "Icon Gallery",
@@ -350,6 +353,7 @@ mod app {
                 | Self::RangeBar
                 | Self::PipRow
                 | Self::PriceTimeline
+                | Self::Leaderboard
                 | Self::FocusList
                 | Self::CardBrowser
                 | Self::IconGallery
@@ -443,6 +447,9 @@ mod app {
                 }
                 Self::PriceTimeline => {
                     "Time-axis price scatter with reference lines/bands, log y, and hover inspection"
+                }
+                Self::Leaderboard => {
+                    "Ranked standings with medals, a share bar, and supporting stats"
                 }
                 Self::FocusList => {
                     "Fixed-geometry master-detail list for tooltips: sliding highlight + detail pane"
@@ -674,6 +681,7 @@ mod app {
         range_bar_state: stories::range_bar::RangeBarState,
         pip_row_state: stories::pip_row::PipRowState,
         price_timeline_state: stories::price_timeline::PriceTimelineState,
+        leaderboard_state: stories::leaderboard::LeaderboardState,
         focus_list_state: stories::focus_list::FocusListState,
         card_browser_state: stories::card_browser::CardBrowserStoryState,
         icon_gallery_state: stories::icon_gallery::IconGalleryState,
@@ -779,6 +787,7 @@ mod app {
                 range_bar_state: stories::range_bar::RangeBarState::default(),
                 pip_row_state: stories::pip_row::PipRowState::default(),
                 price_timeline_state: stories::price_timeline::PriceTimelineState::default(),
+                leaderboard_state: stories::leaderboard::LeaderboardState::default(),
                 focus_list_state: stories::focus_list::FocusListState::default(),
                 card_browser_state: stories::card_browser::CardBrowserStoryState::default(),
                 icon_gallery_state: stories::icon_gallery::IconGalleryState::default(),
@@ -969,6 +978,9 @@ mod app {
                             Story::PipRow => stories::pip_row::show(ui, &mut self.pip_row_state),
                             Story::PriceTimeline => {
                                 stories::price_timeline::show(ui, &mut self.price_timeline_state)
+                            }
+                            Story::Leaderboard => {
+                                stories::leaderboard::show(ui, &mut self.leaderboard_state)
                             }
                             Story::FocusList => {
                                 stories::focus_list::show(ui, &mut self.focus_list_state)

--- a/ui/_storybook-egui/src/stories/leaderboard.rs
+++ b/ui/_storybook-egui/src/stories/leaderboard.rs
@@ -1,0 +1,210 @@
+//! `Leaderboard` story — ranked standings with a share bar.
+//!
+//! Presets cover the three shapes that actually change how the widget reads:
+//! a runaway leader (one bar dominates), a tight race (bars near-equal), and
+//! the long tail past the podium. Plus the empty state, which is the one a
+//! live view hits most often on a quiet day.
+//!
+//! "Long tail" is also the column-alignment check: its spends span two orders
+//! of magnitude, so any per-row right-alignment shows up immediately as a
+//! wandering value column.
+
+use egui::{RichText, Ui};
+use egui_widgets::leaderboard::{
+    self, LeaderboardConfig, LeaderboardPrize, LeaderboardRow, LeaderboardStat,
+};
+
+#[derive(Default)]
+pub struct LeaderboardState {
+    preset: Preset,
+    podium_tint: bool,
+    viewer_row: bool,
+    prizes: bool,
+    last_click: Option<String>,
+    initialised: bool,
+}
+
+#[derive(Default, Clone, Copy, PartialEq, Eq)]
+enum Preset {
+    #[default]
+    RunawayLeader,
+    TightRace,
+    LongTail,
+    Empty,
+}
+
+impl Preset {
+    fn label(self) -> &'static str {
+        match self {
+            Self::RunawayLeader => "Runaway leader",
+            Self::TightRace => "Tight race",
+            Self::LongTail => "Long tail",
+            Self::Empty => "Empty",
+        }
+    }
+}
+
+/// (display name, spend in ADA, assets, trades)
+fn data(preset: Preset) -> Vec<(&'static str, u64, usize, usize)> {
+    match preset {
+        Preset::RunawayLeader => vec![
+            ("$whale", 128_400, 214, 41),
+            ("$damo", 21_050, 33, 12),
+            ("stake1u9…f3kq", 18_200, 29, 9),
+            ("$pirate", 9_400, 14, 6),
+            ("stake1uy…7t2v", 4_100, 7, 3),
+        ],
+        Preset::TightRace => vec![
+            ("$damo", 12_400, 20, 8),
+            ("$pirate", 12_100, 19, 7),
+            ("stake1u9…f3kq", 11_850, 21, 9),
+            ("$collector", 11_400, 18, 6),
+            ("stake1uy…7t2v", 10_900, 17, 7),
+        ],
+        Preset::LongTail => (0..14)
+            .map(|i| {
+                let names = [
+                    "$whale",
+                    "$damo",
+                    "$pirate",
+                    "$collector",
+                    "stake1u9…f3kq",
+                    "stake1uy…7t2v",
+                    "$flipper",
+                    "$hodler",
+                    "$sailor",
+                    "$captain",
+                    "$swab",
+                    "$gunner",
+                    "$cook",
+                    "$navigator",
+                ];
+                (names[i], 40_000 / (i as u64 + 1), 30 - i, 12 - i / 2)
+            })
+            .collect(),
+        Preset::Empty => Vec::new(),
+    }
+}
+
+fn rows(state: &LeaderboardState) -> Vec<LeaderboardRow> {
+    let raw = data(state.preset);
+    let spends: Vec<u64> = raw.iter().map(|(_, spend, _, _)| *spend).collect();
+    let shares = leaderboard::shares(&spends);
+
+    raw.iter()
+        .zip(shares)
+        .enumerate()
+        .map(
+            |(i, ((name, spend, assets, trades), share))| LeaderboardRow {
+                rank: i + 1,
+                name: name.to_string(),
+                tooltip: Some(format!(
+                    "stake1u9qq{i:0>44}\n{trades} trades \u{00b7} {assets} assets"
+                )),
+                value: format!("{} ADA", thousands(*spend)),
+                share,
+                stats: vec![
+                    LeaderboardStat::new(assets.to_string(), "assets"),
+                    LeaderboardStat::new(trades.to_string(), "trades"),
+                ],
+                // No image URL: exercises the placeholder path, since a story
+                // shouldn't depend on a live image host to be reviewable.
+                prize: state.prizes.then(|| LeaderboardPrize {
+                    image_url: None,
+                    label: format!("Pirate #{}", 1000 + i * 37),
+                    value: format!("{} ADA", thousands(spend / (*trades as u64).max(1))),
+                }),
+                // Second place is "you" — shows the accent treatment without
+                // stealing the podium.
+                is_viewer: state.viewer_row && i == 1,
+            },
+        )
+        .collect()
+}
+
+fn thousands(n: u64) -> String {
+    let s = n.to_string();
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if i > 0 && (s.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(c);
+    }
+    out
+}
+
+pub fn show(ui: &mut Ui, state: &mut LeaderboardState) {
+    if !state.initialised {
+        state.initialised = true;
+        state.podium_tint = true;
+        state.prizes = true;
+    }
+
+    ui.label(
+        RichText::new(
+            "Ranked standings: rank gutter (podium by colour, not emoji), prize \
+             thumbnail, name, headline metric, stats, and a thin share bar beneath \
+             each row. The host formats every string — the widget is domain-free.",
+        )
+        .size(11.0),
+    );
+    ui.add_space(8.0);
+
+    ui.horizontal(|ui| {
+        for preset in [
+            Preset::RunawayLeader,
+            Preset::TightRace,
+            Preset::LongTail,
+            Preset::Empty,
+        ] {
+            if ui
+                .selectable_label(state.preset == preset, preset.label())
+                .clicked()
+            {
+                state.preset = preset;
+            }
+        }
+    });
+    ui.horizontal(|ui| {
+        ui.checkbox(&mut state.podium_tint, "podium tint");
+        ui.checkbox(&mut state.prizes, "prize thumbnails");
+        ui.checkbox(&mut state.viewer_row, "highlight viewer row");
+    });
+    ui.add_space(8.0);
+
+    let config = LeaderboardConfig {
+        podium_tint: state.podium_tint,
+        empty_text: "No buys in this window".to_string(),
+        ..Default::default()
+    };
+
+    let rows = rows(state);
+    ui.group(|ui| {
+        ui.set_width(460.0);
+        leaderboard::header(ui, "buyer", "spend", &config);
+        if let Some(leaderboard::LeaderboardAction::RowClicked(idx)) =
+            leaderboard::show(ui, &rows, &config)
+        {
+            state.last_click = rows.get(idx).map(|r| r.name.clone());
+        }
+    });
+
+    if let Some(name) = &state.last_click {
+        ui.add_space(6.0);
+        ui.label(RichText::new(format!("clicked: {name}")).size(10.0));
+    }
+
+    ui.add_space(10.0);
+    ui.label(
+        RichText::new(
+            "Note the difference between 'Runaway leader' and 'Tight race': rank alone \
+             reads identically, the bars don't. That's the reason the bar exists.\n\
+             The value and stat columns are measured across ALL rows before drawing, so \
+             they stay aligned however wide each row's numbers are \u{2014} check the \
+             'Long tail' preset, where spends span two orders of magnitude.",
+        )
+        .size(10.0)
+        .weak(),
+    );
+}

--- a/ui/_storybook-egui/src/stories/mod.rs
+++ b/ui/_storybook-egui/src/stories/mod.rs
@@ -13,6 +13,7 @@ pub mod focus_list;
 pub mod formatting;
 pub mod gated;
 pub mod icon_gallery;
+pub mod leaderboard;
 pub mod marquee;
 pub mod mesh_playground;
 pub mod metric_card;

--- a/ui/egui-widgets/src/card_browser.rs
+++ b/ui/egui-widgets/src/card_browser.rs
@@ -37,6 +37,12 @@ pub struct CardBrowserConfig {
     pub rounding: f32,
     /// Scroll area ID salt (must be unique if multiple browsers on one page).
     pub scroll_id: &'static str,
+    /// Lay the grid out at its natural height instead of inside its own scroll
+    /// area. For a bounded grid embedded in an already-scrolling page, where a
+    /// nested scrollbar is the wrong affordance — the section should simply be
+    /// as tall as its contents. `near_bottom` is then always true, since all
+    /// items are on screen.
+    pub grow_to_content: bool,
     /// Card background color (normal).
     pub bg_card: Color32,
     /// Card background color (hovered).
@@ -83,6 +89,7 @@ impl Default for CardBrowserConfig {
             spacing: 8.0,
             rounding: 6.0,
             scroll_id: "card_browser",
+            grow_to_content: false,
             bg_card: theme::BG_PRIMARY,
             bg_card_hover: theme::BG_HIGHLIGHT,
             bg_card_selected: Color32::from_rgb(40, 45, 55),
@@ -205,7 +212,7 @@ pub fn show<T>(
                 scroll = scroll.vertical_scroll_offset(new_offset);
             }
 
-            let scroll_output = scroll.show(ui, |ui| {
+            let mut grid = |ui: &mut egui::Ui| {
                 ui.horizontal_wrapped(|ui| {
                     ui.spacing_mut().item_spacing = Vec2::splat(config.spacing);
                     let spinner = CachedSpinner::new(ui, 12.0, config.text_muted);
@@ -285,17 +292,26 @@ pub fn show<T>(
                         }
                     }
                 });
-            });
+            };
 
-            // Detect near-bottom: within ~2 card rows of the content bottom
-            let content_height = scroll_output.content_size.y;
-            let viewport_height = scroll_output.inner_rect.height();
-            let offset = scroll_output.state.offset.y;
-            let threshold = (config.card_height() + config.spacing) * 2.0;
-            if content_height > viewport_height
-                && offset + viewport_height >= content_height - threshold
-            {
+            if config.grow_to_content {
+                // Every item is laid out and visible, so any lazy loader
+                // watching `near_bottom` should fetch the next page.
+                grid(ui);
                 response.near_bottom = true;
+            } else {
+                let scroll_output = scroll.show(ui, &mut grid);
+
+                // Detect near-bottom: within ~2 card rows of the content bottom
+                let content_height = scroll_output.content_size.y;
+                let viewport_height = scroll_output.inner_rect.height();
+                let offset = scroll_output.state.offset.y;
+                let threshold = (config.card_height() + config.spacing) * 2.0;
+                if content_height > viewport_height
+                    && offset + viewport_height >= content_height - threshold
+                {
+                    response.near_bottom = true;
+                }
             }
         });
 

--- a/ui/egui-widgets/src/leaderboard.rs
+++ b/ui/egui-widgets/src/leaderboard.rs
@@ -1,0 +1,402 @@
+//! `Leaderboard` — ranked standings: podium-tinted ranks, an optional prize
+//! thumbnail, one headline metric, supporting stats, and a share bar.
+//!
+//! Domain-free by design. The host formats every string (ADA, counts, handles)
+//! and hands over view-model rows; the widget owns ranking presentation only.
+//! That keeps one renderer usable for buyer leaderboards, seller leaderboards,
+//! holder rankings or anything else with an order and a number.
+//!
+//! Two layout rules worth knowing, both learned the hard way:
+//!
+//! - **The share bar is its own thin strip under the row, never a fill behind
+//!   the text.** A translucent fill behind text washes it out at exactly the
+//!   rows you most want to read (the leaders, whose bars are widest).
+//! - **Columns are measured across all rows before anything is drawn**, so the
+//!   value and stat columns line up vertically regardless of how wide each
+//!   row's numbers happen to be.
+//!
+//! No emoji: the bundled fonts have no colour-emoji coverage, so a medal
+//! renders as a tofu box. The podium is conveyed with colour instead (see
+//! `tests/no_broken_glyphs.rs`, which enforces this).
+
+use egui::{Align, Color32, CornerRadius, Layout, Rect, RichText, Sense, Stroke, Ui, Vec2};
+
+/// A supporting stat shown after the headline value (e.g. `12` / `assets`).
+#[derive(Clone, Debug, Default)]
+pub struct LeaderboardStat {
+    pub value: String,
+    pub label: String,
+}
+
+impl LeaderboardStat {
+    pub fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+        }
+    }
+
+    fn text(&self) -> String {
+        format!("{} {}", self.value, self.label)
+    }
+}
+
+/// The standout item behind a row's ranking — e.g. the priciest asset a buyer
+/// took. Gives a leaderboard a face instead of a wall of numbers.
+#[derive(Clone, Debug, Default)]
+pub struct LeaderboardPrize {
+    /// Thumbnail URL. `None` renders the placeholder frame.
+    pub image_url: Option<String>,
+    /// What it is (asset name) — hover only, to keep rows single-line.
+    pub label: String,
+    /// What it cost, pre-formatted — also hover only.
+    pub value: String,
+}
+
+/// One ranked row.
+#[derive(Clone, Debug, Default)]
+pub struct LeaderboardRow {
+    /// 1-based rank. Rendered verbatim rather than derived from position, so a
+    /// host can show a slice ("your position: 47") without the numbers lying.
+    pub rank: usize,
+    /// Primary identity — a handle, name, or shortened address.
+    pub name: String,
+    /// Extra hover detail (e.g. the full stake address behind a handle).
+    pub tooltip: Option<String>,
+    /// Formatted headline metric.
+    pub value: String,
+    /// Share of the top row's value, `0.0..=1.0`. Drives the bar strip.
+    pub share: f32,
+    /// Supporting stats, rendered right of the value in fixed columns.
+    pub stats: Vec<LeaderboardStat>,
+    /// Standout item for this row, shown as a leading thumbnail.
+    pub prize: Option<LeaderboardPrize>,
+    /// Draw this row as the viewer's own.
+    pub is_viewer: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct LeaderboardConfig {
+    /// Tint the top three ranks gold/silver/bronze.
+    pub podium_tint: bool,
+    /// Height of the text portion of a row (the bar strip sits below it).
+    pub row_height: f32,
+    /// Width reserved for the rank gutter.
+    pub rank_width: f32,
+    /// Edge length of the prize thumbnail. Rows without a prize still reserve
+    /// the space when any row has one, so names stay aligned.
+    pub prize_size: f32,
+    /// Thickness of the share bar strip.
+    pub bar_height: f32,
+    pub bar_color: Color32,
+    pub bar_color_viewer: Color32,
+    /// Track behind the bar, so a short bar still reads as "out of a whole".
+    pub bar_track_color: Color32,
+    pub text_primary: Color32,
+    pub text_muted: Color32,
+    pub value_color: Color32,
+    /// Podium colours for ranks 1, 2 and 3.
+    pub podium_colors: [Color32; 3],
+    /// Message when there are no rows.
+    pub empty_text: String,
+}
+
+impl Default for LeaderboardConfig {
+    fn default() -> Self {
+        Self {
+            podium_tint: true,
+            row_height: 30.0,
+            rank_width: 26.0,
+            prize_size: 24.0,
+            bar_height: 2.0,
+            bar_color: Color32::from_rgb(122, 162, 247),
+            bar_color_viewer: Color32::from_rgb(158, 206, 106),
+            // NB unmultiplied: `from_rgba_premultiplied` expects RGB already
+            // scaled by alpha, so passing full-brightness channels with a low
+            // alpha renders near-opaque instead of as a tint.
+            bar_track_color: Color32::from_rgba_unmultiplied(122, 162, 247, 26),
+            text_primary: Color32::from_rgb(192, 202, 245),
+            text_muted: Color32::from_rgb(86, 95, 137),
+            value_color: Color32::from_rgb(125, 207, 255),
+            podium_colors: [
+                Color32::from_rgb(224, 175, 104), // gold
+                Color32::from_rgb(169, 177, 214), // silver
+                Color32::from_rgb(191, 130, 90),  // bronze
+            ],
+            empty_text: "No entries".to_string(),
+        }
+    }
+}
+
+/// What the user did. `None` when nothing was interacted with this frame.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LeaderboardAction {
+    /// Index into the rows passed to [`show`] (not the rank).
+    RowClicked(usize),
+}
+
+/// Rank colour: podium tint for the top three, muted otherwise.
+fn rank_color(rank: usize, config: &LeaderboardConfig) -> Color32 {
+    match (config.podium_tint, rank) {
+        (true, 1..=3) => config.podium_colors[rank - 1],
+        _ => config.text_muted,
+    }
+}
+
+/// Render the leaderboard. Returns an action when a row was clicked.
+///
+/// Lays out at natural height — the host decides whether to wrap it in a
+/// scroll area, so an embedded leaderboard in an already-scrolling page
+/// doesn't grow a nested scrollbar.
+pub fn show(
+    ui: &mut Ui,
+    rows: &[LeaderboardRow],
+    config: &LeaderboardConfig,
+) -> Option<LeaderboardAction> {
+    crate::install_phosphor_font(ui.ctx());
+
+    if rows.is_empty() {
+        ui.label(
+            RichText::new(&config.empty_text)
+                .color(config.text_muted)
+                .size(10.0),
+        );
+        return None;
+    }
+
+    let value_font = egui::FontId::monospace(12.0);
+    let stat_font = egui::FontId::proportional(10.0);
+    let name_font = egui::FontId::proportional(12.0);
+
+    // Measure every column across every row FIRST. Right-aligning each row
+    // independently makes the decimal points wander, which is what makes a
+    // numeric column look broken.
+    let measure = |text: String, font: egui::FontId| -> f32 {
+        ui.painter()
+            .layout_no_wrap(text, font, Color32::WHITE)
+            .size()
+            .x
+    };
+    let value_w = rows
+        .iter()
+        .map(|r| measure(r.value.clone(), value_font.clone()))
+        .fold(0.0_f32, f32::max);
+    let stat_count = rows.iter().map(|r| r.stats.len()).max().unwrap_or(0);
+    let stat_ws: Vec<f32> = (0..stat_count)
+        .map(|i| {
+            rows.iter()
+                .filter_map(|r| r.stats.get(i))
+                .map(|s| measure(s.text(), stat_font.clone()))
+                .fold(0.0_f32, f32::max)
+        })
+        .collect();
+
+    const COL_GAP: f32 = 12.0;
+    let stats_total: f32 = stat_ws.iter().map(|w| w + COL_GAP).sum();
+    let has_prize = rows.iter().any(|r| r.prize.is_some());
+    let prize_w = if has_prize {
+        config.prize_size + 6.0
+    } else {
+        0.0
+    };
+
+    let mut action = None;
+    let full_width = ui.available_width();
+    let row_total_height = config.row_height + config.bar_height + 3.0;
+
+    for (idx, row) in rows.iter().enumerate() {
+        let (rect, response) =
+            ui.allocate_exact_size(Vec2::new(full_width, row_total_height), Sense::click());
+        let text_rect = Rect::from_min_size(rect.min, Vec2::new(rect.width(), config.row_height));
+
+        if response.hovered() {
+            // A whisper of white: the row should lift off the background, not
+            // become a white block that inverts every colour on it.
+            ui.painter()
+                .rect_filled(rect, CornerRadius::same(3), Color32::from_white_alpha(6));
+        }
+        if row.is_viewer {
+            ui.painter().rect_stroke(
+                rect,
+                CornerRadius::same(3),
+                Stroke::new(1.0_f32, config.bar_color_viewer),
+                egui::StrokeKind::Inside,
+            );
+        }
+
+        // Rank gutter — colour carries the podium, no glyph needed.
+        ui.painter().text(
+            egui::pos2(text_rect.min.x + 6.0, text_rect.center().y),
+            egui::Align2::LEFT_CENTER,
+            row.rank.to_string(),
+            egui::FontId::proportional(if row.rank <= 3 && config.podium_tint {
+                13.0
+            } else {
+                11.0
+            }),
+            rank_color(row.rank, config),
+        );
+
+        // Prize thumbnail.
+        let mut cursor_x = text_rect.min.x + config.rank_width;
+        if has_prize {
+            let thumb = Rect::from_min_size(
+                egui::pos2(cursor_x, text_rect.center().y - config.prize_size / 2.0),
+                Vec2::splat(config.prize_size),
+            );
+            if let Some(prize) = &row.prize {
+                let loading = crate::card_browser::draw_thumbnail(
+                    ui,
+                    thumb,
+                    prize.image_url.as_deref(),
+                    &crate::CardBrowserConfig::default(),
+                );
+                if loading {
+                    crate::image_loader::CachedSpinner::request_repaint(ui);
+                }
+            }
+            cursor_x += prize_w;
+        }
+
+        // Name, clipped so a long handle can't run under the value column.
+        let name_rect = Rect::from_min_max(
+            egui::pos2(cursor_x, text_rect.min.y),
+            egui::pos2(
+                (text_rect.max.x - value_w - stats_total - COL_GAP).max(cursor_x),
+                text_rect.max.y,
+            ),
+        );
+        ui.painter().with_clip_rect(name_rect).text(
+            name_rect.left_center(),
+            egui::Align2::LEFT_CENTER,
+            &row.name,
+            name_font.clone(),
+            config.text_primary,
+        );
+
+        // Stats right-to-left in fixed columns, then the value column.
+        let mut x = text_rect.max.x - 6.0;
+        for (i, width) in stat_ws.iter().enumerate().rev() {
+            if let Some(stat) = row.stats.get(i) {
+                ui.painter().text(
+                    egui::pos2(x, text_rect.center().y),
+                    egui::Align2::RIGHT_CENTER,
+                    stat.text(),
+                    stat_font.clone(),
+                    config.text_muted,
+                );
+            }
+            x -= width + COL_GAP;
+        }
+        ui.painter().text(
+            egui::pos2(x, text_rect.center().y),
+            egui::Align2::RIGHT_CENTER,
+            &row.value,
+            value_font.clone(),
+            config.value_color,
+        );
+
+        // Share bar: a thin strip along the bottom, over a faint full-width
+        // track. Never behind the text.
+        let bar_y = text_rect.max.y + 1.0;
+        let track = Rect::from_min_size(
+            egui::pos2(text_rect.min.x + 6.0, bar_y),
+            Vec2::new(text_rect.width() - 12.0, config.bar_height),
+        );
+        ui.painter()
+            .rect_filled(track, CornerRadius::same(1), config.bar_track_color);
+        let share = row.share.clamp(0.0, 1.0);
+        if share > 0.0 {
+            let fill = Rect::from_min_size(
+                track.min,
+                Vec2::new(track.width() * share, config.bar_height),
+            );
+            ui.painter().rect_filled(
+                fill,
+                CornerRadius::same(1),
+                if row.is_viewer {
+                    config.bar_color_viewer
+                } else {
+                    config.bar_color
+                },
+            );
+        }
+
+        // Hover detail: the row's own tooltip plus what the prize was.
+        let mut hover = row.tooltip.clone().unwrap_or_default();
+        if let Some(prize) = &row.prize {
+            if !hover.is_empty() {
+                hover.push('\n');
+            }
+            hover.push_str(&format!(
+                "top buy: {} \u{00b7} {}",
+                prize.label, prize.value
+            ));
+        }
+        let response = if hover.is_empty() {
+            response
+        } else {
+            response.on_hover_text(hover)
+        };
+        if response.clicked() {
+            action = Some(LeaderboardAction::RowClicked(idx));
+        }
+    }
+
+    action
+}
+
+/// Compute `share` for a set of values against the largest — the common case
+/// for building rows.
+pub fn shares(values: &[u64]) -> Vec<f32> {
+    let max = values.iter().copied().max().unwrap_or(0);
+    if max == 0 {
+        return vec![0.0; values.len()];
+    }
+    values.iter().map(|v| *v as f32 / max as f32).collect()
+}
+
+/// Header row matching the widget's column layout — optional, but keeps a
+/// standalone leaderboard legible about what the number means.
+pub fn header(ui: &mut Ui, name_label: &str, value_label: &str, config: &LeaderboardConfig) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().interact_size.y = 0.0;
+        ui.add_space(config.rank_width);
+        ui.label(RichText::new(name_label).color(config.text_muted).size(9.0));
+        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+            ui.add_space(6.0);
+            ui.label(
+                RichText::new(value_label)
+                    .color(config.text_muted)
+                    .size(9.0),
+            );
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shares_scale_against_the_leader() {
+        assert_eq!(shares(&[100, 50, 0]), vec![1.0, 0.5, 0.0]);
+        // All-zero must not divide by zero.
+        assert_eq!(shares(&[0, 0]), vec![0.0, 0.0]);
+        assert!(shares(&[]).is_empty());
+    }
+
+    #[test]
+    fn podium_tint_applies_to_the_top_three_only() {
+        let config = LeaderboardConfig::default();
+        assert_eq!(rank_color(1, &config), config.podium_colors[0]);
+        assert_eq!(rank_color(3, &config), config.podium_colors[2]);
+        assert_eq!(rank_color(4, &config), config.text_muted);
+        // Disabled: every rank reads as an ordinary row.
+        let plain = LeaderboardConfig {
+            podium_tint: false,
+            ..Default::default()
+        };
+        assert_eq!(rank_color(1, &plain), plain.text_muted);
+    }
+}

--- a/ui/egui-widgets/src/lib.rs
+++ b/ui/egui-widgets/src/lib.rs
@@ -25,6 +25,7 @@ pub mod grouped_section;
 pub mod icons;
 pub mod id_pill;
 pub mod image_loader;
+pub mod leaderboard;
 pub mod listing_grid;
 pub mod marquee;
 pub mod metric_card;

--- a/ui/egui-widgets/tests/no_broken_glyphs.rs
+++ b/ui/egui-widgets/tests/no_broken_glyphs.rs
@@ -33,6 +33,12 @@ const DENY: &[(char, &str)] = &[
     ('\u{2717}', "ballot x"),
     ('\u{2718}', "heavy ballot x"),
     ('\u{2212}', "minus sign (use ASCII '-')"),
+    // Emoji: the bundled fonts carry no colour-emoji coverage either, so a
+    // medal renders as tofu just like an arrow does.
+    ('\u{1F947}', "1st place medal"),
+    ('\u{1F948}', "2nd place medal"),
+    ('\u{1F949}', "3rd place medal"),
+    ('\u{1F3C6}', "trophy"),
 ];
 
 /// Truncate a line at the first `//` that is NOT inside a string literal, so

--- a/ui/macroquad-storybook/src/main.rs
+++ b/ui/macroquad-storybook/src/main.rs
@@ -11,10 +11,11 @@
 
 use macroquad::prelude::*;
 use macroquad_widgets::{
-    frame_tap, mint_checkout, order_fulfilment, quantity_stepper, theme, wallet_connect, Button,
-    ButtonVariant, CheckoutAction, CheckoutState, Eligibility, FulfilmentAction, FulfilmentStatus,
-    FulfilmentTx, MintCheckoutVm, OrderFulfilmentVm, OrderStatus, Painter, QuantityStepperVm,
-    StepperAction, Theme, WalletAction, WalletConnectVm, WalletItem, WalletState,
+    frame_tap, mint_checkout, order_fulfilment, quantity_stepper, theme, wallet_connect,
+    wallet_list, Button, ButtonVariant, CheckoutAction, CheckoutState, Eligibility,
+    FulfilmentAction, FulfilmentStatus, FulfilmentTx, MintCheckoutVm, OrderFulfilmentVm,
+    OrderStatus, Painter, QuantityStepperVm, StepperAction, Theme, WalletAction, WalletConnectVm,
+    WalletItem, WalletListAction, WalletListState, WalletListVm, WalletRow, WalletState,
 };
 
 const SIDEBAR_W: f32 = 210.0;
@@ -69,6 +70,7 @@ enum Body {
     Buttons,
     Stepper(u32),
     Wallet(WalletConnectVm),
+    WalletList(WalletListVm),
     Checkout(MintCheckoutVm),
     Fulfilment(Fulfilment),
 }
@@ -80,6 +82,7 @@ enum Kind {
     Buttons,
     Stepper,
     Wallet,
+    WalletList,
     Checkout,
     Fulfilment,
 }
@@ -134,6 +137,14 @@ impl Story {
         }
     }
 
+    fn wallet_list(category: &'static str, name: &'static str, vm: WalletListVm) -> Self {
+        Self {
+            category,
+            name,
+            body: Body::WalletList(vm),
+        }
+    }
+
     fn checkout(category: &'static str, name: &'static str, vm: MintCheckoutVm) -> Self {
         Self {
             category,
@@ -147,6 +158,7 @@ impl Story {
             Body::Buttons => Kind::Buttons,
             Body::Stepper(_) => Kind::Stepper,
             Body::Wallet(_) => Kind::Wallet,
+            Body::WalletList(_) => Kind::WalletList,
             Body::Checkout(_) => Kind::Checkout,
             Body::Fulfilment(_) => Kind::Fulfilment,
         }
@@ -230,6 +242,52 @@ fn stories(sample_icon: Option<Texture2D>) -> Vec<Story> {
             "wallet",
             "error",
             WalletState::Error("user declined the connection".into()),
+        ),
+        Story::wallet_list(
+            "wallet list",
+            "several linked",
+            WalletListVm::new(WalletListState::Ready(vec![
+                WalletRow::new(STAKE_ADDR).with_handle("damo"),
+                WalletRow::new("stake1u9xk4d2rlq7zvnp3m8ftw0hs6yc4jg5zx2vqde7n0aum4tsp3wxyz")
+                    .with_handle("vault"),
+                WalletRow::new("stake1uy7d3n0qkfz2xw8ta5rmv6jc9phe4bgs0ld2u3xqvn8m6kcz9plkr"),
+            ])),
+        ),
+        Story::wallet_list(
+            "wallet list",
+            "one linked",
+            WalletListVm::new(WalletListState::Ready(vec![
+                WalletRow::new(STAKE_ADDR).with_handle("damo")
+            ])),
+        ),
+        // Mid-unlink: that row's controls are disabled so a second click can't
+        // race the first, while the others stay live.
+        Story::wallet_list(
+            "wallet list",
+            "unlink in flight",
+            WalletListVm::new(WalletListState::Ready(vec![
+                WalletRow::new(STAKE_ADDR).with_handle("damo"),
+                WalletRow::new("stake1u9xk4d2rlq7zvnp3m8ftw0hs6yc4jg5zx2vqde7n0aum4tsp3wxyz")
+                    .with_handle("vault"),
+            ]))
+            .busy(1),
+        ),
+        Story::wallet_list(
+            "wallet list",
+            "loading",
+            WalletListVm::new(WalletListState::Loading),
+        ),
+        Story::wallet_list(
+            "wallet list",
+            "none linked",
+            WalletListVm::new(WalletListState::Empty),
+        ),
+        Story::wallet_list(
+            "wallet list",
+            "error",
+            WalletListVm::new(WalletListState::Error(
+                "couldn't reach the auth service".into(),
+            )),
         ),
         Story::checkout(
             "checkout",
@@ -526,6 +584,7 @@ impl Storybook {
             }
             Kind::Stepper => self.draw_stepper(p, sel, x0, y),
             Kind::Wallet => self.draw_wallet(p, sel, x0, y, col_w),
+            Kind::WalletList => self.draw_wallet_list(p, sel, x0, y, col_w),
             Kind::Checkout => self.draw_checkout(p, sel, x0, y, col_w),
             Kind::Fulfilment => self.draw_fulfilment(p, sel, x0, y, col_w),
         }
@@ -560,6 +619,22 @@ impl Storybook {
             13.0,
             p.theme.muted,
         );
+    }
+
+    fn draw_wallet_list(&mut self, p: &Painter, sel: usize, x: f32, y: f32, w: f32) {
+        let action = match &self.stories[sel].body {
+            Body::WalletList(vm) => wallet_list(p, vm, x, y, w).action,
+            _ => return,
+        };
+        if let Some(a) = action {
+            self.last_action = Some(match a {
+                WalletListAction::LinkAnother => "action: LinkAnother".into(),
+                WalletListAction::Unlink(addr) => format!("action: Unlink({addr})"),
+                WalletListAction::MoveUp(i) => format!("action: MoveUp({i})"),
+                WalletListAction::MoveDown(i) => format!("action: MoveDown({i})"),
+                WalletListAction::Retry => "action: Retry".into(),
+            });
+        }
     }
 
     fn draw_wallet(&mut self, p: &Painter, sel: usize, x: f32, y: f32, w: f32) {

--- a/ui/macroquad-widgets/src/lib.rs
+++ b/ui/macroquad-widgets/src/lib.rs
@@ -13,6 +13,7 @@ mod mint_checkout;
 mod order_fulfilment;
 mod quantity_stepper;
 mod wallet_connect;
+mod wallet_list;
 
 pub use button::{Button, ButtonVariant};
 pub use mint_checkout::{
@@ -27,4 +28,7 @@ pub use quantity_stepper::{quantity_stepper, QuantityStepperVm, StepperAction, S
 pub use theme::Theme;
 pub use wallet_connect::{
     wallet_connect, WalletAction, WalletConnectVm, WalletItem, WalletResponse, WalletState,
+};
+pub use wallet_list::{
+    wallet_list, WalletListAction, WalletListResponse, WalletListState, WalletListVm, WalletRow,
 };

--- a/ui/macroquad-widgets/src/wallet_list.rs
+++ b/ui/macroquad-widgets/src/wallet_list.rs
@@ -1,0 +1,283 @@
+//! `WalletList` organism — a user's linked wallets, in their own order.
+//!
+//! Sibling to [`crate::wallet_connect`], and deliberately a separate widget:
+//! connecting is a *session* ("which wallet am I acting as right now"), while
+//! linking is an *identity claim* that outlives the tab. Collapsing the two
+//! into one widget would mean one `Connected` state standing for two very
+//! different commitments.
+//!
+//! Design notes:
+//!
+//! - **Handle first, address second.** `$alice` is recognisable and checkable
+//!   at a glance; a truncated `stake1u…c5rhq9` is not, and its visible ends
+//!   collide often enough that people confirm the wrong wallet. The address is
+//!   always shown underneath, so nothing is hidden — it just isn't the label.
+//! - **Order is the user's**, not a ranking we invent. Rows render in the order
+//!   given and the move actions report intent; the host owns persistence.
+//! - **No "primary" badge.** Every linked wallet counts equally for ownership,
+//!   so marking one would imply a hierarchy that doesn't exist.
+
+use macroquad::prelude::*;
+
+use crate::button::{Button, ButtonVariant};
+use crate::painter::{draw_rounded_rect, with_alpha, Painter};
+
+/// One linked wallet.
+pub struct WalletRow {
+    /// Bech32 stake address — the identity that was actually proved.
+    pub stake_address: String,
+    /// ADA Handle, when the wallet has one.
+    pub handle: Option<String>,
+}
+
+impl WalletRow {
+    pub fn new(stake_address: impl Into<String>) -> Self {
+        Self {
+            stake_address: stake_address.into(),
+            handle: None,
+        }
+    }
+
+    pub fn with_handle(mut self, handle: impl Into<String>) -> Self {
+        self.handle = Some(handle.into());
+        self
+    }
+
+    /// How to name this wallet to a human — handle if there is one.
+    pub fn display(&self) -> String {
+        match &self.handle {
+            Some(h) => format!("${h}"),
+            None => short(&self.stake_address),
+        }
+    }
+}
+
+pub enum WalletListState {
+    /// Fetching. Distinct from `Empty` so a slow load never reads as "you have
+    /// no wallets", which would prompt someone to link a duplicate.
+    Loading,
+    /// Loaded, and genuinely none.
+    Empty,
+    Ready(Vec<WalletRow>),
+    Error(String),
+}
+
+pub struct WalletListVm {
+    pub state: WalletListState,
+    /// Index of a row with an operation in flight; its controls are disabled so
+    /// a second click can't race the first.
+    pub busy: Option<usize>,
+}
+
+impl WalletListVm {
+    pub fn new(state: WalletListState) -> Self {
+        Self { state, busy: None }
+    }
+
+    pub fn busy(mut self, index: usize) -> Self {
+        self.busy = Some(index);
+        self
+    }
+}
+
+pub enum WalletListAction {
+    /// Start the link flow for an additional wallet.
+    LinkAnother,
+    /// Release a wallet. Carries the address rather than the index, because the
+    /// list can be reordered between render and dispatch.
+    Unlink(String),
+    /// Move a row one place toward the front / back.
+    MoveUp(usize),
+    MoveDown(usize),
+    Retry,
+}
+
+pub struct WalletListResponse {
+    pub bottom: f32,
+    pub action: Option<WalletListAction>,
+}
+
+const ROW_H: f32 = 56.0;
+
+pub fn wallet_list(
+    p: &Painter,
+    vm: &WalletListVm,
+    x: f32,
+    mut y: f32,
+    w: f32,
+) -> WalletListResponse {
+    let t = p.theme;
+    let mut action = None;
+
+    match &vm.state {
+        WalletListState::Loading => {
+            let pulse = (get_time() * 2.0).sin() as f32 * 0.5 + 0.5;
+            draw_circle(
+                x + 6.0,
+                y + 9.0,
+                5.0,
+                with_alpha(t.accent, 0.3 + 0.7 * pulse),
+            );
+            p.text_top("loading wallets...", x + 22.0, y, 16.0, t.muted);
+            y += 30.0;
+        }
+
+        WalletListState::Empty => {
+            p.text_top("No wallets linked yet", x, y, 16.0, t.fg);
+            y += 24.0;
+            p.text_top(
+                "Link one to prove ownership of your assets.",
+                x,
+                y,
+                13.0,
+                t.muted,
+            );
+            y += 28.0;
+            if Button::new("Link a wallet")
+                .variant(ButtonVariant::Tonal)
+                .show(p, Rect::new(x, y, 160.0, 40.0))
+            {
+                action = Some(WalletListAction::LinkAnother);
+            }
+            y += 48.0;
+        }
+
+        WalletListState::Ready(rows) => {
+            p.text_top("Linked wallets", x, y, 16.0, t.fg);
+            y += 28.0;
+
+            let last = rows.len().saturating_sub(1);
+            for (i, row) in rows.iter().enumerate() {
+                let enabled = vm.busy != Some(i);
+                let rect = Rect::new(x, y, w, ROW_H);
+                draw_rounded_rect(
+                    rect.x,
+                    rect.y,
+                    rect.w,
+                    rect.h,
+                    10.0,
+                    with_alpha(t.accent, if enabled { 0.12 } else { 0.06 }),
+                );
+
+                // Ordinal, so the user's arrangement is legible rather than
+                // implied purely by vertical position.
+                p.mono(
+                    &format!("{}", i + 1),
+                    x + 12.0,
+                    p.centre_baseline(y, ROW_H, 13.0),
+                    13.0,
+                    t.muted,
+                );
+
+                let label_colour = if enabled { t.accent } else { t.muted };
+                p.text_top(&row.display(), x + 38.0, y + 10.0, 16.0, label_colour);
+                p.mono(
+                    &short(&row.stake_address),
+                    x + 38.0,
+                    p.top_baseline(y + 32.0, 12.0),
+                    12.0,
+                    t.muted,
+                );
+
+                // Reorder controls. The ends are disabled rather than hidden so
+                // the row's controls don't shift position between rows.
+                let ctl_x = x + w - 150.0;
+                if Button::new("↑")
+                    .variant(ButtonVariant::Ghost)
+                    .font_size(14.0)
+                    .enabled(enabled && i > 0)
+                    .show(p, Rect::new(ctl_x, y + 12.0, 32.0, 32.0))
+                {
+                    action = Some(WalletListAction::MoveUp(i));
+                }
+                if Button::new("↓")
+                    .variant(ButtonVariant::Ghost)
+                    .font_size(14.0)
+                    .enabled(enabled && i < last)
+                    .show(p, Rect::new(ctl_x + 36.0, y + 12.0, 32.0, 32.0))
+                {
+                    action = Some(WalletListAction::MoveDown(i));
+                }
+                if Button::new("unlink")
+                    .variant(ButtonVariant::Ghost)
+                    .font_size(13.0)
+                    .enabled(enabled)
+                    .show(p, Rect::new(ctl_x + 74.0, y + 12.0, 68.0, 32.0))
+                {
+                    action = Some(WalletListAction::Unlink(row.stake_address.clone()));
+                }
+
+                y += ROW_H + 8.0;
+            }
+
+            y += 8.0;
+            if Button::new("Link another")
+                .variant(ButtonVariant::Tonal)
+                .show(p, Rect::new(x, y, 160.0, 40.0))
+            {
+                action = Some(WalletListAction::LinkAnother);
+            }
+            y += 48.0;
+        }
+
+        WalletListState::Error(msg) => {
+            p.text_top(msg, x, y, 14.0, t.danger);
+            y += 26.0;
+            if Button::new("Retry")
+                .variant(ButtonVariant::Tonal)
+                .show(p, Rect::new(x, y, 120.0, 40.0))
+            {
+                action = Some(WalletListAction::Retry);
+            }
+            y += 48.0;
+        }
+    }
+
+    WalletListResponse { bottom: y, action }
+}
+
+/// Middle-truncate an address so both ends stay visible.
+///
+/// Keeping the head and tail is what makes two addresses distinguishable at a
+/// glance; truncating one end only would leave near-identical strings.
+fn short(addr: &str) -> String {
+    if addr.len() <= 24 {
+        return addr.to_string();
+    }
+    format!("{}…{}", &addr[..14], &addr[addr.len() - 8..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_prefers_the_handle() {
+        let row = WalletRow::new("stake1u8962x3wtddcq2syq258ka3d9mxxkx5md5xawzx67pac9tgc5rhq9")
+            .with_handle("alice");
+        assert_eq!(row.display(), "$alice");
+    }
+
+    #[test]
+    fn display_falls_back_to_a_truncated_address() {
+        let row = WalletRow::new("stake1u8962x3wtddcq2syq258ka3d9mxxkx5md5xawzx67pac9tgc5rhq9");
+        let d = row.display();
+        assert!(d.starts_with("stake1u8962x3"));
+        assert!(d.ends_with("gc5rhq9"));
+        assert!(d.contains('…'));
+    }
+
+    #[test]
+    fn short_addresses_are_left_intact() {
+        assert_eq!(short("stake1short"), "stake1short");
+    }
+
+    /// Both ends must survive truncation — a head-only cut leaves two different
+    /// wallets looking identical.
+    #[test]
+    fn truncation_keeps_head_and_tail() {
+        let a = "stake1u8962x3wtddcq2syq258ka3d9mxxkx5md5xawzx67pac9tgc5rhq9";
+        let b = "stake1u8962x3wtddcq2syq258ka3d9mxxkx5md5xawzx67pac9tgcAAAA";
+        assert_ne!(short(a), short(b));
+    }
+}


### PR DESCRIPTION
Adds two protocol crates that let a service ask for a graphic or ask who owns a wallet without owning a rasteriser or a KV namespace, extends `augie-plugin` to carry both, and lands the leaderboard/wallet-list widgets.

### New: `services/render-protocol`

The wire format for "render this for me". A service describes a graphic as **HTML+CSS** and a renderer turns it into an image.

Markup rather than a node tree is forced by the engine: takumi's `Node` derives `Deserialize` but **not** `Serialize`, so a Rust producer cannot emit one. That turned out to be the better boundary anyway — the requesting service needs no rasteriser, no font stack and no layout engine, which matters most in a Worker where every dependency is bytes in a wasm bundle. Tailwind utilities work via a `tw` attribute.

Images are **named, never fetched**. Four URI schemes, each parsed and validated because every component becomes a path segment in a URL or storage key the renderer builds:

| scheme | resolves to |
|---|---|
| `asset://{fingerprint}/{size}` or `asset://{policy}:{hex}/{size}` | the IIIF image pipeline |
| `avatar://{user_id}/{hash}` | Discord's CDN |
| `r2://{binding}/{key}` | our own artwork in object storage |

Both asset forms exist because they aren't interchangeable: IIIF *stores* by CIP-14 fingerprint but *resolves* one through an identity index (D1 → Cardanoscan) that only covers some collections. `policy:hex` needs no lookup and works everywhere. Choosing wrong is a 404 mid-render, so both are first-class.

`r2://` names a **binding**, not a bucket — an undeclared binding simply fails, so the consuming worker's wrangler config is the allowlist with no separate map to drift.

`ImageSize` is an enum, not a free integer: only two widths are kept warm, and any other value is a 2–3s on-demand render for the first caller — a cost that never surfaces as an error.

31 tests, weighted toward the security boundary: traversal attempts, non-hex identifiers, bucket-vs-binding confusion, and cross-scheme confusion all fail to parse.

### New: `services/wallet-link`

`LinkedWallet` and the internal lookup path, so services asking auth-service about linked wallets share one definition. There were already three private copies forming. A hand-mirrored struct deserialises a renamed field to `None` rather than erroring, so the symptom is "this user has no wallets" — indistinguishable from the truth.

### `services/augie-plugin`

Three additions, all `#[serde(default)]` so existing plugins are unaffected:

- **`CommandResponse::render`** — a plugin describes a graphic; the *host* renders and attaches it. Not stylistic: `PluginEmbed` can only reference an image by URL and a plugin cannot attach bytes, so any plugin wanting a graphic would otherwise have to host one publicly. This keeps the image private to the message, ephemeral replies included.
- **`CommandInvocation::config` / `ComponentInvocation::config`** — opaque per-guild settings, passed through verbatim. The host interprets nothing, which is what keeps the protocol Discord-only: a collection service reads `policy_id` and a token service reads `contract` without either concept appearing in the type. Replaces plugins keeping their own copy of what guild config already knows.
- **`CommandResponse::layout`** — Components V2 (`Container`, `Text`, `Section`, `Gallery`, `Separator`, `Row`). Mutually exclusive with `content`/`embeds`, documented on the field, because Discord rejects a message carrying both and `IS_COMPONENTS_V2` cannot be removed once set.

### Widgets

- `egui-widgets`: `Leaderboard` — domain-free ranked standings; the host formats every string, so one renderer serves buyer/seller/holder rankings. Plus `card_browser` refinements.
- `macroquad-widgets`: `WalletList` — linked wallets in user order, deliberately separate from `wallet_connect` since connecting is a session and linking is an identity claim that outlives the tab.
- `discord-auth`: `unlisted` servers — roles grant features without the server being advertised.

### Notes for reviewers

- **`render-protocol` and `wallet-link` are new crates**; `augminted-bots` and `cnft.dev-workers` both need their pinned rev bumped once this merges. Until then both reach them through `[patch]` overrides.
- The four schemes each duplicate a little validation. That's deliberate — a shared "validate a slug" helper would make it easy to relax one and silently relax all four.